### PR TITLE
generate pks in main and pass secret keys

### DIFF
--- a/operator/src/actor.rs
+++ b/operator/src/actor.rs
@@ -23,30 +23,21 @@ pub struct Actor {
     pub public_key: PublicKey,
     pub xonly_public_key: XOnlyPublicKey,
     pub address: Address,
-    pub evm_address: EVMAddress,
 }
 
 impl Default for Actor {
     fn default() -> Self {
-        Self::new(&mut OsRng)
+        unimplemented!("Actor::default is not implemented");
     }
 }
 
 impl Actor {
-    pub fn new<R: RngCore>(rng: &mut R) -> Self {
+    pub fn new(sk: SecretKey) -> Self {
         let secp: Secp256k1<All> = Secp256k1::new();
-        let (sk, pk) = secp.generate_keypair(rng);
+        let pk = sk.public_key(&secp);
         let keypair = Keypair::from_secret_key(&secp, &sk);
         let (xonly, _parity) = XOnlyPublicKey::from_keypair(&keypair);
         let address = Address::p2tr(&secp, xonly, None, bitcoin::Network::Regtest);
-
-        let pk_serialized = pk.serialize_uncompressed();
-        let pk_serialized: [u8; 64] = pk_serialized[1..].try_into().unwrap();
-        let mut evm_address = [0u8; 32];
-        let mut keccak_hasher = Keccak::v256();
-        keccak_hasher.update(&pk_serialized);
-        keccak_hasher.finalize(&mut evm_address);
-        let evm_address: EVMAddress = evm_address[12..].try_into().unwrap();
 
         Actor {
             secp,
@@ -55,7 +46,6 @@ impl Actor {
             public_key: pk,
             xonly_public_key: xonly,
             address,
-            evm_address,
         }
     }
 

--- a/operator/src/errors.rs
+++ b/operator/src/errors.rs
@@ -63,6 +63,12 @@ pub enum BridgeError {
     /// ControlBlockError is returned when the control block is not found
     #[error("ControlBlockError")]
     ControlBlockError,
+    /// PkSkLengthMismatch is returned when the public key and secret key length do not match
+    #[error("PkSkLengthMismatch")]
+    PkSkLengthMismatch,
+    /// PublicKeyNotFound is returned when the public key is not found in all public keys
+    #[error("PublicKeyNotFound")]
+    PublicKeyNotFound,
 }
 
 impl From<secp256k1::Error> for BridgeError {

--- a/operator/src/main.rs
+++ b/operator/src/main.rs
@@ -1,21 +1,29 @@
 use bitcoin::secp256k1::rand::rngs::OsRng;
 use operator::config::{NUM_USERS, NUM_VERIFIERS};
+use operator::constant::EVMAddress;
 use operator::errors::BridgeError;
 use operator::{extended_rpc::ExtendedRpc, operator::Operator, user::User};
+use secp256k1::XOnlyPublicKey;
 
-fn main() -> Result<(), BridgeError> {
+fn test_flow() -> Result<(), BridgeError> {
     let rpc = ExtendedRpc::new();
 
-    let mut operator = Operator::new(&mut OsRng, &rpc, NUM_VERIFIERS as u32);
-
-    let verifiers_pks = operator.get_all_verifiers();
-    for verifier in &mut operator.mock_verifier_access {
-        verifier.set_verifiers(verifiers_pks.clone());
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+    let mut all_xonly_pks = Vec::new();
+    let mut all_sks = Vec::new();
+    let rng = &mut OsRng;
+    for _ in 0..NUM_VERIFIERS + 1 {
+        let (sk, pk) = secp.generate_keypair(rng);
+        all_xonly_pks.push(XOnlyPublicKey::from(pk));
+        all_sks.push(sk);
     }
+
+    let mut operator = Operator::new(&mut OsRng, &rpc, all_xonly_pks.clone(), all_sks)?;
 
     let mut users = Vec::new();
     for _ in 0..NUM_USERS {
-        users.push(User::new(&rpc, verifiers_pks.clone()));
+        let (sk, _) = secp.generate_keypair(rng);
+        users.push(User::new(&rpc, all_xonly_pks.clone(), sk));
     }
 
     // Initial setup for connector roots
@@ -43,17 +51,16 @@ fn main() -> Result<(), BridgeError> {
         // println!("move_utxo: {:?}", move_utxo);
         // let move_tx = rpc.get_raw_transaction(&move_utxo.txid, None).unwrap();
         // println!("move_tx: {:?}", move_tx);
+        let evm_address: EVMAddress = [0; 20];
         let (deposit_utxo, deposit_return_address, user_evm_address, user_sig) =
-            user.deposit_tx().unwrap();
+            user.deposit_tx(evm_address).unwrap();
         rpc.mine_blocks(6)?;
-        operator
-            .new_deposit(
-                deposit_utxo,
-                &deposit_return_address,
-                &user_evm_address,
-                user_sig,
-            )
-            .unwrap();
+        operator.new_deposit(
+            deposit_utxo,
+            &deposit_return_address,
+            &user_evm_address,
+            user_sig,
+        )?;
         rpc.mine_blocks(1)?;
     }
 
@@ -63,187 +70,11 @@ fn main() -> Result<(), BridgeError> {
         rpc.mine_blocks(1)?;
     }
 
-    let inscription_output = operator.inscribe_connector_tree_preimages();
-    println!("inscription_output: {:?}", inscription_output);
+    operator.inscribe_connector_tree_preimages()?;
 
-    // operator.prove();
-
-    // for r in 0..NUM_ROUNDS {
-    //     let mut preimages_verifier_track: HashSet<PreimageType> = HashSet::new();
-    //     let mut utxos_verifier_track: HashMap<OutPoint, (u32, u32)> = HashMap::new();
-    //     utxos_verifier_track.insert(connector_tree_root_utxos[r], (0, 0));
-
-    //     let mut flag = operator.mock_verifier_access[r]
-    //         .did_connector_tree_process_start(connector_tree_root_utxos[r].clone());
-    //     println!("flag: {:?}", flag);
-    //     if flag {
-    //         operator.mock_verifier_access[r].watch_connector_tree(
-    //             operator.signer.xonly_public_key,
-    //             &mut preimages_verifier_track,
-    //             &mut utxos_verifier_track,
-    //         );
-    //     }
-
-    //     let mut fund_utxos = Vec::new();
-
-    //     flag = operator.mock_verifier_access[r]
-    //         .did_connector_tree_process_start(connector_tree_root_utxos[r].clone());
-    //     println!("flag: {:?}", flag);
-    //     if flag {
-    //         operator.mock_verifier_access[r].watch_connector_tree(
-    //             operator.signer.xonly_public_key,
-    //             &mut preimages_verifier_track,
-    //             &mut utxos_verifier_track,
-    //         );
-    //     }
-
-    //     println!("utxos verifier track: {:?}", utxos_verifier_track);
-    //     println!("preimages verifier track: {:?}", preimages_verifier_track);
-
-    //     rpc.mine_blocks(3);
-
-    //     let preimages = operator.reveal_connector_tree_preimages(r, 3);
-    //     let (commit_txid, reveal_txid) = operator.inscribe_connector_tree_preimages(r, 3);
-    //     println!("preimages revealed: {:?}", preimages);
-    //     preimages_verifier_track = preimages.clone();
-    //     let inscription_tx = operator.mock_verifier_access[r]
-    //         .rpc
-    //         .get_raw_transaction(&reveal_txid, None)
-    //         .unwrap();
-    //     println!("verifier reads inscription tx: {:?}", inscription_tx);
-
-    //     let commit_tx = operator.mock_verifier_access[r]
-    //         .rpc
-    //         .get_raw_transaction(&commit_txid, None)
-    //         .unwrap();
-    //     println!("verifier reads commit tx: {:?}", commit_tx);
-    //     let inscription_script_pubkey = &commit_tx.output[0].script_pubkey;
-    //     let inscription_address_bytes: [u8; 32] = inscription_script_pubkey.as_bytes()[2..]
-    //         .try_into()
-    //         .unwrap();
-    //     println!(
-    //         "inscription address in bytes: {:?}",
-    //         inscription_address_bytes
-    //     );
-
-    //     let witness_array = inscription_tx.input[0].witness.to_vec();
-    //     println!("witness_array: {:?}", witness_array[1]);
-    //     let inscribed_data = witness_array[1][36..witness_array[1].len() - 1].to_vec();
-    //     println!("inscribed_data: {:?}", inscribed_data);
-    //     println!("inscribed_data length: {:?}", inscribed_data.len());
-    //     let mut verifier_got_preimages = Vec::new();
-    //     for i in 0..(inscribed_data.len() / 33) {
-    //         let preimage: [u8; 32] = inscribed_data[i * 33 + 1..(i + 1) * 33].try_into().unwrap();
-    //         verifier_got_preimages.push(preimage);
-    //     }
-
-    //     println!("verifier_got_preimages: {:?}", verifier_got_preimages);
-
-    //     let flattened_preimages: Vec<u8> = verifier_got_preimages
-    //         .iter()
-    //         .flat_map(|array| array.iter().copied())
-    //         .collect();
-
-    //     let flattened_slice: &[u8] = &flattened_preimages;
-
-    //     let calculated_merkle_root = get_script_hash(
-    //         operator.signer.xonly_public_key.serialize(),
-    //         flattened_slice,
-    //         2,
-    //     );
-    //     println!("calculated_merkle_root: {:?}", calculated_merkle_root);
-    //     let test_res = verify_script_hash_taproot_address(
-    //         operator.signer.xonly_public_key.serialize(),
-    //         flattened_slice,
-    //         2,
-    //         calculated_merkle_root,
-    //         inscription_address_bytes,
-    //     );
-    //     println!("test_res: {:?}", test_res);
-
-    //     for (i, utxo_level) in operator.connector_tree_utxos[r]
-    //         [0..operator.connector_tree_utxos.len() - 1]
-    //         .iter()
-    //         .enumerate()
-    //     {
-    //         for (j, utxo) in utxo_level.iter().enumerate() {
-    //             let preimage = operator.connector_tree_preimages[r][i][j];
-    //             println!("preimage: {:?}", preimage);
-    //             operator.spend_connector_tree_utxo(r, *utxo, preimage, CONNECTOR_TREE_DEPTH);
-    //             operator.mock_verifier_access[r].watch_connector_tree(
-    //                 operator.signer.xonly_public_key,
-    //                 &mut preimages_verifier_track,
-    //                 &mut utxos_verifier_track,
-    //             );
-    //             println!("utxos verifier track: {:?}", utxos_verifier_track);
-    //             println!("preimages verifier track: {:?}", preimages_verifier_track);
-    //         }
-    //         rpc.mine_blocks(1);
-    //     }
-
-    //     operator.mock_verifier_access[r].watch_connector_tree(
-    //         operator.signer.xonly_public_key,
-    //         &mut preimages_verifier_track,
-    //         &mut utxos_verifier_track,
-    //     );
-    //     println!("utxos verifier track: {:?}", utxos_verifier_track);
-    //     println!("preimages verifier track: {:?}", preimages_verifier_track);
-
-    //     for i in 0..3 {
-    //         operator.new_withdrawal(users[i].signer.address.clone());
-    //         rpc.mine_blocks(1);
-    //     }
-
-    //     //k-deep assumption
-    //     rpc.mine_blocks(10);
-
-    //     let chain_info = rpc.get_blockchain_info().unwrap();
-    //     let total_work_bytes = chain_info.chain_work;
-    //     let total_work: U256 = U256::from_be_bytes(total_work_bytes.try_into().unwrap());
-    //     let curr_blockheight = rpc.get_block_count().unwrap();
-    //     let curr_block_hash = rpc.get_best_block_hash().unwrap();
-    //     println!("curr_block_height: {:?}", curr_blockheight);
-    //     println!("curr_block_hash: {:?}", curr_block_hash);
-    //     println!("total_work: {:?}", total_work);
-
-    //     let done_wd_pi_inscription_blockheight: u64;
-    //     let mut wd_blockheight = 0;
-
-    //     for wd_txid in operator.withdrawals_payment_txids.clone() {
-    //         // println!("for withdrawal txid: {:?}", wd_txid);
-    //         let wd_tx = rpc.get_raw_transaction(&wd_txid, None).unwrap();
-    //         // println!("wd_tx: {:?}", wd_tx);
-    //         wd_blockheight = rpc
-    //             .get_transaction(&wd_txid, None)
-    //             .unwrap()
-    //             .info
-    //             .blockheight
-    //             .unwrap() as u64;
-    //         println!("wd blockheight: {:?}", wd_blockheight);
-    //     }
-
-    //     done_wd_pi_inscription_blockheight = wd_blockheight;
-    //     println!(
-    //         "prover done with withdrawals and preimages inscription, blockheight: {:?}",
-    //         done_wd_pi_inscription_blockheight
-    //     );
-    //     // let done_wd_pi_inscription_blockhash = rpc.get_block_hash(done_wd_pi_inscription_blockheight as u64).unwrap();
-
-    //     let wanted_work = rpc.calculate_total_work_between_blocks(
-    //         done_wd_pi_inscription_blockheight,
-    //         curr_blockheight,
-    //     );
-    //     let wanted_blockhash = curr_block_hash;
-    //     let wanted_blockheight = curr_blockheight;
-
-    //     println!("wanted_work: {:?}", wanted_work);
-    //     println!("wanted_blockhash: {:?}", wanted_blockhash);
-    //     println!("wanted_blockheight: {:?}", wanted_blockheight);
-    //     // println!("test: {:?}", test);
-
-    //     // for i in 0..NUM_USERS * r {
-    //     //     operator.claim_deposit(r, i);
-    //     // }
-    // }
     Ok(())
+}
+
+fn main() {
+    test_flow().unwrap();
 }


### PR DESCRIPTION
# Description
instead of generating secret keys with rng, we can generate once, and pass them, in this way, we can use the same core component with reading private keys from .env files in the future

## Linked Issues
- Fixes #70 
- Opens #72
