### PR TITLE
New deposit structure

### DIFF
--- a/circuits/src/bitcoin.rs
+++ b/circuits/src/bitcoin.rs
@@ -330,15 +330,8 @@ pub fn read_and_verify_bitcoin_merkle_path<E: Environment>(txid: [u8; 32]) -> [u
     let mut hash = txid;
     let mut index = E::read_u32();
     let levels = E::read_u32();
-    // bits of path indicator determines if the next tree node should be read from env or be the copy of last node
-    let mut path_indicator = E::read_u32();
     for _ in 0..levels {
-        let node = if path_indicator & 1 == 1 {
-            hash
-        } else {
-            E::read_32bytes()
-        };
-        path_indicator >>= 1;
+        let node = E::read_32bytes();
         hash = if index & 1 == 0 {
             double_sha256_hash!(&hash, &node)
         } else {

--- a/core/src/env_writer.rs
+++ b/core/src/env_writer.rs
@@ -2,8 +2,10 @@ use bitcoin::XOnlyPublicKey;
 use bitcoin::{
     block::Header, consensus::serialize, Block, MerkleBlock, Transaction, TxMerkleNode, Txid,
 };
+use clementine_circuits::double_sha256_hash;
 use clementine_circuits::env::Environment;
 use secp256k1::hashes::Hash;
+use secp256k1::rand::seq::index;
 use std::marker::PhantomData;
 
 use crate::{errors::BridgeError, merkle::MerkleTree};
@@ -98,29 +100,29 @@ impl<E: Environment> ENVWriter<E> {
         }
     }
 
-    pub fn write_bitcoin_merkle_path(txid: Txid, block: &Block) -> Result<(), BridgeError> {
-        let tx_ids: Vec<Txid> = block
-            .txdata
-            .iter()
-            .map(|tx| tx.txid())
-            .collect::<Vec<Txid>>();
+    /// Pretty long and complicated merkle path extraction function to convert rust bitcoins merkleBlock to a flatten single merkle path
+    /// Need to simplify this
+    pub fn get_merkle_path_from_merkle_block(
+        mb: MerkleBlock,
+    ) -> Result<(Vec<TxMerkleNode>, u32), BridgeError> {
+        let mut matches: Vec<Txid> = vec![];
+        let mut index: Vec<u32> = vec![];
+        mb.extract_matches(&mut matches, &mut index)?;
 
-        // find the index of the txid in tx_id_array vector or give error "txid not found in block txids"
-        let index = tx_ids
-            .iter()
-            .position(|&r| r == txid)
-            .ok_or(BridgeError::TxidNotFound)?;
-        E::write_u32(index as u32);
+        if matches.len() != 1 {
+            return Err(BridgeError::MerkleProofError);
+        }
 
-        let length = tx_ids.len();
+        if index.len() != 1 {
+            return Err(BridgeError::MerkleProofError);
+        }
+
+        let txid = matches[0];
+        let index = index[0];
+        let length = mb.txn.num_transactions();
         let depth = (length - 1).ilog(2) + 1;
-        E::write_u32(depth);
 
-        // merkle hashes list is a bit different from what we want, a merkle path, so need to do sth based on bits
-        // length of merkle hashes for one txid is typically depth + 1, at least for the left half of the tree
-        // we extract the merkle path which is of length "depth" from it
-        let merkle_block = MerkleBlock::from_block_with_predicate(block, |t| *t == txid);
-        let mut merkle_hashes = merkle_block
+        let mut merkle_hashes = mb
             .txn
             .hashes()
             .iter()
@@ -150,14 +152,49 @@ impl<E: Environment> ENVWriter<E> {
         for node in merkle_path {
             path_indicator <<= 1;
             match node {
-                Some(txmn) => merkle_path_to_be_sent.push(txmn),
+                Some(txmn) => merkle_path_to_be_sent.push(txmn.clone()),
                 None => path_indicator += 1,
             }
         }
 
         merkle_path_to_be_sent.reverse();
 
-        E::write_u32(path_indicator);
+        let mut hash = txid.to_byte_array();
+        let mut current_index = index;
+        let mut reader_pointer = 0;
+
+        for _ in 0..depth {
+            let node = if path_indicator & 1 == 1 {
+                merkle_path_to_be_sent
+                    .insert(reader_pointer, TxMerkleNode::from_byte_array(hash.clone()));
+                reader_pointer += 1;
+                hash
+            } else {
+                let node = merkle_path_to_be_sent[reader_pointer];
+                reader_pointer += 1;
+                *node.as_byte_array()
+            };
+            path_indicator >>= 1;
+            hash = if current_index & 1 == 0 {
+                double_sha256_hash!(&hash, &node)
+            } else {
+                double_sha256_hash!(&node, &hash)
+            };
+            current_index /= 2;
+        }
+
+        Ok((merkle_path_to_be_sent, index))
+    }
+
+    pub fn write_bitcoin_merkle_path(txid: Txid, block: &Block) -> Result<(), BridgeError> {
+        let merkle_block = MerkleBlock::from_block_with_predicate(block, |t| *t == txid);
+
+        let (merkle_path_to_be_sent, index) =
+            ENVWriter::<E>::get_merkle_path_from_merkle_block(merkle_block)?;
+
+        E::write_u32(index as u32);
+
+        E::write_u32(merkle_path_to_be_sent.len() as u32);
 
         for node in merkle_path_to_be_sent {
             E::write_32bytes(*node.as_byte_array());
@@ -300,18 +337,18 @@ mod tests {
         let mut _num = SHARED_STATE.lock().unwrap();
 
         MockEnvironment::reset_mock_env();
-        // // Mainnet block 00000000b0c5a240b2a61d2e75692224efd4cbecdf6eaf4cc2cf477ca7c270e7
-        // let some_block = "010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0804ffff001d026e04ffffffff0100f2052a0100000043410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac00000000010000000321f75f3139a013f50f315b23b0c9a2b6eac31e2bec98e5891c924664889942260000000049483045022100cb2c6b346a978ab8c61b18b5e9397755cbd17d6eb2fe0083ef32e067fa6c785a02206ce44e613f31d9a6b0517e46f3db1576e9812cc98d159bfdaf759a5014081b5c01ffffffff79cda0945903627c3da1f85fc95d0b8ee3e76ae0cfdc9a65d09744b1f8fc85430000000049483045022047957cdd957cfd0becd642f6b84d82f49b6cb4c51a91f49246908af7c3cfdf4a022100e96b46621f1bffcf5ea5982f88cef651e9354f5791602369bf5a82a6cd61a62501fffffffffe09f5fe3ffbf5ee97a54eb5e5069e9da6b4856ee86fc52938c2f979b0f38e82000000004847304402204165be9a4cbab8049e1af9723b96199bfd3e85f44c6b4c0177e3962686b26073022028f638da23fc003760861ad481ead4099312c60030d4cb57820ce4d33812a5ce01ffffffff01009d966b01000000434104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac00000000";
-        // let block1: Block = deserialize(&hex::decode(some_block).unwrap()).unwrap();
-        // test_block_merkle_path(block1);
+        // Mainnet block 00000000b0c5a240b2a61d2e75692224efd4cbecdf6eaf4cc2cf477ca7c270e7
+        let some_block = "010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0804ffff001d026e04ffffffff0100f2052a0100000043410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac00000000010000000321f75f3139a013f50f315b23b0c9a2b6eac31e2bec98e5891c924664889942260000000049483045022100cb2c6b346a978ab8c61b18b5e9397755cbd17d6eb2fe0083ef32e067fa6c785a02206ce44e613f31d9a6b0517e46f3db1576e9812cc98d159bfdaf759a5014081b5c01ffffffff79cda0945903627c3da1f85fc95d0b8ee3e76ae0cfdc9a65d09744b1f8fc85430000000049483045022047957cdd957cfd0becd642f6b84d82f49b6cb4c51a91f49246908af7c3cfdf4a022100e96b46621f1bffcf5ea5982f88cef651e9354f5791602369bf5a82a6cd61a62501fffffffffe09f5fe3ffbf5ee97a54eb5e5069e9da6b4856ee86fc52938c2f979b0f38e82000000004847304402204165be9a4cbab8049e1af9723b96199bfd3e85f44c6b4c0177e3962686b26073022028f638da23fc003760861ad481ead4099312c60030d4cb57820ce4d33812a5ce01ffffffff01009d966b01000000434104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac00000000";
+        let block1: Block = deserialize(&hex::decode(some_block).unwrap()).unwrap();
+        test_block_merkle_path(block1).unwrap();
 
-        // let segwit_block2 = include_bytes!("../tests/data/mainnet_block_000000000000000000000c835b2adcaedc20fdf6ee440009c249452c726dafae.raw").to_vec();
-        // let block2: Block = deserialize(&segwit_block2).unwrap();
-        // test_block_merkle_path(block2);
+        let segwit_block2 = include_bytes!("../tests/data/mainnet_block_000000000000000000000c835b2adcaedc20fdf6ee440009c249452c726dafae.raw").to_vec();
+        let block2: Block = deserialize(&segwit_block2).unwrap();
+        test_block_merkle_path(block2).unwrap();
 
-        // let segwit_block3 = include_bytes!("../tests/data/mainnet_block_00000000000000000000edfe523d5e2993781d2305f51218ebfc236a250792d6.raw").to_vec();
-        // let block3: Block = deserialize(&segwit_block3).unwrap();
-        // test_block_merkle_path(block3);
+        let segwit_block3 = include_bytes!("../tests/data/mainnet_block_00000000000000000000edfe523d5e2993781d2305f51218ebfc236a250792d6.raw").to_vec();
+        let block3: Block = deserialize(&segwit_block3).unwrap();
+        test_block_merkle_path(block3).unwrap();
 
         let segwit_block4 = include_bytes!("../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw").to_vec();
         let block4: Block = deserialize(&segwit_block4).unwrap();

--- a/core/src/env_writer.rs
+++ b/core/src/env_writer.rs
@@ -1,4 +1,4 @@
-use bitcoin::XOnlyPublicKey;
+use bitcoin::{block, Wtxid, XOnlyPublicKey};
 use bitcoin::{
     block::Header, consensus::serialize, Block, MerkleBlock, Transaction, TxMerkleNode, Txid,
 };
@@ -202,6 +202,49 @@ impl<E: Environment> ENVWriter<E> {
         Ok(())
     }
 
+    pub fn write_witness_merkle_path(txid: Txid, block: &Block) -> Result<(), BridgeError> {
+        let mut wtxid = Txid::all_zeros();
+        let hashes = block
+            .txdata
+            .iter()
+            .enumerate()
+            .map(|(i, t)| {
+                if t.txid() == txid {
+                    wtxid = Txid::from_raw_hash(t.wtxid().to_raw_hash());
+                }
+                if i == 0 {
+                    // Replace the first hash with zeroes.
+                    Txid::from_raw_hash(Wtxid::all_zeros().to_raw_hash())
+                } else {
+                    Txid::from_raw_hash(t.wtxid().to_raw_hash())
+                }
+            })
+            .collect::<Vec<Txid>>();
+        let witness_root = block.witness_root().unwrap();
+        let dummy_header = Header {
+            version: block.header.version,
+            prev_blockhash: block.header.prev_blockhash,
+            merkle_root: TxMerkleNode::from_raw_hash(witness_root.to_raw_hash()),
+            time: block.header.time,
+            bits: block.header.bits,
+            nonce: block.header.nonce,
+        };
+        let merkle_block =
+            MerkleBlock::from_header_txids_with_predicate(&dummy_header, &hashes, |t| *t == wtxid);
+
+        let (merkle_path_to_be_sent, index) =
+            ENVWriter::<E>::get_merkle_path_from_merkle_block(merkle_block)?;
+
+        E::write_u32(index as u32);
+
+        E::write_u32(merkle_path_to_be_sent.len() as u32);
+
+        for node in merkle_path_to_be_sent {
+            E::write_32bytes(*node.as_byte_array());
+        }
+        Ok(())
+    }
+
     pub fn write_merkle_tree_proof<const DEPTH: usize>(
         leaf: [u8; 32],
         index: Option<u32>,
@@ -319,6 +362,20 @@ mod tests {
         Ok(())
     }
 
+    fn test_witness_merkle_path(block: Block) -> Result<(), BridgeError> {
+        let expected_merkle_root = block.witness_root().unwrap().to_byte_array();
+        for tx in block.txdata.iter() {
+            if tx.is_coinbase() {
+                continue;
+            }
+            ENVWriter::<MockEnvironment>::write_witness_merkle_path(tx.txid(), &block)?;
+            let found_merkle_root =
+                read_and_verify_bitcoin_merkle_path::<MockEnvironment>(tx.wtxid().to_byte_array());
+            assert_eq!(expected_merkle_root, found_merkle_root);
+        }
+        Ok(())
+    }
+
     #[test]
     fn test_tx() {
         let mut _num = SHARED_STATE.lock().unwrap();
@@ -353,6 +410,29 @@ mod tests {
         let segwit_block4 = include_bytes!("../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw").to_vec();
         let block4: Block = deserialize(&segwit_block4).unwrap();
         test_block_merkle_path(block4).unwrap();
+    }
+
+    #[test]
+    fn test_bitcoin_witness_merkle_path() {
+        let mut _num = SHARED_STATE.lock().unwrap();
+
+        MockEnvironment::reset_mock_env();
+        // Mainnet block 00000000b0c5a240b2a61d2e75692224efd4cbecdf6eaf4cc2cf477ca7c270e7
+        let some_block = "010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0804ffff001d026e04ffffffff0100f2052a0100000043410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac00000000010000000321f75f3139a013f50f315b23b0c9a2b6eac31e2bec98e5891c924664889942260000000049483045022100cb2c6b346a978ab8c61b18b5e9397755cbd17d6eb2fe0083ef32e067fa6c785a02206ce44e613f31d9a6b0517e46f3db1576e9812cc98d159bfdaf759a5014081b5c01ffffffff79cda0945903627c3da1f85fc95d0b8ee3e76ae0cfdc9a65d09744b1f8fc85430000000049483045022047957cdd957cfd0becd642f6b84d82f49b6cb4c51a91f49246908af7c3cfdf4a022100e96b46621f1bffcf5ea5982f88cef651e9354f5791602369bf5a82a6cd61a62501fffffffffe09f5fe3ffbf5ee97a54eb5e5069e9da6b4856ee86fc52938c2f979b0f38e82000000004847304402204165be9a4cbab8049e1af9723b96199bfd3e85f44c6b4c0177e3962686b26073022028f638da23fc003760861ad481ead4099312c60030d4cb57820ce4d33812a5ce01ffffffff01009d966b01000000434104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac00000000";
+        let block1: Block = deserialize(&hex::decode(some_block).unwrap()).unwrap();
+        test_witness_merkle_path(block1).unwrap();
+
+        let segwit_block2 = include_bytes!("../tests/data/mainnet_block_000000000000000000000c835b2adcaedc20fdf6ee440009c249452c726dafae.raw").to_vec();
+        let block2: Block = deserialize(&segwit_block2).unwrap();
+        test_witness_merkle_path(block2).unwrap();
+
+        let segwit_block3 = include_bytes!("../tests/data/mainnet_block_00000000000000000000edfe523d5e2993781d2305f51218ebfc236a250792d6.raw").to_vec();
+        let block3: Block = deserialize(&segwit_block3).unwrap();
+        test_witness_merkle_path(block3).unwrap();
+
+        let segwit_block4 = include_bytes!("../tests/data/testnet_block_000000000000045e0b1660b6445b5e5c5ab63c9a4f956be7e1e69be04fa4497b.raw").to_vec();
+        let block4: Block = deserialize(&segwit_block4).unwrap();
+        test_witness_merkle_path(block4).unwrap();
     }
 
     #[test]

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -1,5 +1,8 @@
 //! This module defines errors returned by the library.
-use bitcoin::taproot::{TaprootBuilder, TaprootBuilderError};
+use bitcoin::{
+    merkle_tree::MerkleBlockError,
+    taproot::{TaprootBuilder, TaprootBuilderError},
+};
 use core::fmt::Debug;
 use std::array::TryFromSliceError;
 use thiserror::Error;
@@ -90,6 +93,12 @@ pub enum BridgeError {
     /// Block not found
     #[error("Block not found")]
     BlockNotFound,
+    /// Merkle Block Error
+    #[error("MerkleBlockError: {0}")]
+    MerkleBlockError(MerkleBlockError),
+    /// Merkle Proof Error
+    #[error("MerkleProofError")]
+    MerkleProofError,
 }
 
 impl From<secp256k1::Error> for BridgeError {
@@ -139,5 +148,11 @@ impl From<TaprootBuilder> for BridgeError {
 impl From<bitcoincore_rpc::Error> for BridgeError {
     fn from(err: bitcoincore_rpc::Error) -> Self {
         BridgeError::BitcoinRpcError(err)
+    }
+}
+
+impl From<MerkleBlockError> for BridgeError {
+    fn from(err: MerkleBlockError) -> Self {
+        BridgeError::MerkleBlockError(err)
     }
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -94,15 +94,10 @@ fn test_flow() -> Result<(), BridgeError> {
         for i in 0..NUM_USERS {
             let user = &users[i];
             let evm_address: EVMAddress = [0; 20];
-            let (deposit_utxo, deposit_return_address, user_evm_address, user_sig) =
+            let (deposit_utxo, deposit_return_address, user_evm_address) =
                 user.deposit_tx(evm_address).unwrap();
             rpc.mine_blocks(6)?;
-            operator.new_deposit(
-                deposit_utxo,
-                &deposit_return_address,
-                &user_evm_address,
-                user_sig,
-            )?;
+            operator.new_deposit(deposit_utxo, &deposit_return_address, &user_evm_address)?;
             // rpc.mine_blocks(1)?;
         }
 

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -26,6 +26,7 @@ use bitcoin::hashes::Hash;
 
 use bitcoin::{secp256k1, secp256k1::schnorr, Address};
 use bitcoin::{Amount, BlockHash, OutPoint};
+use bitcoincore_rpc::RawTx;
 use clementine_circuits::constants::{
     BLOCKHASH_MERKLE_TREE_DEPTH, BRIDGE_AMOUNT_SATS, CLAIM_MERKLE_TREE_DEPTH, MAX_BLOCK_HANDLE_OPS,
     NUM_ROUNDS, WITHDRAWAL_MERKLE_TREE_DEPTH,
@@ -134,13 +135,13 @@ impl Operator {
         start_utxo: OutPoint,
         return_address: &XOnlyPublicKey,
         evm_address: &EVMAddress,
-        user_sig: schnorr::Signature,
     ) -> Result<OutPoint, BridgeError> {
         check_deposit_utxo(
             &self.rpc,
             &self.transaction_builder,
             &start_utxo,
             return_address,
+            evm_address,
             BRIDGE_AMOUNT_SATS,
         )?;
 
@@ -193,7 +194,6 @@ impl Operator {
             .signer
             .sign_taproot_script_spend_tx_new(&mut move_tx, 0)?;
         move_signatures.push(sig);
-        move_signatures.push(user_sig);
         move_signatures.reverse();
 
         let mut witness_elements: Vec<&[u8]> = Vec::new();

--- a/core/src/script_builder.rs
+++ b/core/src/script_builder.rs
@@ -61,6 +61,22 @@ impl ScriptBuilder {
         builder.into_script()
     }
 
+    pub fn create_deposit_script(&self, evm_address: &EVMAddress) -> ScriptBuf {
+        let mut builder = Builder::new();
+        for vpk in self.verifiers_pks.clone() {
+            builder = builder.push_x_only_key(&vpk).push_opcode(OP_CHECKSIGVERIFY);
+        }
+
+        builder = builder
+            .push_opcode(OP_TRUE)
+            .push_opcode(OP_FALSE)
+            .push_opcode(OP_IF)
+            .push_slice(evm_address)
+            .push_opcode(OP_ENDIF);
+
+        builder.into_script()
+    }
+
     pub fn create_inscription_script_32_bytes(
         public_key: &XOnlyPublicKey,
         data: &Vec<[u8; 32]>,

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -34,25 +34,15 @@ impl User {
     pub fn deposit_tx(
         &self,
         evm_address: EVMAddress,
-    ) -> Result<(OutPoint, XOnlyPublicKey, EVMAddress, Signature), BridgeError> {
+    ) -> Result<(OutPoint, XOnlyPublicKey, EVMAddress), BridgeError> {
         let (deposit_address, _) = self
             .transaction_builder
-            .generate_deposit_address(&self.signer.xonly_public_key)?;
+            .generate_deposit_address(&self.signer.xonly_public_key, &evm_address)?;
 
         let deposit_utxo = self
             .rpc
             .send_to_address(&deposit_address, BRIDGE_AMOUNT_SATS)?;
 
-        let mut move_tx = self.transaction_builder.create_move_tx(
-            deposit_utxo,
-            &evm_address,
-            &self.signer.xonly_public_key,
-        )?;
-
-        let sig = self
-            .signer
-            .sign_taproot_script_spend_tx_new(&mut move_tx, 0)?;
-
-        Ok((deposit_utxo, self.signer.xonly_public_key, evm_address, sig))
+        Ok((deposit_utxo, self.signer.xonly_public_key, evm_address))
     }
 }

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -3,8 +3,11 @@ use crate::errors::BridgeError;
 use crate::extended_rpc::ExtendedRpc;
 use crate::transaction_builder::TransactionBuilder;
 use crate::EVMAddress;
+use bitcoin::merkle_tree;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::OutPoint;
+use bitcoin::Transaction;
+use bitcoin::Txid;
 use bitcoin::XOnlyPublicKey;
 use clementine_circuits::constants::BRIDGE_AMOUNT_SATS;
 use secp256k1::schnorr::Signature;
@@ -44,5 +47,12 @@ impl User {
             .send_to_address(&deposit_address, BRIDGE_AMOUNT_SATS)?;
 
         Ok((deposit_utxo, self.signer.xonly_public_key, evm_address))
+    }
+
+    pub fn generate_deposit_proof(&self, move_txid: Transaction) -> Result<(), BridgeError> {
+        // let out = self.rpc.get_spent_tx_out(&deposit_utxo)?;
+        // self.rpc.get_spent_tx_out(outpoint)
+        // merkle_tree::PartialMerkleTree::from_txids(&[move_txid.wtxid()], &[move_txid.txid()]);
+        Ok(())
     }
 }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -22,7 +22,7 @@ use crate::constants::CONFIRMATION_BLOCK_COUNT;
 use crate::errors::BridgeError;
 use crate::extended_rpc::ExtendedRpc;
 use crate::transaction_builder::{CreateTxOutputs, TransactionBuilder};
-use crate::HashTree;
+use crate::{EVMAddress, HashTree};
 
 pub fn parse_hex_to_btc_tx(
     tx_hex: &str,
@@ -47,13 +47,14 @@ pub fn check_deposit_utxo(
     tx_builder: &TransactionBuilder,
     outpoint: &OutPoint,
     return_address: &XOnlyPublicKey,
+    evm_address: &EVMAddress,
     amount_sats: u64,
 ) -> Result<(), BridgeError> {
     if rpc.confirmation_blocks(&outpoint.txid)? < CONFIRMATION_BLOCK_COUNT {
         return Err(BridgeError::DepositNotFinalized);
     }
 
-    let (deposit_address, _) = tx_builder.generate_deposit_address(return_address)?;
+    let (deposit_address, _) = tx_builder.generate_deposit_address(return_address, evm_address)?;
 
     if !rpc.check_utxo_address_and_amount(
         outpoint,

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -47,6 +47,7 @@ impl VerifierConnector for Verifier {
             &self.transaction_builder,
             &start_utxo,
             return_address,
+            evm_address,
             BRIDGE_AMOUNT_SATS,
         )?;
 


### PR DESCRIPTION
We now inscribe the EVM address along with an N-of-N signature check. We need to update the contracts to check if this UTXO is spent.

This deposit UTXO can be spent by two paths:

1. The user claims back the UTXO after 200 blocks. (This 200-block period is to prevent DoS.)
2. An N-of-N transaction takes this deposit by sending a move_tx. (This way, the user can mint on the rollup.)