### PR TITLE
Constants: Add Bitcoin network constant.

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -1,3 +1,4 @@
+use crate::constants::NETWORK;
 use crate::errors::BridgeError;
 use crate::transaction_builder::CreateTxOutputs;
 use bitcoin::sighash::SighashCache;
@@ -34,7 +35,7 @@ impl Actor {
         let pk = sk.public_key(&secp);
         let keypair = Keypair::from_secret_key(&secp, &sk);
         let (xonly, _parity) = XOnlyPublicKey::from_keypair(&keypair);
-        let address = Address::p2tr(&secp, xonly, None, bitcoin::Network::Regtest);
+        let address = Address::p2tr(&secp, xonly, None, NETWORK);
 
         Actor {
             secp,

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -33,3 +33,6 @@ pub const K_DEEP: u32 = 3;
 pub const MAX_BITVM_CHALLENGE_RESPONSE_BLOCKS: u32 = 5;
 
 pub type VerifierChallenge = (BlockHash, U256, u8);
+
+/// Which of the Bitcoin's networks to act on
+pub const NETWORK: bitcoin::Network = bitcoin::Network::Regtest;

--- a/core/src/transaction_builder.rs
+++ b/core/src/transaction_builder.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use crate::{
     constants::{
         CONNECTOR_TREE_DEPTH, CONNECTOR_TREE_OPERATOR_TAKES_AFTER, DUST_VALUE, K_DEEP,
-        MAX_BITVM_CHALLENGE_RESPONSE_BLOCKS, MIN_RELAY_FEE, USER_TAKES_AFTER,
+        MAX_BITVM_CHALLENGE_RESPONSE_BLOCKS, MIN_RELAY_FEE, NETWORK, USER_TAKES_AFTER,
     },
     merkle::MerkleTree,
     utils::get_claim_proof_tree_leaf,
@@ -75,12 +75,7 @@ impl TransactionBuilder {
             .add_leaf(1, deposit_script.clone())?
             .add_leaf(1, script_timelock.clone())?;
         let tree_info = taproot.finalize(&self.secp, *INTERNAL_KEY)?;
-        let address = Address::p2tr(
-            &self.secp,
-            *INTERNAL_KEY,
-            tree_info.merkle_root(),
-            bitcoin::Network::Regtest,
-        );
+        let address = Address::p2tr(&self.secp, *INTERNAL_KEY, tree_info.merkle_root(), NETWORK);
         Ok((address, tree_info))
     }
 
@@ -89,12 +84,7 @@ impl TransactionBuilder {
         let script_n_of_n = self.script_builder.generate_script_n_of_n();
         let taproot = TaprootBuilder::new().add_leaf(0, script_n_of_n.clone())?;
         let tree_info = taproot.finalize(&self.secp, *INTERNAL_KEY)?;
-        let address = Address::p2tr(
-            &self.secp,
-            *INTERNAL_KEY,
-            tree_info.merkle_root(),
-            bitcoin::Network::Regtest,
-        );
+        let address = Address::p2tr(&self.secp, *INTERNAL_KEY, tree_info.merkle_root(), NETWORK);
         Ok((address, tree_info))
     }
 
@@ -384,12 +374,7 @@ impl TransactionBuilder {
         let internal_key = *INTERNAL_KEY;
         let tree_info = taproot_builder.finalize(secp, internal_key)?;
         Ok((
-            Address::p2tr(
-                secp,
-                internal_key,
-                tree_info.merkle_root(),
-                bitcoin::Network::Regtest,
-            ),
+            Address::p2tr(secp, internal_key, tree_info.merkle_root(), NETWORK),
             tree_info,
         ))
     }


### PR DESCRIPTION
# Description

This PR adds a constant for Bitcoin network.

## Testing

No unit tests needed. Just run the program and `cargo test`. They worked fine.

## Docs

Just added a single line of comment describing the constant.