### PR TITLE
Cleanup: Run `cargo fix` and fix patch warnings in Cargo.toml.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ risc0-guests/operator/guest/Cargo.lock
 risc0-guests/verifier/guest/Cargo.lock
 target/
 .env
+configs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ lto = true
 
 [profile.release.build-override]
 opt-level = 3
+
+[patch.crates-io]
+sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
+k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
+crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ bitcoin-cli -regtest -rpcuser=admin -rpcpassword=admin -rpcport=18443 generateto
 cargo run
 ```
 
+### Create Random Key Pairs
+
+To create random key pairs for testing, run:
+
+```sh
+cargo run --bin key_generator
+```
+
+This will generate JSON files in `configs` directory.
+
 ### Test
 ```sh
 cargo test

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -11,8 +11,3 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 lazy_static = {version="1.4.0", default-features = false, features = ["spin_no_std"]}
 tracing = { version = "0.1.40", default-features = false }
 tracing-subscriber = { version = "0.3.18", default-features = false }
-
-[patch.crates-io]
-sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2/v0.10.8-risczero.0" }
-k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
-crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "clementine-core"
 version = "0.1.0"
 edition = "2021"
+default-run = "clementine-core"
 
 [dependencies]
 clementine-circuits = {path = "../circuits"}
@@ -15,9 +16,12 @@ risc0-zkvm = { version = "0.21.0" }
 serde = "1.0"
 serde_json = "1.0.108"
 byteorder = "1.5.0"
-secp256k1 = "0.28.1"
+secp256k1 = {version="0.28.1", features = ["serde"]}
 crypto-bigint = {version="=0.5.5"}
 thiserror = "1.0.57"
 tracing = "0.1.40"
 tracing-subscriber = {version = "0.3.18", features = ["env-filter"] }
 operator-circuit = {path = "../risc0-guests/operator"}
+
+[[bin]]
+name = "key_generator"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,8 +21,3 @@ thiserror = "1.0.57"
 tracing = "0.1.40"
 tracing-subscriber = {version = "0.3.18", features = ["env-filter"] }
 operator-circuit = {path = "../risc0-guests/operator"}
-
-[patch.crates-io]
-sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2/v0.10.8-risczero.0" }
-crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
-k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }

--- a/core/src/bin/key_generator.rs
+++ b/core/src/bin/key_generator.rs
@@ -1,0 +1,78 @@
+//! This binary generates random private/public key pairs for testing. They will
+//! be put in `DIRECTORY`/`PREFIX`(0..`crate::constants::NUM_VERIFIERS`).json. File format is described
+//! in `core/src/keys.rs`.
+
+use bitcoin::XOnlyPublicKey;
+use clementine_core::keys::{self, FileContents};
+use core::panic;
+use crypto_bigint::rand_core::OsRng;
+use secp256k1::SecretKey;
+use std::{
+    env,
+    fs::{self, File},
+    io::Write,
+};
+
+/// Environment variable that defines key file's directory.
+const ENV_DIR: &str = "KEY_DIR";
+
+/// Defualt directory to put generated key files if `ENV_DIR` is not specified.
+const DIRECTORY: &str = "configs";
+
+/// Key file prefix.
+const PREFIX: &str = "keys";
+
+fn main() {
+    let directory = env::var(ENV_DIR).unwrap_or_else(|_| DIRECTORY.to_string());
+    let (all_sks, all_xonly_pks) = generate_keypair();
+    println!("Generated private keys: {:#?}", all_sks.clone());
+    println!("Generated public keys: {:#?}", all_xonly_pks.clone());
+
+    // Create directory. If it exist, it will return an `Err`. Handle that with
+    // a variable.
+    let _ = fs::create_dir(directory.clone());
+
+    for i in 0..all_sks.len() {
+        create_file(&directory, i, all_sks.clone(), all_xonly_pks.clone());
+    }
+}
+
+/// This function's contents are copied from clementine_core's `main.rs`.
+/// Currently it is not in a dedicated function. If it is refactored to have a
+/// dedicated function, it should also be used here and this should be deleted.
+/// It is not ideal to have a possibly different key generator algorithms, in
+/// case of a change.
+fn generate_keypair() -> (Vec<SecretKey>, Vec<XOnlyPublicKey>) {
+    let secp: secp256k1::Secp256k1<secp256k1::All> = bitcoin::secp256k1::Secp256k1::new();
+    let rng = &mut OsRng;
+
+    let (all_sks, all_xonly_pks): (Vec<_>, Vec<_>) = match keys::get_keys(secp.clone(), rng) {
+        Ok(result) => result,
+        Err(e) => {
+            eprintln!("Error while reading private/public key pair: {}", e);
+            panic!();
+        }
+    };
+
+    (all_sks, all_xonly_pks)
+}
+
+/// Creates nth file in key directory.
+fn create_file(
+    directory: &String,
+    index: usize,
+    all_sks: Vec<SecretKey>,
+    all_xonly_sks: Vec<XOnlyPublicKey>,
+) {
+    let content = FileContents {
+        private_key: all_sks[index],
+        public_keys: all_xonly_sks,
+        id: index,
+    };
+
+    let serialized = serde_json::to_string_pretty(&content).unwrap();
+    let file = directory.to_string() + "/" + PREFIX + index.to_string().as_str() + ".json";
+
+    let mut file = File::create(file).unwrap();
+    file.write_all(serialized.as_bytes()).unwrap();
+}

--- a/core/src/env_writer.rs
+++ b/core/src/env_writer.rs
@@ -1,11 +1,10 @@
-use bitcoin::{block, Wtxid, XOnlyPublicKey};
 use bitcoin::{
     block::Header, consensus::serialize, Block, MerkleBlock, Transaction, TxMerkleNode, Txid,
 };
+use bitcoin::{Wtxid, XOnlyPublicKey};
 use clementine_circuits::double_sha256_hash;
 use clementine_circuits::env::Environment;
 use secp256k1::hashes::Hash;
-use secp256k1::rand::seq::index;
 use std::marker::PhantomData;
 
 use crate::{errors::BridgeError, merkle::MerkleTree};
@@ -342,8 +341,7 @@ mod tests {
     // use operator_circuit::GUEST_ELF;
 
     use crypto_bigint::U256;
-    use operator_circuit::GUEST_ELF;
-    use risc0_zkvm::default_prover;
+
     use secp256k1::hashes::Hash;
 
     use crate::{

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -99,6 +99,9 @@ pub enum BridgeError {
     /// Merkle Proof Error
     #[error("MerkleProofError")]
     MerkleProofError,
+    /// Given key pair is invalid and new pairs can't be generated randomly
+    #[error("InvalidKeyPair")]
+    InvalidKeyPair,
 }
 
 impl From<secp256k1::Error> for BridgeError {

--- a/core/src/keys.rs
+++ b/core/src/keys.rs
@@ -1,0 +1,129 @@
+//! # Private and Public Keys
+//!
+//! This module reads or creates private and public keys depending on what the
+//! user is supplying.
+//!
+//! ## Specifying Files
+//!
+//! This module accepts a single file as input. It can be specified as
+//! environment variable `KEYS`.
+//!
+//! ## File Format
+//!
+//! Input file is in JSON file format. It has 3 sections:
+//!
+//! 1. private: Single private key, as a string
+//! 2. public: Multiple public keys, as a string array
+//! 3. id: Single number (starts from 0) to select which public key is going to
+//! be used, as a number
+//!
+//! Example:
+//!
+//! ```json
+//! {
+//!     "private_key": "987654321",
+//!     "public_keys": ["123", "345", "565"],
+//!     id: 1
+//! }
+//! ```
+//!
+//! In this example, we have a private key of "987654321" and public key of
+//! "345".
+//!
+//! ## Random Key Generation
+//!
+//! If input file is not specified, key pairs will be generated randomly.
+
+use crate::constants::NUM_VERIFIERS;
+use bitcoin::XOnlyPublicKey;
+use crypto_bigint::rand_core::OsRng;
+use secp256k1::{All, Secp256k1, SecretKey};
+use serde::{Deserialize, Serialize};
+use std::{env, fs};
+use thiserror::Error;
+
+/// Key file's structure.
+#[derive(Serialize, Deserialize)]
+pub struct FileContents {
+    pub private_key: SecretKey,
+    pub public_keys: Vec<XOnlyPublicKey>,
+    pub id: usize,
+}
+
+/// Environment variable that points to the file that has private key and public
+/// keys.
+const ENV_FILE: &str = "KEYS";
+
+/// Tells which sources specified by user and why they can't be used.
+#[derive(Debug, Error)]
+enum InvalidKeySource {
+    /// No source is given as input. This is not exactly an error.
+    #[error("None")]
+    None,
+    /// Only private keys file is given and but file is not readable.
+    #[error("Error")]
+    Error(std::io::Error),
+}
+
+/// Returns private and public keys, either from a user supplied source or
+/// randomly generated pairs. First choice is the user supplied file.
+pub fn get_keys(
+    secp: Secp256k1<All>,
+    rng: &mut OsRng,
+) -> Result<(Vec<SecretKey>, Vec<XOnlyPublicKey>), std::io::Error> {
+    match get_from_file() {
+        Ok(ret) => return Ok(ret),
+        Err(InvalidKeySource::None) => {
+            tracing::info!(
+                "Neither private nor public keys are specified: They will be generated randomly..."
+            );
+            return Ok(create_key_pairs(secp, rng));
+        }
+        Err(InvalidKeySource::Error(e)) => Err(std::io::Error::other(format!(
+            "Error reading key file: {}",
+            e
+        ))),
+    }
+}
+
+/// Reads private key, public keys and id from a file if `ENV_FILE` is
+/// specified.
+fn get_from_file() -> Result<(Vec<SecretKey>, Vec<XOnlyPublicKey>), InvalidKeySource> {
+    let env_file = env::var(ENV_FILE);
+
+    match env_file {
+        Ok(file) => match read_file(file) {
+            Ok(content) => Ok(content),
+            Err(e) => Err(InvalidKeySource::Error(e)),
+        },
+        Err(_) => Err(InvalidKeySource::None),
+    }
+}
+
+/// Internal function for reading contents of the key file. If file is readable
+/// and in right format, returns target key pair.
+fn read_file(name: String) -> Result<(Vec<SecretKey>, Vec<XOnlyPublicKey>), std::io::Error> {
+    match fs::read_to_string(name) {
+        Ok(content) => match serde_json::from_str::<FileContents>(&content) {
+            Ok(deserialized) => Ok((
+                vec![deserialized.private_key; NUM_VERIFIERS + 1],
+                vec![deserialized.public_keys[deserialized.id]; NUM_VERIFIERS + 1],
+            )),
+            Err(e) => return Err(e.into()),
+        },
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Creates public and private keys randomly.
+pub fn create_key_pairs(
+    secp: Secp256k1<All>,
+    rng: &mut OsRng,
+) -> (Vec<SecretKey>, Vec<XOnlyPublicKey>) {
+    (0..NUM_VERIFIERS + 1)
+        .map(|_| {
+            let (sk, pk) = secp.generate_keypair(rng);
+            (sk, XOnlyPublicKey::from(pk))
+        })
+        .unzip()
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod db;
 pub mod env_writer;
 pub mod errors;
 pub mod extended_rpc;
+pub mod keys;
 pub mod merkle;
 pub mod mock_env;
 pub mod operator;

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -26,7 +26,6 @@ use bitcoin::hashes::Hash;
 
 use bitcoin::{secp256k1, secp256k1::schnorr, Address};
 use bitcoin::{Amount, BlockHash, OutPoint};
-use bitcoincore_rpc::RawTx;
 use clementine_circuits::constants::{
     BLOCKHASH_MERKLE_TREE_DEPTH, BRIDGE_AMOUNT_SATS, CLAIM_MERKLE_TREE_DEPTH, MAX_BLOCK_HANDLE_OPS,
     NUM_ROUNDS, WITHDRAWAL_MERKLE_TREE_DEPTH,

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -3,14 +3,11 @@ use crate::errors::BridgeError;
 use crate::extended_rpc::ExtendedRpc;
 use crate::transaction_builder::TransactionBuilder;
 use crate::EVMAddress;
-use bitcoin::merkle_tree;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::OutPoint;
 use bitcoin::Transaction;
-use bitcoin::Txid;
 use bitcoin::XOnlyPublicKey;
 use clementine_circuits::constants::BRIDGE_AMOUNT_SATS;
-use secp256k1::schnorr::Signature;
 use secp256k1::SecretKey;
 
 #[derive(Debug)]
@@ -49,7 +46,7 @@ impl User {
         Ok((deposit_utxo, self.signer.xonly_public_key, evm_address))
     }
 
-    pub fn generate_deposit_proof(&self, move_txid: Transaction) -> Result<(), BridgeError> {
+    pub fn generate_deposit_proof(&self, _move_txid: Transaction) -> Result<(), BridgeError> {
         // let out = self.rpc.get_spent_tx_out(&deposit_utxo)?;
         // self.rpc.get_spent_tx_out(outpoint)
         // merkle_tree::PartialMerkleTree::from_txids(&[move_txid.wtxid()], &[move_txid.txid()]);

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -8,7 +8,7 @@ use crate::{EVMAddress, HashTree};
 use bitcoin::Address;
 use bitcoin::{secp256k1, secp256k1::Secp256k1, OutPoint};
 
-use clementine_circuits::constants::{BRIDGE_AMOUNT_SATS, CLAIM_MERKLE_TREE_DEPTH, NUM_ROUNDS};
+use clementine_circuits::constants::{BRIDGE_AMOUNT_SATS, NUM_ROUNDS};
 use secp256k1::SecretKey;
 use secp256k1::XOnlyPublicKey;
 


### PR DESCRIPTION
# Description

This PR fixes warnings when running Cargo.

## Linked Issues

- None

## Testing

- Run `cargo test`
- Run `cargo run`

## Docs

- None
