### PR TITLE
Ceyhun/keys

### DIFF
--- a/core/src/keys.rs
+++ b/core/src/keys.rs
@@ -1,0 +1,39 @@
+//! This module reads or creates private and public keys depending on what the
+//! user is supplying.
+
+use crate::constants::NUM_VERIFIERS;
+use bitcoin::XOnlyPublicKey;
+use crypto_bigint::rand_core::OsRng;
+use secp256k1::{All, Secp256k1, SecretKey};
+use std::env;
+
+/// Gets private and public keys, either from a user supplied source or creates
+/// random pairs. User can supply keys as files using PUBLIC_KEYS and
+/// PRIVATE_KEYS environment variables.
+pub fn get_keys(secp: Secp256k1<All>, rng: &mut OsRng) -> (Vec<SecretKey>, Vec<XOnlyPublicKey>) {
+    match read_from_file() {
+        Some(ret) => return ret,
+        None => (),
+    }
+
+    create(secp, rng)
+}
+
+/// Reads private and public keys from files if they are specified as
+/// environment variables.
+fn read_from_file() -> Option<(Vec<SecretKey>, Vec<XOnlyPublicKey>)> {
+    let _private = env::var("PRIVATE_KEYS");
+    let _public = env::var("PUBLIC_KEYS");
+
+    None
+}
+
+/// Creates public and private keys randomly.
+fn create(secp: Secp256k1<All>, rng: &mut OsRng) -> (Vec<SecretKey>, Vec<XOnlyPublicKey>) {
+    (0..NUM_VERIFIERS + 1)
+        .map(|_| {
+            let (sk, pk) = secp.generate_keypair(rng);
+            (sk, XOnlyPublicKey::from(pk))
+        })
+        .unzip()
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod db;
 pub mod env_writer;
 pub mod errors;
 pub mod extended_rpc;
+pub mod keys;
 pub mod merkle;
 pub mod mock_env;
 pub mod operator;

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -14,7 +14,6 @@ use operator_circuit::GUEST_ELF;
 use risc0_zkvm::default_prover;
 use secp256k1::rand::rngs::StdRng;
 use secp256k1::rand::SeedableRng;
-use secp256k1::XOnlyPublicKey;
 use std::env;
 use std::str::FromStr;
 use std::sync::Mutex;
@@ -24,6 +23,7 @@ use tracing_subscriber::{fmt, EnvFilter};
 lazy_static::lazy_static! {
     static ref SHARED_STATE: Mutex<i32> = Mutex::new(0);
 }
+use clementine_core::keys;
 
 fn test_flow() -> Result<(), BridgeError> {
     let rpc = ExtendedRpc::new();
@@ -34,12 +34,7 @@ fn test_flow() -> Result<(), BridgeError> {
     let mut seeded_rng = StdRng::from_seed(seed);
     let rng = &mut OsRng;
 
-    let (all_sks, all_xonly_pks): (Vec<_>, Vec<_>) = (0..NUM_VERIFIERS + 1)
-        .map(|_| {
-            let (sk, pk) = secp.generate_keypair(rng);
-            (sk, XOnlyPublicKey::from(pk))
-        })
-        .unzip();
+    let (all_sks, all_xonly_pks) = keys::get_keys(secp.clone(), rng);
 
     let mut verifiers: Vec<Box<dyn VerifierConnector>> = Vec::new();
     for i in 0..NUM_VERIFIERS {


### PR DESCRIPTION
# Description

This PR introduces keys module, which handles reading or creating private and public keys depending on what the user is supplying.

## Linked Issues

- None

## Testing

- cargo test
- cargo run

## Docs

Module and functions are documented using /// blocks.