### PR TITLE
CLI Parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,3 @@ opt-level = 3
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 k256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "k256/v0.13.3-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
-
-[[bin]]
-name = "key_generator"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,4 +26,3 @@ clap = { version = "4.5.4", features = ["derive", "cargo"] }
 
 [[bin]]
 name = "key_generator"
-

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "1.0.57"
 tracing = "0.1.40"
 tracing-subscriber = {version = "0.3.18", features = ["env-filter"] }
 operator-circuit = {path = "../risc0-guests/operator"}
+clap = { version = "4.5.4", features = ["derive", "cargo"] }
 
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2/v0.10.8-risczero.0" }

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -18,7 +18,7 @@ pub struct Args {
     /// Remote procedure call user password in Bitcoin network. Warning: Not yet implemented.
     #[arg(long, default_value_t = DEFAULT_RPC_PASSWORD.to_string())]
     pub rpc_password: String,
-    /// Bitcoin network to work on.
+    /// Bitcoin network to work on. Warning: Not yet implemented.
     #[arg(
         short,
         long,

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -1,6 +1,7 @@
 //! This module parses CLI arguments and options.
 
 use crate::extended_rpc::{DEFAULT_RPC_PASSWORD, DEFAULT_RPC_URL, DEFAULT_RPC_USER};
+use clap::builder::TypedValueParser;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -17,6 +18,17 @@ pub struct Args {
     /// Remote procedure call user password in Bitcoin network. Warning: Not yet implemented.
     #[arg(long, default_value_t = DEFAULT_RPC_PASSWORD.to_string())]
     pub rpc_password: String,
+    /// Bitcoin network to work on.
+    #[arg(
+        short,
+        long,
+        default_value_t = bitcoin::Network::Regtest,
+        value_parser = clap::builder::PossibleValuesParser
+            ::new(["bitcoin", "testnet", "signet", "regtest"])
+            .map(|s| s.parse::<bitcoin::Network>().unwrap()),
+        )
+    ]
+    pub network: bitcoin::Network,
     /// Private/public key pair file.
     #[arg(short, long)]
     pub key_file: Option<PathBuf>,

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -1,0 +1,28 @@
+//! This module parses CLI arguments and options.
+
+use crate::extended_rpc::{DEFAULT_RPC_PASSWORD, DEFAULT_RPC_URL, DEFAULT_RPC_USER};
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Clementine (c) 2024 Chainway Limited
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Remote procedure call URL to communicate with Bitcoin network.
+    #[arg(short, long, default_value_t = DEFAULT_RPC_URL.to_string())]
+    pub rpc_url: String,
+    /// Remote procedure call user name in Bitcoin network. Warning: Not yet implemented.
+    #[arg(long, default_value_t = DEFAULT_RPC_USER.to_string())]
+    pub rpc_user: String,
+    /// Remote procedure call user password in Bitcoin network. Warning: Not yet implemented.
+    #[arg(long, default_value_t = DEFAULT_RPC_PASSWORD.to_string())]
+    pub rpc_password: String,
+    /// Private/public key pair file.
+    #[arg(short, long)]
+    pub key_file: Option<PathBuf>,
+}
+
+/// Parse all command line inputs.
+pub fn parse_cli() -> Args {
+    Args::parse()
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,6 +2,7 @@ use bitcoin::{OutPoint, Txid};
 use clementine_circuits::{HashType, PreimageType};
 
 pub mod actor;
+pub mod cli;
 pub mod constants;
 pub mod db;
 pub mod env_writer;

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,12 +1,13 @@
 use bitcoin::hashes::Hash;
 use bitcoin::BlockHash;
 use clementine_circuits::constants::{MAX_BLOCK_HANDLE_OPS, NUM_ROUNDS};
+use clementine_core::cli::Args;
 use clementine_core::constants::{NUM_USERS, NUM_VERIFIERS, PERIOD_BLOCK_COUNT};
 use clementine_core::errors::BridgeError;
 use clementine_core::mock_env::MockEnvironment;
 use clementine_core::traits::verifier::VerifierConnector;
 use clementine_core::verifier::Verifier;
-use clementine_core::EVMAddress;
+use clementine_core::{cli, EVMAddress};
 use clementine_core::{extended_rpc::ExtendedRpc, operator::Operator, user::User};
 use crypto_bigint::rand_core::OsRng;
 use crypto_bigint::U256;
@@ -25,8 +26,8 @@ lazy_static::lazy_static! {
     static ref SHARED_STATE: Mutex<i32> = Mutex::new(0);
 }
 
-fn test_flow() -> Result<(), BridgeError> {
-    let rpc = ExtendedRpc::new();
+fn test_flow(cli_options: Args) -> Result<(), BridgeError> {
+    let rpc = ExtendedRpc::new(cli_options.rpc_url);
 
     let secp = bitcoin::secp256k1::Secp256k1::new();
 
@@ -162,6 +163,7 @@ pub fn initialize_logging() {
 }
 
 fn main() {
+    let cli_options = cli::parse_cli();
     initialize_logging();
-    test_flow().unwrap();
+    test_flow(cli_options).unwrap();
 }


### PR DESCRIPTION
# Description

This PR proposes to add a CLI option and arguments parser. Benefits will be:

- Central location for program arguments
- Helpful usage messages
- Kind of an automated documentation

## Linked Issues

- Closes #123

## Testing

- cargo test
- cargo run
  - cargo run --help
  - cargo run -r http://localhost:18443

No unit tests are added.

## Docs

/// block comments are added. Clap (parser used) automatically uses those comments for help messages.