### PR TITLE
Use BitVM Branch With Bitcoin Dependendency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ resolver = "2"
 members = ["core", "circuits"]
 
 [workspace.dependencies]
-bitcoin = "0.31.1"
-bitcoincore-rpc = "0.18.0"
+bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", branch = "bitvm" }
+bitcoincore-rpc = { git = "https://github.com/rust-bitcoin/rust-bitcoincore-rpc" }
 hex = "0.4.3"
 lazy_static = { version = "1.4.0", default-features = false }
 sha2 = { version = "=0.10.8", default-features = false }
@@ -41,3 +41,23 @@ lto = true
 
 [profile.release.build-override]
 opt-level = 3
+
+[patch.crates-io.base58check]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "bitvm"
+
+[patch.crates-io.bitcoin]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "bitvm"
+
+[patch.crates-io.bitcoin_hashes]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "bitvm"
+
+[patch.crates-io.bitcoin-internals]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "bitvm"
+
+[patch.crates-io.bitcoin-io]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "bitvm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3.30"
 dotenv = "0.15.0"
 clap = "4.5.4"
 toml = "0.8.12"
-sqlx = "0.7.4"
+sqlx = { version = "0.7.4", default-features = false }
 k256 = { version = "=0.13.3", default_features = false }
 risc0-build = "0.21.0"
 

--- a/circuits/src/bitcoin.rs
+++ b/circuits/src/bitcoin.rs
@@ -136,7 +136,7 @@ pub fn read_preimages_and_calculate_commit_taproot<E: Environment>() -> ([u8; 32
     for _ in 0..num_preimages {
         hasher_commit_taproot.update([32u8]);
         let preimage = E::read_32bytes();
-        hasher_commit_taproot.update(&preimage);
+        hasher_commit_taproot.update(preimage);
         hasher_claim_proof_leaf.update(sha256_hash!(preimage));
     }
     hasher_commit_taproot.update([104u8]);
@@ -144,7 +144,7 @@ pub fn read_preimages_and_calculate_commit_taproot<E: Environment>() -> ([u8; 32
     let claim_proof_leaf: [u8; 32] = hasher_claim_proof_leaf.finalize().into();
     let taproot_address = calculate_taproot_from_single_script(script_hash);
 
-    return (taproot_address, claim_proof_leaf);
+    (taproot_address, claim_proof_leaf)
 }
 
 pub fn calculate_taproot_from_single_script(tap_leaf_hash: [u8; 32]) -> [u8; 32] {

--- a/circuits/src/bitcoin.rs
+++ b/circuits/src/bitcoin.rs
@@ -1,3 +1,4 @@
+use core::cmp::Ordering;
 use crypto_bigint::Encoding;
 use crypto_bigint::U256;
 use k256::elliptic_curve::group::GroupEncoding;
@@ -75,14 +76,14 @@ pub fn decode_compact_target(bits: [u8; 4]) -> [u8; 32] {
 fn check_hash_valid(hash: [u8; 32], target: [u8; 32]) {
     // for loop from 31 to 0
     for i in (0..32).rev() {
-        if hash[i] < target[i] {
-            // The hash is valid because a byte in hash is less than the corresponding byte in target
-            return;
-        } else if hash[i] > target[i] {
+        match hash[i].cmp(&target[i]) {
             // The hash is invalid because a byte in hash is greater than the corresponding byte in target
-            panic!("Hash is not valid");
+            Ordering::Greater => panic!("Hash is not valid"),
+            // The hash is valid because a byte in hash is less than the corresponding byte in target
+            Ordering::Less => return,
+            // If the bytes are equal, continue to the next byte
+            Ordering::Equal => (),
         }
-        // If the bytes are equal, continue to the next byte
     }
     // If we reach this point, all bytes are equal, so the hash is valid
 }

--- a/circuits/src/bridge.rs
+++ b/circuits/src/bridge.rs
@@ -97,14 +97,14 @@ fn read_header_except_root_and_calculate_blockhash<E: Environment>(mt_root: Hash
     let time = E::read_u32();
     let bits = E::read_u32();
     let nonce = E::read_u32();
-    return double_sha256_hash!(
+    double_sha256_hash!(
         &version.to_le_bytes(),
         &prev_blockhash,
         &mt_root,
         &time.to_le_bytes(),
         &bits.to_le_bytes(),
         &nonce.to_le_bytes()
-    );
+    )
 }
 
 fn calculate_next_block_hash(
@@ -141,7 +141,7 @@ pub fn read_merkle_tree_proof<E: Environment, const D: usize>(
         level_idx /= 2;
     }
     // tracing::debug!("READ merkle_tree_proof of: {:?}", leaf);
-    return hash;
+    hash
 }
 
 /// Reads a withdrawal proof, adds output address to incremental merkle tree
@@ -182,7 +182,7 @@ pub fn read_and_verify_lc_proof<E: Environment>(
 
 /// TODO: implement this function
 pub fn verify_challenge_proof(_proof: [[u8; 32]; 4]) -> bool {
-    return true;
+    true
 }
 
 pub fn read_and_verify_verifiers_challenge_proof<E: Environment>() -> (U256, [u8; 32], u8) {
@@ -324,13 +324,13 @@ pub fn bridge_proof<E: Environment>() -> (U256, [u8; 32], u8) {
         PERIOD_CLAIM_MT_ROOTS[verifiers_challenge_period as usize],
         read_merkle_tree_proof::<E, CLAIM_MERKLE_TREE_DEPTH>(
             claim_proof_tree_leaf,
-            Some(total_num_withdrawals as u32),
+            Some(total_num_withdrawals),
         )
     );
 
-    return (
+    (
         verifiers_pow,
         verifiers_last_finalized_blockhash,
         verifiers_challenge_period,
-    );
+    )
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 clementine-circuits = { path = "../circuits" }
-bitcoin = { workspace = true, features = ["rand", "bitcoinconsensus"] }
+bitcoin = { workspace = true, features = ["rand", "bitcoinconsensus", "serde"] }
 bitcoincore-rpc = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 lazy_static = { workspace = true, features = ["spin_no_std"] }

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -125,7 +125,7 @@ impl Actor {
     pub fn sign_taproot_pubkey_spend_tx(
         &self,
         tx: &mut bitcoin::Transaction,
-        prevouts: &Vec<TxOut>,
+        prevouts: &[TxOut],
         input_index: usize,
     ) -> Result<schnorr::Signature, BridgeError> {
         let mut sighash_cache = SighashCache::new(tx);

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -65,7 +65,7 @@ impl Actor {
     pub fn sign_taproot_script_spend_tx(
         &self,
         tx: &mut bitcoin::Transaction,
-        prevouts: &Vec<TxOut>,
+        prevouts: &[TxOut],
         spend_script: &bitcoin::Script,
         input_index: usize,
     ) -> Result<schnorr::Signature, BridgeError> {

--- a/core/src/bin/config_generator.rs
+++ b/core/src/bin/config_generator.rs
@@ -83,7 +83,8 @@ fn main() {
             .join(",")
     );
     println!(
-        "OPERATOR_URL={}",
-        format!("http://{}:{}", cur_config.host, ports[num_verifiers - 1])
+        "OPERATOR_URL=http://{}:{}",
+        cur_config.host,
+        ports[num_verifiers - 1]
     );
 }

--- a/core/src/bin/user_deposit.rs
+++ b/core/src/bin/user_deposit.rs
@@ -18,7 +18,7 @@ fn main() {
     );
     let evm_address: EVMAddress = EVMAddress([1u8; 20]);
     let deposit_address = tx_builder
-        .generate_deposit_address(&address.as_unchecked(), &evm_address, BRIDGE_AMOUNT_SATS)
+        .generate_deposit_address(address.as_unchecked(), &evm_address, BRIDGE_AMOUNT_SATS)
         .unwrap();
 
     println!("EVM Address: {:?}", hex::encode(evm_address.0));

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -19,7 +19,7 @@ pub struct Args {
     pub config_file: PathBuf,
 }
 
-/// Parse all the cli arguments and generate a `BridgeConfig`.
+/// Parse all the command line arguments and generate a `BridgeConfig`.
 pub fn parse() -> Result<Args, BridgeError> {
     parse_from(env::args())
 }
@@ -39,7 +39,7 @@ where
 /// Parses cli arguments, reads configuration file, parses it and generates a
 /// `BridgeConfig`.
 ///
-/// # Kills Process
+/// # Exits
 ///
 /// Prints help + error messages and kills process on error. This will not panic
 /// intentionally, just to print a user friendly message and not a trace.
@@ -47,7 +47,7 @@ pub fn get_configuration() -> BridgeConfig {
     let args = match parse() {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("{}", e.to_string());
+            eprintln!("{}", e);
             exit(1);
         }
     };
@@ -55,7 +55,7 @@ pub fn get_configuration() -> BridgeConfig {
     match get_configuration_from(args) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("{}", e.to_string());
+            eprintln!("{}", e);
             exit(1);
         }
     }

--- a/core/src/database/common.rs
+++ b/core/src/database/common.rs
@@ -254,6 +254,7 @@ mod tests {
     use std::thread;
 
     #[tokio::test]
+    #[should_panic]
     async fn invalid_connection() {
         let mut config = BridgeConfig::new();
         config.db_host = "nonexistinghost".to_string();
@@ -262,30 +263,14 @@ mod tests {
         config.db_password = "nonexistingpassword".to_string();
         config.db_port = 123;
 
-        match Database::new(config).await {
-            Ok(_) => {
-                assert!(false);
-            }
-            Err(e) => {
-                println!("{}", e);
-                assert!(true);
-            }
-        };
+        Database::new(config).await.unwrap();
     }
 
     #[tokio::test]
     async fn valid_connection() {
         let config = common::get_test_config("test_config.toml").unwrap();
 
-        match Database::new(config).await {
-            Ok(_) => {
-                assert!(true);
-            }
-            Err(e) => {
-                eprintln!("{}", e);
-                assert!(false);
-            }
-        };
+        Database::new(config).await.unwrap();
     }
 
     #[tokio::test]
@@ -293,7 +278,7 @@ mod tests {
         let handle = thread::current()
             .name()
             .unwrap()
-            .split(":")
+            .split(':')
             .last()
             .unwrap()
             .to_owned();

--- a/core/src/env_writer.rs
+++ b/core/src/env_writer.rs
@@ -150,7 +150,7 @@ impl<E: Environment> ENVWriter<E> {
         for node in merkle_path {
             path_indicator <<= 1;
             match node {
-                Some(txmn) => merkle_path_to_be_sent.push(txmn.clone()),
+                Some(txmn) => merkle_path_to_be_sent.push(*txmn),
                 None => path_indicator += 1,
             }
         }
@@ -163,8 +163,7 @@ impl<E: Environment> ENVWriter<E> {
 
         for _ in 0..depth {
             let node = if path_indicator & 1 == 1 {
-                merkle_path_to_be_sent
-                    .insert(reader_pointer, TxMerkleNode::from_byte_array(hash.clone()));
+                merkle_path_to_be_sent.insert(reader_pointer, TxMerkleNode::from_byte_array(hash));
                 reader_pointer += 1;
                 hash
             } else {
@@ -190,7 +189,7 @@ impl<E: Environment> ENVWriter<E> {
         let (merkle_path_to_be_sent, index) =
             ENVWriter::<E>::get_merkle_path_from_merkle_block(merkle_block)?;
 
-        E::write_u32(index as u32);
+        E::write_u32(index);
 
         E::write_u32(merkle_path_to_be_sent.len() as u32);
 
@@ -233,7 +232,7 @@ impl<E: Environment> ENVWriter<E> {
         let (merkle_path_to_be_sent, index) =
             ENVWriter::<E>::get_merkle_path_from_merkle_block(merkle_block)?;
 
-        E::write_u32(index as u32);
+        E::write_u32(index);
 
         E::write_u32(merkle_path_to_be_sent.len() as u32);
 

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -129,7 +129,7 @@ pub enum BridgeError {
 
 impl Into<ErrorObject<'static>> for BridgeError {
     fn into(self) -> ErrorObjectOwned {
-        ErrorObject::owned(-30000, &format!("{:?}", self), Some(1))
+        ErrorObject::owned(-30000, format!("{:?}", self), Some(1))
     }
 }
 

--- a/core/src/merkle.rs
+++ b/core/src/merkle.rs
@@ -76,14 +76,9 @@ impl<const DEPTH: usize> MerkleTree<DEPTH> {
     }
 
     /// TODO: Make this more efficient
+    /// Note: Clippy suggested to use this iterator over loop
     pub fn index_of(&self, a: HashType) -> Option<u32> {
-        for i in 0..self.index {
-            if self.data[0][i as usize] == a {
-                return Some(i);
-            }
-        }
-
-        None
+        (0..self.index).find(|&i| self.data[0][i as usize] == a)
     }
 
     pub fn to_incremental_tree(&self, index: u32) -> IncrementalMerkleTree<DEPTH> {
@@ -139,7 +134,7 @@ mod tests {
         ];
         assert_eq!(mt.root(), contract_empty_root);
         assert_eq!(mt.root(), imt.root);
-        let a = [1 as u8; 32];
+        let a = [1_u8; 32];
         mt.add(a);
         imt.add(a);
         let contract_insert_1_root: [u8; 32] = [

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -112,7 +112,7 @@ impl Operator {
         let mut move_tx = self.transaction_builder.create_move_tx(
             start_utxo,
             evm_address,
-            &recovery_taproot_address,
+            recovery_taproot_address,
         )?;
 
         let presigns_from_all_verifiers: Vec<_> = self

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -123,7 +123,7 @@ pub async fn create_operator_and_verifiers(
             .await
             .unwrap();
     let operator_client = HttpClientBuilder::default()
-        .build(&format!(
+        .build(format!(
             "http://{}:{}/",
             operator_socket_addr.ip(),
             operator_socket_addr.port()

--- a/core/src/transaction_builder.rs
+++ b/core/src/transaction_builder.rs
@@ -339,7 +339,7 @@ mod tests {
 
         let deposit_address = tx_builder
             .generate_deposit_address(
-                &recovery_taproot_address.as_unchecked(),
+                recovery_taproot_address.as_unchecked(),
                 &crate::EVMAddress(evm_address),
                 10_000,
             )

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -46,7 +46,7 @@ impl User {
         evm_address: EVMAddress,
     ) -> Result<(OutPoint, XOnlyPublicKey, EVMAddress), BridgeError> {
         let (deposit_address, _) = self.transaction_builder.generate_deposit_address(
-            &self.signer.address.as_unchecked(),
+            self.signer.address.as_unchecked(),
             &evm_address,
             BRIDGE_AMOUNT_SATS,
         )?;
@@ -60,7 +60,7 @@ impl User {
 
     pub fn get_deposit_address(&self, evm_address: EVMAddress) -> Result<Address, BridgeError> {
         let (deposit_address, _) = self.transaction_builder.generate_deposit_address(
-            &self.signer.address.as_unchecked(),
+            self.signer.address.as_unchecked(),
             &evm_address,
             BRIDGE_AMOUNT_SATS,
         )?;

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -38,7 +38,7 @@ pub fn calculate_amount(depth: usize, value: Amount, fee: Amount) -> Amount {
 pub fn handle_taproot_witness<T: AsRef<[u8]>>(
     tx: &mut bitcoin::Transaction,
     index: usize,
-    witness_elements: &Vec<T>,
+    witness_elements: &[T],
     script: &ScriptBuf,
     tree_info: &TaprootSpendInfo,
 ) -> Result<(), BridgeError> {
@@ -64,7 +64,7 @@ pub fn handle_taproot_witness<T: AsRef<[u8]>>(
 
 pub fn handle_taproot_witness_new<T: AsRef<[u8]>>(
     tx: &mut CreateTxOutputs,
-    witness_elements: &Vec<T>,
+    witness_elements: &[T],
     txin_index: usize,
     script_index: usize,
 ) -> Result<(), BridgeError> {
@@ -144,12 +144,11 @@ pub fn calculate_claim_proof_root(
                 hasher.update(hashes[i as usize * 2]);
                 hasher.update(hashes[i as usize * 2 + 1]);
 
-                let hash = hasher.finalize().into();
-                hash
+                hasher.finalize().into()
             })
             .collect();
 
-        hashes = level_hashes.clone();
+        hashes.clone_from(&level_hashes);
         level += 1;
     }
 

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -85,7 +85,7 @@ impl Verifier {
         let mut move_tx = self.transaction_builder.create_move_tx(
             start_utxo,
             evm_address,
-            &recovery_taproot_address,
+            recovery_taproot_address,
         )?;
         let move_txid = move_tx.tx.txid();
 

--- a/core/tests/flow.rs
+++ b/core/tests/flow.rs
@@ -105,13 +105,7 @@ async fn test_flow_1() {
     tracing::debug!("Withdrawal TXID: {:#?}", withdraw_txid);
 
     // get the tx details from rpc with txid
-    let tx = match rpc.get_raw_transaction(&withdraw_txid, None) {
-        Ok(c) => c,
-        Err(e) => {
-            assert!(false);
-            panic!("Transaction error: {:#?}", e);
-        }
-    };
+    let tx = rpc.get_raw_transaction(&withdraw_txid, None).unwrap();
     // tracing::debug!("Withdraw TXID raw transaction: {:#?}", tx);
 
     // check whether it has an output with the withdrawal address

--- a/core/tests/flow.rs
+++ b/core/tests/flow.rs
@@ -23,7 +23,7 @@ async fn test_flow_1() {
     let handle = thread::current()
         .name()
         .unwrap()
-        .split(":")
+        .split(':')
         .last()
         .unwrap()
         .to_owned();
@@ -53,7 +53,7 @@ async fn test_flow_1() {
         config.min_relay_fee,
     );
 
-    let evm_addresses = vec![
+    let evm_addresses = [
         EVMAddress([1u8; 20]),
         EVMAddress([2u8; 20]),
         EVMAddress([3u8; 20]),
@@ -65,7 +65,7 @@ async fn test_flow_1() {
         .map(|evm_address| {
             tx_builder
                 .generate_deposit_address(
-                    &taproot_address.as_unchecked(),
+                    taproot_address.as_unchecked(),
                     evm_address,
                     BRIDGE_AMOUNT_SATS,
                 )
@@ -77,7 +77,7 @@ async fn test_flow_1() {
 
     for (idx, deposit_address) in deposit_addresses.iter().enumerate() {
         let deposit_utxo = rpc
-            .send_to_address(&deposit_address, BRIDGE_AMOUNT_SATS)
+            .send_to_address(deposit_address, BRIDGE_AMOUNT_SATS)
             .unwrap();
         tracing::debug!("Deposit UTXO #{}: {:#?}", idx, deposit_utxo);
 
@@ -122,9 +122,8 @@ async fn test_flow_1() {
     let anyone_can_spend_amount = ScriptBuilder::anyone_can_spend_txout().value;
 
     // check if the amounts match
-    let expected_withdraw_amount =
-        Amount::from_sat(BRIDGE_AMOUNT_SATS - 2 * config.min_relay_fee.clone())
-            - anyone_can_spend_amount * 2;
+    let expected_withdraw_amount = Amount::from_sat(BRIDGE_AMOUNT_SATS - 2 * config.min_relay_fee)
+        - anyone_can_spend_amount * 2;
     assert_eq!(expected_withdraw_amount, rpc_withdraw_amount);
 }
 
@@ -134,7 +133,7 @@ async fn test_flow_2() {
     let handle = thread::current()
         .name()
         .unwrap()
-        .split(":")
+        .split(':')
         .last()
         .unwrap()
         .to_owned();
@@ -172,7 +171,7 @@ async fn test_flow_2() {
 
     let deposit_address_info = tx_builder
         .generate_deposit_address(
-            &taproot_address.as_unchecked(),
+            taproot_address.as_unchecked(),
             &evm_address,
             BRIDGE_AMOUNT_SATS,
         )

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -57,7 +57,7 @@ async fn run() {
     .unwrap();
     let utxo = rpc.send_to_address(&taproot_address, 1000).unwrap();
 
-    let ins = TransactionBuilder::create_tx_ins(vec![utxo.clone()]);
+    let ins = TransactionBuilder::create_tx_ins(vec![utxo]);
 
     let tx_outs = vec![TxOut {
         value: Amount::from_sat(330),


### PR DESCRIPTION
# Description

Using BitVM branch with Bitcoin dependency will be useful with BitVM related libraries. Currently, BitVM branch is very immature and care should be taken when we integrate with it.

## Testing

No new tests are needed and existing tests must pass.