### PR TITLE
Use global SECP

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -1,17 +1,17 @@
 use crate::errors::BridgeError;
 use crate::transaction_builder::CreateTxOutputs;
+use crate::utils;
 use bitcoin::sighash::SighashCache;
 use bitcoin::taproot::LeafVersion;
 use bitcoin::{
     hashes::Hash,
-    secp256k1::{ecdsa, schnorr, All, Keypair, Message, Secp256k1, SecretKey, XOnlyPublicKey},
+    secp256k1::{ecdsa, schnorr, Keypair, Message, SecretKey, XOnlyPublicKey},
     Address, TapSighash, TapTweakHash,
 };
 use bitcoin::{TapLeafHash, TapNodeHash, TxOut};
 
 #[derive(Debug, Clone)]
 pub struct Actor {
-    secp: Secp256k1<All>,
     keypair: Keypair,
     secret_key: SecretKey,
     pub xonly_public_key: XOnlyPublicKey,
@@ -20,13 +20,11 @@ pub struct Actor {
 
 impl Actor {
     pub fn new(sk: SecretKey, network: bitcoin::Network) -> Self {
-        let secp: Secp256k1<All> = Secp256k1::new();
-        let keypair = Keypair::from_secret_key(&secp, &sk);
+        let keypair = Keypair::from_secret_key(&utils::SECP, &sk);
         let (xonly, _parity) = XOnlyPublicKey::from_keypair(&keypair);
-        let address = Address::p2tr(&secp, xonly, None, network);
+        let address = Address::p2tr(&utils::SECP, xonly, None, network);
 
         Actor {
-            secp,
             keypair,
             secret_key: keypair.secret_key(),
             xonly_public_key: xonly,
@@ -39,24 +37,24 @@ impl Actor {
         sighash: TapSighash,
         merkle_root: Option<TapNodeHash>,
     ) -> Result<schnorr::Signature, BridgeError> {
-        Ok(self.secp.sign_schnorr(
+        Ok(utils::SECP.sign_schnorr(
             &Message::from_digest_slice(sighash.as_byte_array()).expect("should be hash"),
             &self.keypair.add_xonly_tweak(
-                &self.secp,
+                &utils::SECP,
                 &TapTweakHash::from_key_and_tweak(self.xonly_public_key, merkle_root).to_scalar(),
             )?,
         ))
     }
 
     pub fn sign(&self, sighash: TapSighash) -> schnorr::Signature {
-        self.secp.sign_schnorr(
+        utils::SECP.sign_schnorr(
             &Message::from_digest_slice(sighash.as_byte_array()).expect("should be hash"),
             &self.keypair,
         )
     }
 
     pub fn sign_ecdsa(&self, data: [u8; 32]) -> ecdsa::Signature {
-        self.secp.sign_ecdsa(
+        utils::SECP.sign_ecdsa(
             &Message::from_digest_slice(&data).expect("should be hash"),
             &self.secret_key,
         )

--- a/core/src/bin/user_deposit.rs
+++ b/core/src/bin/user_deposit.rs
@@ -10,13 +10,15 @@ fn main() {
     let secp = bitcoin::secp256k1::Secp256k1::new();
     let (xonly_pk, _) = config.secret_key.public_key(&secp).x_only_public_key();
     let address = Address::p2tr(&secp, xonly_pk, None, config.network);
-    let tx_builder = TransactionBuilder::new(
-        config.verifiers_public_keys.clone(),
-        config.network,
-    );
+    let tx_builder = TransactionBuilder::new(config.verifiers_public_keys.clone(), config.network);
     let evm_address: EVMAddress = EVMAddress([1u8; 20]);
     let deposit_address = tx_builder
-        .generate_deposit_address(address.as_unchecked(), &evm_address, BRIDGE_AMOUNT_SATS)
+        .generate_deposit_address(
+            address.as_unchecked(),
+            &evm_address,
+            BRIDGE_AMOUNT_SATS,
+            config.user_takes_after,
+        )
         .unwrap();
 
     println!("EVM Address: {:?}", hex::encode(evm_address.0));

--- a/core/src/bin/user_deposit.rs
+++ b/core/src/bin/user_deposit.rs
@@ -13,8 +13,6 @@ fn main() {
     let tx_builder = TransactionBuilder::new(
         config.verifiers_public_keys.clone(),
         config.network,
-        config.user_takes_after,
-        config.min_relay_fee,
     );
     let evm_address: EVMAddress = EVMAddress([1u8; 20]);
     let deposit_address = tx_builder

--- a/core/src/extended_rpc.rs
+++ b/core/src/extended_rpc.rs
@@ -255,6 +255,7 @@ impl ExtendedRpc {
         recovery_taproot_address: &Address<NetworkUnchecked>,
         evm_address: &EVMAddress,
         amount_sats: u64,
+        user_takes_after: u32,
         confirmation_block_count: u32,
     ) -> Result<(), BridgeError> {
         if self.confirmation_blocks(&outpoint.txid)? < confirmation_block_count {
@@ -265,6 +266,7 @@ impl ExtendedRpc {
             recovery_taproot_address,
             evm_address,
             BRIDGE_AMOUNT_SATS,
+            user_takes_after,
         )?;
 
         if !self.check_utxo_address_and_amount(

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -32,6 +32,7 @@ pub struct Operator {
     verifier_connector: Vec<jsonrpsee::http_client::HttpClient>,
     confirmation_treshold: u32,
     min_relay_fee: u64,
+    user_takes_after: u32,
 }
 
 impl Operator {
@@ -48,10 +49,8 @@ impl Operator {
             return Err(BridgeError::InvalidOperatorKey);
         }
 
-        let transaction_builder = TransactionBuilder::new(
-            config.verifiers_public_keys.clone(),
-            config.network,
-        );
+        let transaction_builder =
+            TransactionBuilder::new(config.verifiers_public_keys.clone(), config.network);
 
         let db = OperatorDB::new(config.clone()).await;
 
@@ -63,6 +62,7 @@ impl Operator {
             verifier_connector: verifiers,
             confirmation_treshold: config.confirmation_treshold,
             min_relay_fee: config.min_relay_fee,
+            user_takes_after: config.user_takes_after,
         })
     }
 
@@ -102,6 +102,7 @@ impl Operator {
             recovery_taproot_address,
             evm_address,
             BRIDGE_AMOUNT_SATS,
+            self.user_takes_after,
             self.confirmation_treshold,
         )?;
 
@@ -111,6 +112,7 @@ impl Operator {
             start_utxo,
             evm_address,
             recovery_taproot_address,
+            self.user_takes_after,
         )?;
 
         let presigns_from_all_verifiers: Vec<_> = self

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -51,8 +51,6 @@ impl Operator {
         let transaction_builder = TransactionBuilder::new(
             config.verifiers_public_keys.clone(),
             config.network,
-            config.user_takes_after,
-            config.min_relay_fee,
         );
 
         let db = OperatorDB::new(config.clone()).await;

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -15,6 +15,7 @@ pub struct User {
     rpc: ExtendedRpc,
     signer: Actor,
     transaction_builder: TransactionBuilder,
+    user_takes_after: u32,
 }
 
 impl User {
@@ -27,15 +28,13 @@ impl User {
     ) -> Self {
         let signer = Actor::new(sk, config.network);
 
-        let transaction_builder = TransactionBuilder::new(
-            all_xonly_pks.clone(),
-            config.network,
-        );
+        let transaction_builder = TransactionBuilder::new(all_xonly_pks.clone(), config.network);
 
         User {
             rpc,
             signer,
             transaction_builder,
+            user_takes_after: config.user_takes_after,
         }
     }
 
@@ -47,6 +46,7 @@ impl User {
             self.signer.address.as_unchecked(),
             &evm_address,
             BRIDGE_AMOUNT_SATS,
+            self.user_takes_after,
         )?;
 
         let deposit_utxo = self
@@ -61,6 +61,7 @@ impl User {
             self.signer.address.as_unchecked(),
             &evm_address,
             BRIDGE_AMOUNT_SATS,
+            self.user_takes_after,
         )?;
 
         Ok(deposit_address)

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -30,8 +30,6 @@ impl User {
         let transaction_builder = TransactionBuilder::new(
             all_xonly_pks.clone(),
             config.network,
-            config.user_takes_after,
-            config.min_relay_fee,
         );
 
         User {

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -9,13 +9,31 @@ use bitcoin::taproot::LeafVersion;
 use bitcoin::taproot::TaprootSpendInfo;
 use bitcoin::Amount;
 use bitcoin::ScriptBuf;
+use bitcoin::XOnlyPublicKey;
 use hex;
 use sha2::{Digest, Sha256};
 use std::borrow::BorrowMut;
+use std::str::FromStr;
 
 lazy_static::lazy_static! {
-	/// Global secp context.
-	pub static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
+    /// Global secp context.
+    pub static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
+}
+
+lazy_static::lazy_static! {
+    /// This is an unspendable pubkey.
+    ///
+    /// See https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
+    pub static ref UNSPENDABLE_PUBKEY: bitcoin::secp256k1::PublicKey =
+        "93c7378d96518a75448821c4f7c8f4bae7ce60f804d03d1f0628dd5dd0f5de51".parse().unwrap();
+}
+
+lazy_static::lazy_static! {
+    /// This is an unspendable pubkey.
+    ///
+    /// See https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
+    pub static ref UNSPENDABLE_XONLY_PUBKEY: bitcoin::secp256k1::XOnlyPublicKey =
+        XOnlyPublicKey::from_str("93c7378d96518a75448821c4f7c8f4bae7ce60f804d03d1f0628dd5dd0f5de51").unwrap();
 }
 
 pub fn parse_hex_to_btc_tx(

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -13,6 +13,11 @@ use hex;
 use sha2::{Digest, Sha256};
 use std::borrow::BorrowMut;
 
+lazy_static::lazy_static! {
+	/// Global secp context.
+	pub static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
+}
+
 pub fn parse_hex_to_btc_tx(
     tx_hex: &str,
 ) -> Result<bitcoin::blockdata::transaction::Transaction, bitcoin::consensus::encode::Error> {

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -45,8 +45,6 @@ impl Verifier {
         let transaction_builder = TransactionBuilder::new(
             config.verifiers_public_keys.clone(),
             config.network,
-            config.user_takes_after,
-            config.min_relay_fee,
         );
 
         Ok(Verifier {

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -24,6 +24,7 @@ pub struct Verifier {
     network: Network,
     confirmation_treshold: u32,
     min_relay_fee: u64,
+    user_takes_after: u32,
 }
 
 impl Verifier {
@@ -42,10 +43,8 @@ impl Verifier {
 
         let db = VerifierDB::new(config.clone()).await;
 
-        let transaction_builder = TransactionBuilder::new(
-            config.verifiers_public_keys.clone(),
-            config.network,
-        );
+        let transaction_builder =
+            TransactionBuilder::new(config.verifiers_public_keys.clone(), config.network);
 
         Ok(Verifier {
             rpc,
@@ -55,6 +54,7 @@ impl Verifier {
             network: config.network,
             confirmation_treshold: config.confirmation_treshold,
             min_relay_fee: config.min_relay_fee,
+            user_takes_after: config.user_takes_after,
         })
     }
 
@@ -77,6 +77,7 @@ impl Verifier {
             recovery_taproot_address,
             evm_address,
             BRIDGE_AMOUNT_SATS,
+            self.user_takes_after,
             self.confirmation_treshold,
         )?;
 
@@ -84,6 +85,7 @@ impl Verifier {
             start_utxo,
             evm_address,
             recovery_taproot_address,
+            self.user_takes_after,
         )?;
         let move_txid = move_tx.tx.compute_txid();
 

--- a/core/tests/flow.rs
+++ b/core/tests/flow.rs
@@ -46,10 +46,7 @@ async fn test_flow_1() {
     let secp = bitcoin::secp256k1::Secp256k1::new();
     let (xonly_pk, _) = config.secret_key.public_key(&secp).x_only_public_key();
     let taproot_address = Address::p2tr(&secp, xonly_pk, None, config.network);
-    let tx_builder = TransactionBuilder::new(
-        config.verifiers_public_keys.clone(),
-        config.network,
-    );
+    let tx_builder = TransactionBuilder::new(config.verifiers_public_keys.clone(), config.network);
 
     let evm_addresses = [
         EVMAddress([1u8; 20]),
@@ -66,6 +63,7 @@ async fn test_flow_1() {
                     taproot_address.as_unchecked(),
                     evm_address,
                     BRIDGE_AMOUNT_SATS,
+                    config.user_takes_after,
                 )
                 .unwrap()
                 .0
@@ -152,10 +150,7 @@ async fn test_flow_2() {
         "Taproot address script pubkey: {:#?}",
         taproot_address.script_pubkey()
     );
-    let tx_builder = TransactionBuilder::new(
-        config.verifiers_public_keys.clone(),
-        config.network,
-    );
+    let tx_builder = TransactionBuilder::new(config.verifiers_public_keys.clone(), config.network);
 
     let evm_address = EVMAddress([1u8; 20]);
 
@@ -164,6 +159,7 @@ async fn test_flow_2() {
             taproot_address.as_unchecked(),
             &evm_address,
             BRIDGE_AMOUNT_SATS,
+            config.user_takes_after,
         )
         .unwrap();
 

--- a/core/tests/flow.rs
+++ b/core/tests/flow.rs
@@ -49,8 +49,6 @@ async fn test_flow_1() {
     let tx_builder = TransactionBuilder::new(
         config.verifiers_public_keys.clone(),
         config.network,
-        config.user_takes_after,
-        config.min_relay_fee,
     );
 
     let evm_addresses = [
@@ -157,8 +155,6 @@ async fn test_flow_2() {
     let tx_builder = TransactionBuilder::new(
         config.verifiers_public_keys.clone(),
         config.network,
-        config.user_takes_after,
-        config.min_relay_fee,
     );
 
     let evm_address = EVMAddress([1u8; 20]);

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -50,7 +50,6 @@ async fn run() {
         .into_script();
 
     let (taproot_address, taproot_spend_info) = TransactionBuilder::create_taproot_address(
-        &secp,
         vec![to_pay_script.clone()],
         config.network,
     )

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -49,11 +49,9 @@ async fn run() {
         .push_opcode(OP_CHECKSIG)
         .into_script();
 
-    let (taproot_address, taproot_spend_info) = TransactionBuilder::create_taproot_address(
-        vec![to_pay_script.clone()],
-        config.network,
-    )
-    .unwrap();
+    let (taproot_address, taproot_spend_info) =
+        TransactionBuilder::create_taproot_address(vec![to_pay_script.clone()], config.network)
+            .unwrap();
     let utxo = rpc.send_to_address(&taproot_address, 1000).unwrap();
 
     let ins = TransactionBuilder::create_tx_ins(vec![utxo]);


### PR DESCRIPTION
# Description
Uses global secp context instead of passing, 

## Linked Issues

- Closes #182 
