### PR TITLE
Add code check for CI.

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -1,0 +1,25 @@
+name: Code Checks
+
+on: [push]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  formatting:
+    name: Check formatting
+    runs-on: ubicloud-standard-4
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run Cargo fmt
+      run: cargo fmt --check
+
+  linting:
+    name: Check linting
+    runs-on: ubicloud-standard-4
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run Cargo clippy
+      run: cargo clippy --no-deps -- -Dwarnings


### PR DESCRIPTION
# Description

This PR adds a new check for CI. It basically checks format of the code and linting. Helpful for eliminating ugly code.

This is copied from [bitcoin-mock-rpc](https://github.com/chainwayxyz/bitcoin-mock-rpc). Check [actions in bitcoin-mock-rpc](https://github.com/chainwayxyz/bitcoin-mock-rpc/actions) to see how it will look.

Please note that this will mark action as failed if any of these 2 tools are failed.