### PR TITLE
Tracing instrument tagging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ toml = "0.8.19"
 sqlx = { version = "0.7.4", default-features = false }
 # k256 = { version = "=0.13.3", default-features = false }
 # risc0-build = "0.21.0"
-bitcoin-mock-rpc = { git = "https://github.com/chainwayxyz/bitcoin-mock-rpc", tag = "v0.0.10" }
+bitcoin-mock-rpc = { git = "https://github.com/chainwayxyz/bitcoin-mock-rpc", rev = "d1dd0af" }
 musig2 = { version = "0.0.11", features = ["serde"] }
 
 # Always optimize; building and running the guest takes much longer without optimization.

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -34,6 +34,7 @@ impl Actor {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn sign_with_tweak(
         &self,
         sighash: TapSighash,
@@ -48,6 +49,7 @@ impl Actor {
         ))
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn sign(&self, sighash: TapSighash) -> schnorr::Signature {
         utils::SECP.sign_schnorr(
             &Message::from_digest_slice(sighash.as_byte_array()).expect("should be hash"),
@@ -55,6 +57,7 @@ impl Actor {
         )
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn sign_ecdsa(&self, data: [u8; 32]) -> ecdsa::Signature {
         utils::SECP.sign_ecdsa(
             &Message::from_digest_slice(&data).expect("should be hash"),
@@ -62,6 +65,7 @@ impl Actor {
         )
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn sign_taproot_script_spend_tx(
         &self,
         tx: &mut bitcoin::Transaction,
@@ -79,6 +83,7 @@ impl Actor {
         Ok(self.sign(sig_hash))
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn sighash_taproot_script_spend(
         &self,
         tx: &mut TxHandler,
@@ -99,6 +104,7 @@ impl Actor {
         Ok(sig_hash)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn sign_taproot_script_spend_tx_new(
         &self,
         tx: &mut TxHandler,
@@ -122,6 +128,7 @@ impl Actor {
         Ok(self.sign(sig_hash))
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn sign_taproot_pubkey_spend(
         &self,
         tx_handler: &mut TxHandler,
@@ -143,6 +150,7 @@ impl Actor {
         self.sign_with_tweak(sig_hash, None)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn sign_taproot_pubkey_spend_tx(
         &self,
         tx: &mut bitcoin::Transaction,
@@ -158,6 +166,7 @@ impl Actor {
         self.sign_with_tweak(sig_hash, None)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn sign_taproot_pubkey_spend_tx_with_sighash(
         &self,
         tx: &mut bitcoin::Transaction,
@@ -179,6 +188,7 @@ impl Actor {
         self.sign_with_tweak(sig_hash, None)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn sign_taproot_script_spend_tx_new_tweaked(
         &self,
         tx_handler: &mut TxHandler,
@@ -202,6 +212,7 @@ impl Actor {
         Ok(self.sign_with_tweak(sig_hash, None).unwrap())
     }
 
+    #[tracing::instrument]
     pub fn convert_tx_to_sighash_script_spend(
         tx_handler: &mut TxHandler,
         txin_index: usize,
@@ -220,6 +231,7 @@ impl Actor {
         )?;
         Ok(sig_hash)
     }
+    #[tracing::instrument]
     pub fn convert_tx_to_sighash_pubkey_spend(
         tx: &mut TxHandler,
         txin_index: usize,

--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -45,6 +45,7 @@ impl Aggregator {
         })
     }
 
+    #[tracing::instrument(skip(self))]
     fn aggregate_slash_or_take_partial_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -91,6 +92,7 @@ impl Aggregator {
         Ok(final_sig)
     }
 
+    #[tracing::instrument(skip(self))]
     fn aggregate_operator_takes_partial_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -173,6 +175,7 @@ impl Aggregator {
         Ok(final_sig)
     }
 
+    #[tracing::instrument(skip(self))]
     fn aggregate_move_partial_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -207,6 +210,7 @@ impl Aggregator {
         Ok(final_sig)
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn aggregate_pub_nonces(
         &self,
         pub_nonces: Vec<Vec<MuSigPubNonce>>,
@@ -225,6 +229,7 @@ impl Aggregator {
         Ok(agg_nonces)
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn aggregate_slash_or_take_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -258,6 +263,7 @@ impl Aggregator {
         Ok(slash_or_take_sigs)
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn aggregate_operator_take_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -281,6 +287,7 @@ impl Aggregator {
         Ok(operator_take_sigs)
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn aggregate_move_tx_sigs(
         &self,
         deposit_outpoint: OutPoint,

--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -325,6 +325,7 @@ impl Aggregator {
 
 #[async_trait]
 impl AggregatorServer for Aggregator {
+    #[tracing::instrument(skip(self))]
     async fn aggregate_pub_nonces_rpc(
         &self,
         pub_nonces: Vec<Vec<MuSigPubNonce>>,
@@ -332,6 +333,7 @@ impl AggregatorServer for Aggregator {
         self.aggregate_pub_nonces(pub_nonces).await
     }
 
+    #[tracing::instrument(skip(self))]
     async fn aggregate_slash_or_take_sigs_rpc(
         &self,
         deposit_outpoint: OutPoint,
@@ -343,6 +345,7 @@ impl AggregatorServer for Aggregator {
             .await
     }
 
+    #[tracing::instrument(skip(self))]
     async fn aggregate_operator_take_sigs_rpc(
         &self,
         deposit_outpoint: OutPoint,
@@ -354,6 +357,7 @@ impl AggregatorServer for Aggregator {
             .await
     }
 
+    #[tracing::instrument(skip(self))]
     async fn aggregate_move_tx_sigs_rpc(
         &self,
         deposit_outpoint: OutPoint,

--- a/core/src/extended_rpc.rs
+++ b/core/src/extended_rpc.rs
@@ -49,6 +49,7 @@ where
         }
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn confirmation_blocks(&self, txid: &bitcoin::Txid) -> Result<u32, BridgeError> {
         let raw_transaction_results = self.client.get_raw_transaction_info(txid, None)?;
 
@@ -57,6 +58,7 @@ where
             .ok_or(BridgeError::NoConfirmationData)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn check_utxo_address_and_amount(
         &self,
         outpoint: &OutPoint,
@@ -75,6 +77,7 @@ where
         Ok(expected_output == current_output)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn is_utxo_spent(&self, outpoint: &OutPoint) -> Result<bool, BridgeError> {
         let res = self
             .client
@@ -83,6 +86,7 @@ where
         Ok(res.is_none())
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn generate_dummy_block(&self) -> Result<Vec<bitcoin::BlockHash>, BridgeError> {
         let address = self.client.get_new_address(None, None)?.assume_checked();
 
@@ -104,6 +108,7 @@ where
         Ok(self.client.generate_to_address(1, &address)?)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn mine_blocks(&self, block_num: u64) -> Result<(), BridgeError> {
         let new_address = self.client.get_new_address(None, None)?.assume_checked();
 
@@ -112,6 +117,7 @@ where
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn send_to_address(
         &self,
         address: &Address,
@@ -134,6 +140,7 @@ where
         Ok(OutPoint { txid, vout })
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_work_at_block(&self, blockheight: u64) -> Result<Work, BridgeError> {
         let block_hash = self.get_block_hash(blockheight)?;
         let block = self.client.get_block(&block_hash)?;
@@ -142,6 +149,7 @@ where
         Ok(work)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_block_hash(
         &self,
         blockheight: u64,
@@ -151,6 +159,7 @@ where
         Ok(block_hash)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_block_header(
         &self,
         block_hash: &bitcoin::BlockHash,
@@ -160,6 +169,7 @@ where
         Ok(block_header)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn calculate_total_work_between_blocks(
         &self,
         start: u64,
@@ -179,6 +189,7 @@ where
         Ok(U256::from_be_bytes(work_bytes))
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_total_work_as_u256(&self) -> Result<U256, BridgeError> {
         let chain_info = self.client.get_blockchain_info()?;
         let total_work_bytes = chain_info.chain_work;
@@ -187,6 +198,7 @@ where
         Ok(total_work)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_total_work(&self) -> Result<Work, BridgeError> {
         let chain_info = self.client.get_blockchain_info()?;
         let total_work_bytes = chain_info.chain_work;
@@ -195,6 +207,7 @@ where
         Ok(total_work)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_block_height(&self) -> Result<u64, BridgeError> {
         let chain_info = self.client.get_blockchain_info()?;
         let block_height = chain_info.blocks;
@@ -202,6 +215,7 @@ where
         Ok(block_height)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_txout_from_outpoint(&self, outpoint: &OutPoint) -> Result<TxOut, BridgeError> {
         let tx = self.client.get_raw_transaction(&outpoint.txid, None)?;
         let txout = tx.output[outpoint.vout as usize].clone();
@@ -209,6 +223,7 @@ where
         Ok(txout)
     }
 
+    #[tracing::instrument(skip(self))]
     // Following methods are just wrappers around the bitcoincore_rpc::Client methods
     pub fn fund_raw_transaction(
         &self,
@@ -219,6 +234,7 @@ where
         self.client.fund_raw_transaction(tx, options, is_witness)
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn sign_raw_transaction_with_wallet<T: bitcoincore_rpc::RawTx>(
         &self,
         tx: T,
@@ -229,20 +245,24 @@ where
             .sign_raw_transaction_with_wallet(tx, utxos, sighash_type)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_blockchain_info(
         &self,
     ) -> Result<bitcoincore_rpc::json::GetBlockchainInfoResult, bitcoincore_rpc::Error> {
         self.client.get_blockchain_info()
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_block_count(&self) -> Result<u64, bitcoincore_rpc::Error> {
         self.client.get_block_count()
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_best_block_hash(&self) -> Result<bitcoin::BlockHash, bitcoincore_rpc::Error> {
         self.client.get_best_block_hash()
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_raw_transaction(
         &self,
         txid: &bitcoin::Txid,
@@ -251,6 +271,7 @@ where
         self.client.get_raw_transaction(txid, block_hash)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_transaction(
         &self,
         txid: &bitcoin::Txid,
@@ -259,6 +280,7 @@ where
         self.client.get_transaction(txid, include_watchonly)
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn send_raw_transaction<T: bitcoincore_rpc::RawTx>(
         &self,
         tx: T,
@@ -266,12 +288,14 @@ where
         self.client.send_raw_transaction(tx)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_block(
         &self,
         block_hash: &bitcoin::BlockHash,
     ) -> Result<bitcoin::Block, bitcoincore_rpc::Error> {
         self.client.get_block(block_hash)
     }
+    #[tracing::instrument(skip(self))]
     pub fn get_raw_transaction_info(
         &self,
         txid: &bitcoin::Txid,
@@ -280,6 +304,7 @@ where
         self.client.get_raw_transaction_info(txid, block_hash)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn check_deposit_utxo(
         &self,
         nofn_xonly_pk: &XOnlyPublicKey,
@@ -320,6 +345,7 @@ where
     }
 
     /// Generates bitcoins to specified address.
+    #[tracing::instrument(skip(self))]
     pub fn generate_to_address(
         &self,
         block_num: u64,
@@ -331,6 +357,7 @@ where
     }
 
     /// Requests a new Bitcoin address via an RPC call.
+    #[tracing::instrument(skip(self))]
     pub fn get_new_address(&self) -> Result<Address, BridgeError> {
         let address = self
             .client

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -564,6 +564,7 @@ impl<R> OperatorRpcServer for Operator<R>
 where
     R: RpcApiWrapper,
 {
+    #[tracing::instrument(skip(self))]
     async fn new_deposit_rpc(
         &self,
         deposit_outpoint: OutPoint,
@@ -574,10 +575,12 @@ where
             .await
     }
 
+    #[tracing::instrument(skip(self))]
     async fn set_funding_utxo_rpc(&self, funding_utxo: UTXO) -> Result<(), BridgeError> {
         self.set_funding_utxo(funding_utxo).await
     }
 
+    #[tracing::instrument(skip(self))]
     async fn new_withdrawal_sig_rpc(
         &self,
         withdrawal_idx: usize,
@@ -589,6 +592,7 @@ where
             .await
     }
 
+    #[tracing::instrument(skip(self))]
     async fn withdrawal_proved_on_citrea_rpc(
         &self,
         withdrawal_idx: usize,

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -25,6 +25,7 @@ use std::thread;
 use traits::rpc::OperatorRpcServer;
 
 /// Starts a server for a verifier.
+#[tracing::instrument]
 pub async fn create_verifier_server<R>(
     config: BridgeConfig,
     rpc: ExtendedRpc<R>,
@@ -54,7 +55,8 @@ where
 }
 
 /// Starts the server for the operator.
-pub async fn create_operator_server<R>(
+#[tracing::instrument]
+pub async fn create_operator_server<R: RpcApiWrapper>(
     config: BridgeConfig,
     rpc: ExtendedRpc<R>,
 ) -> Result<(HttpClient, ServerHandle, std::net::SocketAddr), BridgeError>
@@ -84,6 +86,7 @@ where
 }
 
 /// Starts the server for the aggregator.
+#[tracing::instrument]
 pub async fn create_aggregator_server(
     config: BridgeConfig,
 ) -> Result<(HttpClient, ServerHandle, std::net::SocketAddr), BridgeError> {
@@ -125,6 +128,7 @@ fn is_test_env() -> bool {
 /// # Panics
 ///
 /// Panics if there was an error while creating any of the servers.
+#[tracing::instrument]
 pub async fn create_verifiers_and_operators(
     config_name: &str,
     // rpc: ExtendedRpc<R>,

--- a/core/src/traits/rpc.rs
+++ b/core/src/traits/rpc.rs
@@ -8,11 +8,12 @@ use secp256k1::schnorr;
 
 #[rpc(client, server, namespace = "verifier")]
 pub trait VerifierRpc {
-    #[method(name = "new_deposit")]
     /// - Check deposit UTXO,
     /// - Generate random pubNonces, secNonces
     /// - Save pubNonces and secNonces to a in-memory db
     /// - Return pubNonces
+    #[tracing::instrument(skip(self))]
+    #[method(name = "new_deposit")]
     async fn verifier_new_deposit_rpc(
         &self,
         deposit_outpoint: OutPoint,
@@ -20,10 +21,11 @@ pub trait VerifierRpc {
         evm_address: EVMAddress,
     ) -> Result<Vec<MuSigPubNonce>, BridgeError>;
 
-    #[method(name = "operator_kickoffs_generated")]
     /// - Check the kickoff_utxos
     /// - for every kickoff_utxo, calculate kickoff2_tx
     /// - for every kickoff2_tx, partial sign burn_tx (ommitted for now)
+    #[tracing::instrument(skip(self))]
+    #[method(name = "operator_kickoffs_generated")]
     async fn operator_kickoffs_generated_rpc(
         &self,
         deposit_outpoint: OutPoint,
@@ -32,9 +34,10 @@ pub trait VerifierRpc {
         agg_nonces: Vec<MuSigAggNonce>,
     ) -> Result<(Vec<MuSigPartialSignature>, Vec<MuSigPartialSignature>), BridgeError>;
 
-    #[method(name = "burn_txs_signed")]
     /// verify burn txs are signed by verifiers
     /// sign operator_takes_txs
+    #[tracing::instrument(skip(self))]
+    #[method(name = "burn_txs_signed")]
     async fn burn_txs_signed_rpc(
         &self,
         deposit_outpoint: OutPoint,
@@ -43,6 +46,7 @@ pub trait VerifierRpc {
     ) -> Result<Vec<MuSigPartialSignature>, BridgeError>;
 
     // operator_take_txs_signed
+    #[tracing::instrument(skip(self))]
     #[method(name = "operator_take_txs_signed")]
     /// verify the operator_take_sigs
     /// sign move_tx
@@ -57,6 +61,7 @@ pub trait VerifierRpc {
 pub trait OperatorRpc {
     #[method(name = "new_deposit")]
     /// - Create kickoffUTXO, make sure to not send it to bitcoin yet
+    #[tracing::instrument(skip(self))]
     async fn new_deposit_rpc(
         &self,
         deposit_outpoint: OutPoint,
@@ -64,14 +69,16 @@ pub trait OperatorRpc {
         evm_address: EVMAddress,
     ) -> Result<(UTXO, secp256k1::schnorr::Signature), BridgeError>;
 
+    #[tracing::instrument(skip(self))]
     #[method(name = "set_funding_utxo")]
     async fn set_funding_utxo_rpc(&self, funding_utxo: UTXO) -> Result<(), BridgeError>;
 
-    #[method(name = "new_withdrawal_sig")]
     /// Gets the withdrawal utxo from citrea,
     /// checks wheter sig is for a correct withdrawal from citrea,
     /// checks the signature, calls is_profitable, if is profitable pays the withdrawal,
     /// adds it to flow, when its finalized, proves on citrea, sends kickoff2
+    #[tracing::instrument(skip(self))]
+    #[method(name = "new_withdrawal_sig")]
     async fn new_withdrawal_sig_rpc(
         &self,
         withdrawal_idx: usize,
@@ -80,10 +87,11 @@ pub trait OperatorRpc {
         output_txout: TxOut,
     ) -> Result<Option<Txid>, BridgeError>;
 
-    #[method(name = "withdrawal_proved_on_citrea")]
     /// 1- Calculate move_txid, check if the withdrawal idx matches the move_txid
     /// 2- Check if it is really proved on citrea
     /// 3- If it is, send operator_take_txs
+    #[tracing::instrument(skip(self))]
+    #[method(name = "withdrawal_proved_on_citrea")]
     async fn withdrawal_proved_on_citrea_rpc(
         &self,
         withdrawal_idx: usize,
@@ -96,12 +104,14 @@ pub trait OperatorRpc {
 
 #[rpc(client, server, namespace = "aggregator")]
 pub trait Aggregator {
+    #[tracing::instrument(skip(self))]
     #[method(name = "aggregate_pub_nonces")]
     async fn aggregate_pub_nonces_rpc(
         &self,
         pub_nonces: Vec<Vec<MuSigPubNonce>>,
     ) -> Result<Vec<MuSigAggNonce>, BridgeError>;
 
+    #[tracing::instrument(skip(self))]
     #[method(name = "aggregate_slash_or_take_sigs")]
     async fn aggregate_slash_or_take_sigs_rpc(
         &self,
@@ -111,6 +121,7 @@ pub trait Aggregator {
         partial_sigs: Vec<Vec<MuSigPartialSignature>>,
     ) -> Result<Vec<schnorr::Signature>, BridgeError>;
 
+    #[tracing::instrument(skip(self))]
     #[method(name = "aggregate_operator_take_sigs")]
     async fn aggregate_operator_take_sigs_rpc(
         &self,
@@ -120,6 +131,7 @@ pub trait Aggregator {
         partial_sigs: Vec<Vec<MuSigPartialSignature>>,
     ) -> Result<Vec<schnorr::Signature>, BridgeError>;
 
+    #[tracing::instrument(skip(self))]
     #[method(name = "aggregate_move_tx_sigs")]
     async fn aggregate_move_tx_sigs_rpc(
         &self,

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -27,6 +27,7 @@ where
     R: RpcApiWrapper,
 {
     /// Creates a new `User`.
+    #[tracing::instrument]
     pub fn new(rpc: ExtendedRpc<R>, sk: SecretKey, config: BridgeConfig) -> Self {
         let signer = Actor::new(sk, config.network);
 
@@ -44,6 +45,7 @@ where
         }
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn deposit_tx(
         &self,
         evm_address: EVMAddress,
@@ -64,6 +66,7 @@ where
         Ok((deposit_outpoint, self.signer.xonly_public_key, evm_address))
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn get_deposit_address(&self, evm_address: EVMAddress) -> Result<Address, BridgeError> {
         let (deposit_address, _) = TransactionBuilder::generate_deposit_address(
             &self.nofn_xonly_pk,
@@ -77,6 +80,7 @@ where
         Ok(deposit_address)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn generate_withdrawal_sig(
         &self,
         withdrawal_address: Address,

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -543,6 +543,7 @@ impl<R> VerifierRpcServer for Verifier<R>
 where
     R: RpcApiWrapper,
 {
+    #[tracing::instrument(skip(self))]
     async fn verifier_new_deposit_rpc(
         &self,
         deposit_outpoint: OutPoint,
@@ -553,6 +554,7 @@ where
             .await
     }
 
+    #[tracing::instrument(skip(self))]
     async fn operator_kickoffs_generated_rpc(
         &self,
         deposit_outpoint: OutPoint,
@@ -569,6 +571,7 @@ where
         .await
     }
 
+    #[tracing::instrument(skip(self))]
     async fn burn_txs_signed_rpc(
         &self,
         deposit_outpoint: OutPoint,
@@ -579,6 +582,7 @@ where
             .await
     }
 
+    #[tracing::instrument(skip(self))]
     async fn operator_take_txs_signed_rpc(
         &self,
         deposit_outpoint: OutPoint,


### PR DESCRIPTION
# Description

This PR adds `#[tracing::instrument]` tag to some core functions. Aims to provide context to debug information.

Old log example:

```bash
2024-09-06T14:59:51.593660Z TRACE bitcoincore_rpc: JSON-RPC response for sendrawtransaction: "8fdeea20c10c134b1be2e87548dadefb5e558e3eda787935627b5430dec93c60"
```

New log example:

```bash
2024-09-06T14:57:45.870395Z TRACE send_to_address{address=bcrt1plr5908qjdayaa5ehcxwy7hcur9glqafpvtt2v8c2nc24s4v5899s50wnte amount_sats=10000000}: bitcoincore_rpc: JSON-RPC response for sendtoaddress: "42bd0cbe5ea480e70cf834cf57c9d65063769d33caf978c3cbadaec575e52ce4"    
```