### PR TITLE
Add logs all over the place

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -25,12 +25,6 @@ impl Actor {
         let keypair = Keypair::from_secret_key(&utils::SECP, &sk);
         let (xonly, _parity) = XOnlyPublicKey::from_keypair(&keypair);
         let address = Address::p2tr(&utils::SECP, xonly, None, network);
-        tracing::trace!(
-            "Creating a new actor with keypair {:?}, x-only public key {:?} and address {:?}",
-            keypair,
-            xonly,
-            address
-        );
 
         Actor {
             keypair,
@@ -87,7 +81,6 @@ impl Actor {
             TapLeafHash::from_script(spend_script, LeafVersion::TapScript),
             bitcoin::sighash::TapSighashType::Default,
         )?;
-        tracing::trace!("Signature hash is {:?}", sig_hash);
 
         Ok(self.sign(sig_hash))
     }

--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -32,6 +32,7 @@ pub struct Aggregator {
 }
 
 impl Aggregator {
+    #[tracing::instrument(err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn new(config: BridgeConfig) -> Result<Self, BridgeError> {
         let nofn_xonly_pk = secp256k1::XOnlyPublicKey::from_musig2_pks(
             config.verifiers_public_keys.clone(),
@@ -45,6 +46,7 @@ impl Aggregator {
         })
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     fn aggregate_slash_or_take_partial_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -90,6 +92,7 @@ impl Aggregator {
         Ok(final_sig)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     fn aggregate_operator_takes_partial_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -172,6 +175,7 @@ impl Aggregator {
         Ok(final_sig)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     fn aggregate_move_partial_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -205,6 +209,7 @@ impl Aggregator {
         Ok(final_sig)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn aggregate_pub_nonces(
         &self,
         pub_nonces: Vec<Vec<MuSigPubNonce>>,
@@ -223,6 +228,7 @@ impl Aggregator {
         Ok(agg_nonces)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn aggregate_slash_or_take_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -260,6 +266,7 @@ impl Aggregator {
         Ok(slash_or_take_sigs)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn aggregate_operator_take_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -283,6 +290,7 @@ impl Aggregator {
         Ok(operator_take_sigs)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn aggregate_move_tx_sigs(
         &self,
         deposit_outpoint: OutPoint,

--- a/core/src/database/common.rs
+++ b/core/src/database/common.rs
@@ -130,6 +130,7 @@ impl Database {
         }
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn lock_operators_kickoff_utxo_table(
         &self,
         tx: &mut sqlx::Transaction<'_, Postgres>,
@@ -140,6 +141,7 @@ impl Database {
         Ok(())
     }
 
+    // #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     // pub async fn unlock_operators_kickoff_utxo_table(
     //     &self,
     //     tx: &mut sqlx::Transaction<'_, Postgres>,
@@ -151,6 +153,7 @@ impl Database {
     // }
 
     /// Operator: If operator already created a kickoff UTXO for this deposit UTXO, return it.
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn get_kickoff_utxo(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -177,6 +180,7 @@ impl Database {
     }
 
     /// Operator: Get unused kickoff_utxo at ready if there are any.
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn get_unused_kickoff_utxo_and_increase_idx(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -231,6 +235,7 @@ impl Database {
     }
 
     /// Operator: Gets the funding UTXO for kickoffs
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn get_funding_utxo(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -254,6 +259,7 @@ impl Database {
     }
 
     /// Operator: Sets the funding UTXO for kickoffs
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn set_funding_utxo(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -275,6 +281,7 @@ impl Database {
     }
 
     /// Operator: Save the kickoff UTXO for this deposit UTXO.
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn save_kickoff_utxo(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -301,6 +308,7 @@ impl Database {
     /// Operator: Save the signed kickoff UTXO generator tx.
     ///  Txid is the txid of the signed tx.
     /// funding_txid is the txid of the input[0].
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn add_deposit_kickoff_generator_tx(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -325,6 +333,7 @@ impl Database {
     }
 
     /// Verifier: Get the verified kickoff UTXOs for a deposit UTXO.
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn get_kickoff_utxos(
         &self,
         deposit_outpoint: OutPoint,
@@ -350,6 +359,7 @@ impl Database {
     }
 
     /// Verifier: Save the kickoff UTXOs for this deposit UTXO.
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn save_kickoff_utxos(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -389,6 +399,7 @@ impl Database {
     }
 
     /// Verifier: Get the public nonces for a deposit UTXO.
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn get_pub_nonces(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -412,6 +423,7 @@ impl Database {
     }
 
     /// Verifier: save the generated sec nonce and pub nonces
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn save_nonces(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -443,6 +455,7 @@ impl Database {
     }
 
     /// Verifier: Save the deposit info to use later
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn save_deposit_info(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -464,6 +477,7 @@ impl Database {
     }
 
     /// Verifier: Get the deposit info to use later
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn get_deposit_info(
         &self,
         deposit_outpoint: OutPoint,
@@ -477,6 +491,7 @@ impl Database {
     }
 
     /// Verifier: saves the sighash and returns sec and agg nonces, if the sighash is already there and different, returns error
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn save_sighashes_and_get_nonces(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -522,6 +537,7 @@ impl Database {
     }
 
     /// Verifier: Save the agg nonces for signing
+    #[tracing::instrument(skip(self, agg_nonces), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn save_agg_nonces(
         &self,
         tx: Option<&mut sqlx::Transaction<'_, Postgres>>,
@@ -556,6 +572,7 @@ impl Database {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, slash_or_take_sigs), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn save_slash_or_take_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -587,6 +604,7 @@ impl Database {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn get_slash_or_take_sig(
         &self,
         deposit_outpoint: OutPoint,
@@ -611,6 +629,7 @@ impl Database {
         }
     }
 
+    #[tracing::instrument(skip(self, kickoff_utxos_and_sigs), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn save_operator_take_sigs(
         &self,
         deposit_outpoint: OutPoint,
@@ -645,6 +664,7 @@ impl Database {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn get_operator_take_sig(
         &self,
         deposit_outpoint: OutPoint,
@@ -669,6 +689,7 @@ impl Database {
         }
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn get_deposit_kickoff_generator_tx(
         &self,
         txid: Txid,

--- a/core/src/extended_rpc.rs
+++ b/core/src/extended_rpc.rs
@@ -49,6 +49,7 @@ where
         }
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn confirmation_blocks(&self, txid: &bitcoin::Txid) -> Result<u32, BridgeError> {
         let raw_transaction_results = self.client.get_raw_transaction_info(txid, None)?;
 
@@ -57,6 +58,7 @@ where
             .ok_or(BridgeError::NoConfirmationData)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn check_utxo_address_and_amount(
         &self,
         outpoint: &OutPoint,
@@ -75,6 +77,7 @@ where
         Ok(expected_output == current_output)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn is_utxo_spent(&self, outpoint: &OutPoint) -> Result<bool, BridgeError> {
         let res = self
             .client
@@ -83,6 +86,7 @@ where
         Ok(res.is_none())
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn generate_dummy_block(&self) -> Result<Vec<bitcoin::BlockHash>, BridgeError> {
         let address = self.client.get_new_address(None, None)?.assume_checked();
 
@@ -104,6 +108,7 @@ where
         Ok(self.client.generate_to_address(1, &address)?)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn mine_blocks(&self, block_num: u64) -> Result<(), BridgeError> {
         let new_address = self.client.get_new_address(None, None)?.assume_checked();
 
@@ -112,6 +117,7 @@ where
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn send_to_address(
         &self,
         address: &Address,
@@ -134,6 +140,7 @@ where
         Ok(OutPoint { txid, vout })
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_work_at_block(&self, blockheight: u64) -> Result<Work, BridgeError> {
         let block_hash = self.get_block_hash(blockheight)?;
         let block = self.client.get_block(&block_hash)?;
@@ -142,6 +149,7 @@ where
         Ok(work)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_block_hash(
         &self,
         blockheight: u64,
@@ -151,6 +159,7 @@ where
         Ok(block_hash)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_block_header(
         &self,
         block_hash: &bitcoin::BlockHash,
@@ -160,6 +169,7 @@ where
         Ok(block_header)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn calculate_total_work_between_blocks(
         &self,
         start: u64,
@@ -179,6 +189,7 @@ where
         Ok(U256::from_be_bytes(work_bytes))
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_total_work_as_u256(&self) -> Result<U256, BridgeError> {
         let chain_info = self.client.get_blockchain_info()?;
         let total_work_bytes = chain_info.chain_work;
@@ -187,6 +198,7 @@ where
         Ok(total_work)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_total_work(&self) -> Result<Work, BridgeError> {
         let chain_info = self.client.get_blockchain_info()?;
         let total_work_bytes = chain_info.chain_work;
@@ -195,6 +207,7 @@ where
         Ok(total_work)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_block_height(&self) -> Result<u64, BridgeError> {
         let chain_info = self.client.get_blockchain_info()?;
         let block_height = chain_info.blocks;
@@ -202,6 +215,7 @@ where
         Ok(block_height)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_txout_from_outpoint(&self, outpoint: &OutPoint) -> Result<TxOut, BridgeError> {
         let tx = self.client.get_raw_transaction(&outpoint.txid, None)?;
         let txout = tx.output[outpoint.vout as usize].clone();
@@ -210,6 +224,7 @@ where
     }
 
     // Following methods are just wrappers around the bitcoincore_rpc::Client methods
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn fund_raw_transaction(
         &self,
         tx: &Transaction,
@@ -219,6 +234,7 @@ where
         self.client.fund_raw_transaction(tx, options, is_witness)
     }
 
+    #[tracing::instrument(skip(self, tx, sighash_type), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn sign_raw_transaction_with_wallet<T: bitcoincore_rpc::RawTx>(
         &self,
         tx: T,
@@ -229,20 +245,24 @@ where
             .sign_raw_transaction_with_wallet(tx, utxos, sighash_type)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_blockchain_info(
         &self,
     ) -> Result<bitcoincore_rpc::json::GetBlockchainInfoResult, bitcoincore_rpc::Error> {
         self.client.get_blockchain_info()
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_block_count(&self) -> Result<u64, bitcoincore_rpc::Error> {
         self.client.get_block_count()
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_best_block_hash(&self) -> Result<bitcoin::BlockHash, bitcoincore_rpc::Error> {
         self.client.get_best_block_hash()
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_raw_transaction(
         &self,
         txid: &bitcoin::Txid,
@@ -251,6 +271,7 @@ where
         self.client.get_raw_transaction(txid, block_hash)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_transaction(
         &self,
         txid: &bitcoin::Txid,
@@ -259,6 +280,7 @@ where
         self.client.get_transaction(txid, include_watchonly)
     }
 
+    #[tracing::instrument(skip(self, tx), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn send_raw_transaction<T: bitcoincore_rpc::RawTx>(
         &self,
         tx: T,
@@ -266,12 +288,14 @@ where
         self.client.send_raw_transaction(tx)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_block(
         &self,
         block_hash: &bitcoin::BlockHash,
     ) -> Result<bitcoin::Block, bitcoincore_rpc::Error> {
         self.client.get_block(block_hash)
     }
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_raw_transaction_info(
         &self,
         txid: &bitcoin::Txid,
@@ -280,6 +304,7 @@ where
         self.client.get_raw_transaction_info(txid, block_hash)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn check_deposit_utxo(
         &self,
         nofn_xonly_pk: &XOnlyPublicKey,
@@ -320,6 +345,7 @@ where
     }
 
     /// Generates bitcoins to specified address.
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn generate_to_address(
         &self,
         block_num: u64,
@@ -331,6 +357,7 @@ where
     }
 
     /// Requests a new Bitcoin address via an RPC call.
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_new_address(&self) -> Result<Address, BridgeError> {
         let address = self
             .client

--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -29,6 +29,7 @@ pub trait AggregateFromPublicKeys {
 }
 
 impl AggregateFromPublicKeys for secp256k1::XOnlyPublicKey {
+    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
     fn from_musig2_pks(
         pks: Vec<PublicKey>,
         tweak: Option<TapNodeHash>,
@@ -48,6 +49,7 @@ impl AggregateFromPublicKeys for secp256k1::XOnlyPublicKey {
 
 // Creates the key aggregation context, with the public keys and the tweak (if any).
 // There are two functions to retrieve the aggregated public key, one with the tweak and one without.
+#[tracing::instrument(err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
 pub fn create_key_agg_ctx(
     pks: Vec<PublicKey>,
     tweak: Option<TapNodeHash>,
@@ -81,6 +83,7 @@ pub fn create_key_agg_ctx(
 }
 
 // Aggregates the public nonces into a single aggregated nonce. Wrapper for the musig2::AggNonce::sum function.
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
 pub fn aggregate_nonces(pub_nonces: Vec<MuSigPubNonce>) -> MuSigAggNonce {
     let musig_pub_nonces: Vec<musig2::PubNonce> = pub_nonces
         .iter()
@@ -91,6 +94,7 @@ pub fn aggregate_nonces(pub_nonces: Vec<MuSigPubNonce>) -> MuSigAggNonce {
 }
 
 // Aggregates the partial signatures into a single final signature. Wrapper for the musig2::aggregate_partial_signatures function.
+#[tracing::instrument(err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
 pub fn aggregate_partial_signatures(
     pks: Vec<PublicKey>,
     tweak: Option<TapNodeHash>,
@@ -115,6 +119,7 @@ pub fn aggregate_partial_signatures(
 // Generates a pair of nonces, one secret and one public. Wrapper for the musig2::SecNonce::build function. Be careful,
 // DO NOT REUSE the same pair of nonces for multiple transactions. It will cause you to leak your secret key. For more information,
 // see https://medium.com/blockstream/musig-dn-schnorr-multisignatures-with-verifiably-deterministic-nonces-27424b5df9d6#e3b6.
+#[tracing::instrument(skip(rng), ret(level = tracing::Level::TRACE))]
 pub fn nonce_pair(
     keypair: &secp256k1::Keypair,
     rng: &mut impl Rng,
@@ -138,6 +143,7 @@ pub fn nonce_pair(
 }
 
 // We are creating the key aggregation context manually here, adding the tweaks by hand.
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
 pub fn partial_sign(
     pks: Vec<PublicKey>,
     // Aggregated tweak, if there is any. This is useful for

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -42,6 +42,7 @@ where
     R: RpcApiWrapper,
 {
     /// Creates a new `Operator`.
+    #[tracing::instrument(skip_all, err(level = tracing::Level::ERROR))]
     pub async fn new(config: BridgeConfig, rpc: ExtendedRpc<R>) -> Result<Self, BridgeError> {
         // let num_verifiers = config.verifiers_public_keys.len();
 
@@ -112,6 +113,7 @@ where
     /// 3. Create a kickoff transaction but do not broadcast it
     ///
     /// TODO: Create multiple kickoffs in single transaction
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub async fn new_deposit(
         &self,
         deposit_outpoint: OutPoint,
@@ -323,11 +325,13 @@ where
 
     /// Checks if utxo is valid, spendable by operator and not spent
     /// Saves the utxo to the db
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     async fn set_funding_utxo(&self, funding_utxo: UTXO) -> Result<(), BridgeError> {
         self.db.set_funding_utxo(None, funding_utxo).await?;
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     async fn is_profitable(
         &self,
         input_amount: u64,
@@ -343,6 +347,7 @@ where
         }
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     async fn new_withdrawal_sig(
         &self,
         withdrawal_idx: u32,
@@ -437,6 +442,7 @@ where
         Ok(final_txid)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     async fn withdrawal_proved_on_citrea(
         &self,
         withdrawal_idx: u32,

--- a/core/src/script_builder.rs
+++ b/core/src/script_builder.rs
@@ -13,6 +13,7 @@ use bitcoin::{
 };
 use secp256k1::XOnlyPublicKey;
 
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
 pub fn anyone_can_spend_txout() -> TxOut {
     let script = Builder::new().push_opcode(OP_PUSHNUM_1).into_script();
     let script_pubkey = script.to_p2wsh();
@@ -24,6 +25,7 @@ pub fn anyone_can_spend_txout() -> TxOut {
     }
 }
 
+#[tracing::instrument(skip_all, ret(level = tracing::Level::TRACE))]
 pub fn op_return_txout<S: AsRef<bitcoin::script::PushBytes>>(slice: S) -> TxOut {
     let script = Builder::new()
         .push_opcode(OP_RETURN)
@@ -36,6 +38,7 @@ pub fn op_return_txout<S: AsRef<bitcoin::script::PushBytes>>(slice: S) -> TxOut 
     }
 }
 
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
 pub fn create_deposit_script(
     nofn_xonly_pk: &XOnlyPublicKey,
     evm_address: &EVMAddress,
@@ -55,6 +58,7 @@ pub fn create_deposit_script(
         .into_script()
 }
 
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
 pub fn create_musig2_and_operator_multisig_script(
     nofn_xonly_pk: &XOnlyPublicKey,
     operator_xonly_pk: &XOnlyPublicKey,
@@ -70,6 +74,7 @@ pub fn create_musig2_and_operator_multisig_script(
 /// ATTENTION: If you want to spend a UTXO using timelock script, the
 /// condition is that (`# in the script`) < (`# in the sequence of the tx`)
 /// < (`# of blocks mined after UTXO`) appears on the chain.
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
 pub fn generate_relative_timelock_script(
     actor_taproot_xonly_pk: &XOnlyPublicKey, // This is the tweaked XonlyPublicKey, which appears in the script_pubkey of the address
     block_count: u32,
@@ -83,6 +88,7 @@ pub fn generate_relative_timelock_script(
         .into_script()
 }
 
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
 pub fn generate_absolute_timelock_script(actor_pk: &XOnlyPublicKey, block_count: u32) -> ScriptBuf {
     Builder::new()
         .push_int(block_count as i64)
@@ -93,6 +99,7 @@ pub fn generate_absolute_timelock_script(actor_pk: &XOnlyPublicKey, block_count:
         .into_script()
 }
 
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
 pub fn generate_hash_script(hash: [u8; 32]) -> ScriptBuf {
     Builder::new()
         .push_opcode(OP_SHA256)
@@ -101,6 +108,7 @@ pub fn generate_hash_script(hash: [u8; 32]) -> ScriptBuf {
         .into_script()
 }
 
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
 pub fn generate_dust_script(evm_address: &EVMAddress) -> ScriptBuf {
     Builder::new()
         .push_opcode(OP_RETURN)

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -125,6 +125,7 @@ fn is_test_env() -> bool {
 ///
 /// Panics if there was an error while creating any of the servers.
 #[tracing::instrument(ret(level = tracing::Level::TRACE))]
+#[allow(clippy::type_complexity)] // Enabling tracing::instrument causes this.
 pub async fn create_verifiers_and_operators(
     config_name: &str,
     // rpc: ExtendedRpc<R>,

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -23,6 +23,7 @@ use std::thread;
 use traits::rpc::OperatorRpcServer;
 
 /// Starts a server for a verifier.
+#[tracing::instrument(skip(rpc), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
 pub async fn create_verifier_server<R>(
     config: BridgeConfig,
     rpc: ExtendedRpc<R>,
@@ -51,6 +52,7 @@ where
 }
 
 /// Starts the server for the operator.
+#[tracing::instrument(skip(rpc), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
 pub async fn create_operator_server<R>(
     config: BridgeConfig,
     rpc: ExtendedRpc<R>,
@@ -80,6 +82,7 @@ where
 }
 
 /// Starts the server for the aggregator.
+#[tracing::instrument(err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
 pub async fn create_aggregator_server(
     config: BridgeConfig,
 ) -> Result<(HttpClient, ServerHandle, std::net::SocketAddr), BridgeError> {
@@ -104,6 +107,7 @@ pub async fn create_aggregator_server(
     Ok((client, handle, addr))
 }
 
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
 fn is_test_env() -> bool {
     // if thread name is not main then it is a test
     thread::current().name().unwrap_or_default() != "main"
@@ -120,6 +124,7 @@ fn is_test_env() -> bool {
 /// # Panics
 ///
 /// Panics if there was an error while creating any of the servers.
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
 pub async fn create_verifiers_and_operators(
     config_name: &str,
     // rpc: ExtendedRpc<R>,

--- a/core/src/transaction_builder.rs
+++ b/core/src/transaction_builder.rs
@@ -52,6 +52,7 @@ impl TransactionBuilder {
 
     // ADDRESS BUILDERS
 
+    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
     pub fn create_taproot_address(
         scripts: &[ScriptBuf],
         internal_key: Option<XOnlyPublicKey>,
@@ -98,6 +99,7 @@ impl TransactionBuilder {
 
     /// Generates a deposit address for the user. N-of-N or user takes after
     /// timelock script can be used to spend the funds.
+    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
     pub fn generate_deposit_address(
         nofn_xonly_pk: &XOnlyPublicKey,
         recovery_taproot_address: &Address<NetworkUnchecked>,
@@ -128,6 +130,7 @@ impl TransactionBuilder {
         )
     }
 
+    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
     pub fn create_musig2_address(
         nofn_xonly_pk: XOnlyPublicKey,
         network: bitcoin::Network,
@@ -135,6 +138,7 @@ impl TransactionBuilder {
         TransactionBuilder::create_taproot_address(&[], Some(nofn_xonly_pk), network)
     }
 
+    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
     pub fn create_kickoff_address(
         nofn_xonly_pk: &XOnlyPublicKey,
         operator_xonly_pk: &XOnlyPublicKey,
@@ -150,6 +154,7 @@ impl TransactionBuilder {
     // TX BUILDERS
 
     /// Creates the move_tx to move the deposit.
+    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
     pub fn create_move_tx(
         deposit_outpoint: OutPoint,
         evm_address: &EVMAddress,
@@ -197,6 +202,7 @@ impl TransactionBuilder {
     }
 
     /// Creates the kickoff_tx for the operator. It also returns the change utxo
+    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
     pub fn create_kickoff_utxo_tx(
         funding_utxo: &UTXO, // Make sure this comes from the operator's address.
         nofn_xonly_pk: &XOnlyPublicKey,
@@ -259,6 +265,7 @@ impl TransactionBuilder {
         }
     }
 
+    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
     pub fn create_slash_or_take_tx(
         deposit_outpoint: OutPoint,
         kickoff_utxo: UTXO,
@@ -350,6 +357,7 @@ impl TransactionBuilder {
         }
     }
 
+    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
     pub fn create_operator_takes_tx(
         bridge_fund_outpoint: OutPoint,
         slash_or_take_utxo: UTXO,

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -44,6 +44,7 @@ where
         }
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn deposit_tx(
         &self,
         evm_address: EVMAddress,
@@ -64,6 +65,7 @@ where
         Ok((deposit_outpoint, self.signer.xonly_public_key, evm_address))
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn get_deposit_address(&self, evm_address: EVMAddress) -> Result<Address, BridgeError> {
         let (deposit_address, _) = TransactionBuilder::generate_deposit_address(
             &self.nofn_xonly_pk,
@@ -77,6 +79,7 @@ where
         Ok(deposit_address)
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn generate_withdrawal_sig(
         &self,
         withdrawal_address: Address,

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -72,6 +72,7 @@ where
     /// 2. Generate random pubNonces, secNonces
     /// 3. Save pubNonces and secNonces to a db
     /// 4. Return pubNonces
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     async fn new_deposit(
         &self,
         deposit_outpoint: OutPoint,
@@ -143,6 +144,7 @@ where
     ///
     /// do not forget to add tweak when signing since this address has n_of_n as internal_key
     /// and operator_timelock as script.
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     async fn operator_kickoffs_generated(
         &self,
         deposit_outpoint: OutPoint,
@@ -270,6 +272,7 @@ where
         Ok((slash_or_take_partial_sigs, vec![]))
     }
 
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     async fn create_deposit_details(
         &self,
         deposit_outpoint: OutPoint,
@@ -311,6 +314,7 @@ where
     /// verify burn txs are signed by verifiers
     /// sign operator_takes_txs
     /// TODO: Change the name of this function.
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     async fn burn_txs_signed(
         &self,
         deposit_outpoint: OutPoint,
@@ -407,6 +411,7 @@ where
 
     /// verify the operator_take_sigs
     /// sign move_tx
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     async fn operator_take_txs_signed(
         &self,
         deposit_outpoint: OutPoint,


### PR DESCRIPTION
# Description

This PR adds log statements, all over the place. For debugging purposes.

For the places `#[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]` is used for a function, it should be excepted to see a log containing arguments and return value of that function after the function is returned:

```bash
2024-09-10T13:42:53.248374Z TRACE sign_taproot_script_spend_tx_new_tweaked{tx_handler=TxHandler { tx: Transaction { version: Version(2), lock_time: 0 blocks, input: [TxIn { previous_output: OutPoint { txid: 49d799e7cb2fa5c20ed92340864ab189e683e04f95bf3d6290f471f9b31960f3, vout: 0 }, script_sig: Script(), sequence: Sequence(0xfffffffd), witness: Witness: { indices: 0, indices_start: 0, witnesses: [] } }], output: [TxOut { value: 330 SAT, script_pubkey: Script(OP_PUSHNUM_1 OP_PUSHBYTES_32 70fe0a680d3ab666f78aa0bfaf2ad9f45d4682ddb96cf5e57efff281e935b7b5) }] }, prevouts: [TxOut { value: 1000 SAT, script_pubkey: Script(OP_PUSHNUM_1 OP_PUSHBYTES_32 70fe0a680d3ab666f78aa0bfaf2ad9f45d4682ddb96cf5e57efff281e935b7b5) }], scripts: [[Script(OP_PUSHBYTES_32 f8e8579c126f49ded337c19c4f5f1c1951f0752162d6a61f0a9e15585594394b OP_CHECKSIG)]], taproot_spend_infos: [TaprootSpendInfo { internal_key: XOnlyPublicKey(51def5d05ddd28061f3dd004f860cee7baf4c8f7c4218844758a51968d37c793280f903bc47f922b1c4d4fdcb73801679003a5ac7112f6374c8b41f58d48e6b7), merkle_root: Some(753b565398b9da7f6e325091c453fddcd4bf79f48b481f4557d8a211ce823e02), output_key_parity: Even, output_key: TweakedPublicKey(XOnlyPublicKey(b5b735e981f2ff7ee5f56cb9dd82465df4d92aafbfa08af766b63a0d680afe70bcba5b825134439cee018f146dbb59589ba1c6ecff966284167a9283ae612bae)), script_map: {(Script(OP_PUSHBYTES_32 f8e8579c126f49ded337c19c4f5f1c1951f0752162d6a61f0a9e15585594394b OP_CHECKSIG), TapScript): {TaprootMerkleBranch([])}} }] } txin_index=0 script_index=0}:sign_with_tweak{sighash=168d96a499e0ae147f4a50b09ab184c94288125b368d29462060a841f5bff900 merkle_root=None}: clementine_core::actor: return=Signature(52906a0af00a2ff9b6cc83ea4ca9f99366f407d8658025f1647c53451a36c65d5def44fcdc2227134ddbdddc1871c8215acdc29ffeb0d73a28419ef324175c8f)
```