### PR TITLE
Unit tests for where the code coverage is not present

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -59,7 +59,7 @@ impl Actor {
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn sign_taproot_script_spend_tx_new(
+    pub fn sign_taproot_script_spend_tx(
         &self,
         tx: &mut TxHandler,
         txin_index: usize,

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -5,7 +5,7 @@ use bitcoin::sighash::SighashCache;
 use bitcoin::taproot::LeafVersion;
 use bitcoin::{
     hashes::Hash,
-    secp256k1::{ecdsa, schnorr, Keypair, Message, SecretKey, XOnlyPublicKey},
+    secp256k1::{schnorr, Keypair, Message, SecretKey, XOnlyPublicKey},
     Address, TapSighash, TapTweakHash,
 };
 use bitcoin::{TapLeafHash, TapNodeHash, TapSighashType, TxOut};
@@ -13,7 +13,7 @@ use bitcoin::{TapLeafHash, TapNodeHash, TapSighashType, TxOut};
 #[derive(Debug, Clone)]
 pub struct Actor {
     pub keypair: Keypair,
-    secret_key: SecretKey,
+    _secret_key: SecretKey,
     pub xonly_public_key: XOnlyPublicKey,
     pub public_key: secp256k1::PublicKey,
     pub address: Address,
@@ -28,7 +28,7 @@ impl Actor {
 
         Actor {
             keypair,
-            secret_key: keypair.secret_key(),
+            _secret_key: keypair.secret_key(),
             xonly_public_key: xonly,
             public_key: keypair.public_key(),
             address,
@@ -58,54 +58,6 @@ impl Actor {
         )
     }
 
-    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
-    pub fn sign_ecdsa(&self, data: [u8; 32]) -> ecdsa::Signature {
-        utils::SECP.sign_ecdsa(
-            &Message::from_digest_slice(&data).expect("should be hash"),
-            &self.secret_key,
-        )
-    }
-
-    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn sign_taproot_script_spend_tx(
-        &self,
-        tx: &mut bitcoin::Transaction,
-        prevouts: &[TxOut],
-        spend_script: &bitcoin::Script,
-        input_index: usize,
-    ) -> Result<schnorr::Signature, BridgeError> {
-        let mut sighash_cache = SighashCache::new(tx);
-        let sig_hash = sighash_cache.taproot_script_spend_signature_hash(
-            input_index,
-            &bitcoin::sighash::Prevouts::All(prevouts),
-            TapLeafHash::from_script(spend_script, LeafVersion::TapScript),
-            bitcoin::sighash::TapSighashType::Default,
-        )?;
-
-        Ok(self.sign(sig_hash))
-    }
-
-    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn sighash_taproot_script_spend(
-        &self,
-        tx: &mut TxHandler,
-        txin_index: usize,
-        script_index: usize,
-    ) -> Result<TapSighash, BridgeError> {
-        let mut sighash_cache: SighashCache<&mut bitcoin::Transaction> =
-            SighashCache::new(&mut tx.tx);
-        let sig_hash = sighash_cache.taproot_script_spend_signature_hash(
-            txin_index,
-            &bitcoin::sighash::Prevouts::All(&tx.prevouts),
-            TapLeafHash::from_script(
-                &tx.scripts[txin_index][script_index],
-                LeafVersion::TapScript,
-            ),
-            bitcoin::sighash::TapSighashType::Default,
-        )?;
-        Ok(sig_hash)
-    }
-
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     pub fn sign_taproot_script_spend_tx_new(
         &self,
@@ -115,9 +67,9 @@ impl Actor {
     ) -> Result<schnorr::Signature, BridgeError> {
         // TODO: if sighash_cache exists in the TxHandler, use it
         // else create a new one and save it to the TxHandler
-
         let mut sighash_cache: SighashCache<&mut bitcoin::Transaction> =
             SighashCache::new(&mut tx.tx);
+
         let sig_hash = sighash_cache.taproot_script_spend_signature_hash(
             txin_index,
             &bitcoin::sighash::Prevouts::All(&tx.prevouts),
@@ -127,6 +79,7 @@ impl Actor {
             ),
             bitcoin::sighash::TapSighashType::Default,
         )?;
+
         Ok(self.sign(sig_hash))
     }
 
@@ -138,6 +91,7 @@ impl Actor {
         sighash_type: Option<TapSighashType>,
     ) -> Result<schnorr::Signature, BridgeError> {
         let mut sighash_cache = SighashCache::new(&mut tx_handler.tx);
+
         let sig_hash = sighash_cache.taproot_key_spend_signature_hash(
             input_index,
             &match sighash_type {
@@ -149,6 +103,7 @@ impl Actor {
             },
             sighash_type.unwrap_or(TapSighashType::Default),
         )?;
+
         self.sign_with_tweak(sig_hash, None)
     }
 
@@ -160,11 +115,13 @@ impl Actor {
         input_index: usize,
     ) -> Result<schnorr::Signature, BridgeError> {
         let mut sighash_cache = SighashCache::new(tx);
+
         let sig_hash = sighash_cache.taproot_key_spend_signature_hash(
             input_index,
             &bitcoin::sighash::Prevouts::All(prevouts),
             bitcoin::sighash::TapSighashType::Default,
         )?;
+
         self.sign_with_tweak(sig_hash, None)
     }
 
@@ -177,6 +134,7 @@ impl Actor {
         sighash_type: Option<TapSighashType>,
     ) -> Result<schnorr::Signature, BridgeError> {
         let mut sighash_cache = SighashCache::new(tx);
+
         let sig_hash = sighash_cache.taproot_key_spend_signature_hash(
             input_index,
             &match sighash_type {
@@ -187,6 +145,7 @@ impl Actor {
             },
             sighash_type.unwrap_or(TapSighashType::Default),
         )?;
+
         self.sign_with_tweak(sig_hash, None)
     }
 
@@ -199,9 +158,9 @@ impl Actor {
     ) -> Result<schnorr::Signature, BridgeError> {
         // TODO: if sighash_cache exists in the TxHandler, use it
         // else create a new one and save it to the TxHandler
-
         let mut sighash_cache: SighashCache<&mut bitcoin::Transaction> =
             SighashCache::new(&mut tx_handler.tx);
+
         let sig_hash = sighash_cache.taproot_script_spend_signature_hash(
             txin_index,
             &bitcoin::sighash::Prevouts::All(&tx_handler.prevouts),
@@ -223,6 +182,7 @@ impl Actor {
     ) -> Result<TapSighash, BridgeError> {
         let mut sighash_cache: SighashCache<&mut bitcoin::Transaction> =
             SighashCache::new(&mut tx_handler.tx);
+
         let sig_hash = sighash_cache.taproot_script_spend_signature_hash(
             txin_index,
             &bitcoin::sighash::Prevouts::All(&tx_handler.prevouts),
@@ -232,6 +192,7 @@ impl Actor {
             ),
             bitcoin::sighash::TapSighashType::Default,
         )?;
+
         Ok(sig_hash)
     }
 
@@ -242,11 +203,151 @@ impl Actor {
     ) -> Result<TapSighash, BridgeError> {
         let mut sighash_cache: SighashCache<&mut bitcoin::Transaction> =
             SighashCache::new(&mut tx.tx);
+
         let sig_hash = sighash_cache.taproot_key_spend_signature_hash(
             txin_index,
             &bitcoin::sighash::Prevouts::All(&tx.prevouts),
             bitcoin::sighash::TapSighashType::Default,
         )?;
+
         Ok(sig_hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Actor;
+    use crate::transaction_builder::TxHandler;
+    use bitcoin::{
+        absolute::Height, transaction::Version, Amount, Network, OutPoint, Transaction, TxIn, TxOut,
+    };
+    use secp256k1::{rand, Secp256k1, SecretKey};
+
+    /// Returns a valid [`TxHandler`].
+    fn create_valid_mock_tx_handler(actor: &Actor) -> TxHandler {
+        let mut tx_handler = create_invalid_mock_tx_handler(actor);
+
+        let prev_tx: Transaction = Transaction {
+            version: Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::Blocks(Height::ZERO),
+            input: vec![],
+            output: tx_handler.prevouts.clone(),
+        };
+
+        tx_handler.tx = Transaction {
+            version: prev_tx.version,
+            lock_time: prev_tx.lock_time,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: prev_tx.compute_txid(),
+                    vout: 0,
+                },
+                script_sig: actor.address.script_pubkey(),
+                ..Default::default()
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(0x1F),
+                script_pubkey: actor.address.script_pubkey(),
+            }],
+        };
+
+        tx_handler
+    }
+    /// Returns an invalid [`TxHandler`]. Only the tx part is invalid.
+    fn create_invalid_mock_tx_handler(actor: &Actor) -> TxHandler {
+        let prevouts = vec![TxOut {
+            value: Amount::from_sat(0x45),
+            script_pubkey: actor.address.script_pubkey(),
+        }];
+
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::Blocks(Height::ZERO),
+            input: vec![],
+            output: vec![TxOut {
+                value: Amount::from_sat(0x1F),
+                script_pubkey: actor.address.script_pubkey(),
+            }],
+        };
+
+        let tx_handler = TxHandler {
+            tx,
+            prevouts,
+            scripts: vec![],
+            taproot_spend_infos: vec![],
+        };
+
+        tx_handler
+    }
+
+    #[test]
+    fn actor_new() {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::new(&mut rand::thread_rng());
+        let network = Network::Regtest;
+
+        let actor = Actor::new(sk, network);
+
+        assert_eq!(sk, actor._secret_key);
+        assert_eq!(sk.public_key(&secp), actor.public_key);
+        assert_eq!(sk.x_only_public_key(&secp).0, actor.xonly_public_key);
+    }
+
+    #[test]
+    fn sign_taproot_pubkey_spend() {
+        let sk = SecretKey::new(&mut rand::thread_rng());
+        let network = Network::Regtest;
+        let actor = Actor::new(sk, network);
+
+        // Trying to sign with an invalid transaction will result with an error.
+        let mut tx_handler = create_invalid_mock_tx_handler(&actor);
+        assert!(actor
+            .sign_taproot_pubkey_spend(
+                &mut tx_handler,
+                0,
+                Some(bitcoin::TapSighashType::SinglePlusAnyoneCanPay),
+            )
+            .is_err());
+
+        // This transaction is matching with prevouts. Therefore signing will
+        // be successful.
+        tx_handler = create_valid_mock_tx_handler(&actor);
+        actor
+            .sign_taproot_pubkey_spend(
+                &mut tx_handler,
+                0,
+                Some(bitcoin::TapSighashType::SinglePlusAnyoneCanPay),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn sign_taproot_pubkey_spend_tx_with_sighash() {
+        let sk = SecretKey::new(&mut rand::thread_rng());
+        let network = Network::Regtest;
+        let actor = Actor::new(sk, network);
+
+        // Trying to sign with an invalid transaction will result with an error.
+        let mut tx_handler = create_invalid_mock_tx_handler(&actor);
+        assert!(actor
+            .sign_taproot_pubkey_spend_tx_with_sighash(
+                &mut tx_handler.tx,
+                &tx_handler.prevouts,
+                0,
+                Some(bitcoin::TapSighashType::SinglePlusAnyoneCanPay),
+            )
+            .is_err());
+
+        // This transaction is matching with prevouts. Therefore signing will
+        // be successful.
+        tx_handler = create_valid_mock_tx_handler(&actor);
+        actor
+            .sign_taproot_pubkey_spend_tx_with_sighash(
+                &mut tx_handler.tx,
+                &tx_handler.prevouts,
+                0,
+                Some(bitcoin::TapSighashType::SinglePlusAnyoneCanPay),
+            )
+            .unwrap();
     }
 }

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -270,14 +270,12 @@ mod tests {
             }],
         };
 
-        let tx_handler = TxHandler {
+        TxHandler {
             tx,
             prevouts,
             scripts: vec![],
             taproot_spend_infos: vec![],
-        };
-
-        tx_handler
+        }
     }
 
     #[test]

--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -7,7 +7,7 @@ use crate::{
         MuSigPartialSignature, MuSigPubNonce,
     },
     traits::rpc::AggregatorServer,
-    transaction_builder::TransactionBuilder,
+    transaction_builder,
     utils::{self, handle_taproot_witness_new},
     ByteArray32, ByteArray66, EVMAddress, UTXO,
 };
@@ -56,7 +56,7 @@ impl Aggregator {
         agg_nonce: &MuSigAggNonce,
         partial_sigs: Vec<MuSigPartialSignature>,
     ) -> Result<[u8; 64], BridgeError> {
-        let mut tx = TransactionBuilder::create_slash_or_take_tx(
+        let mut tx = transaction_builder::create_slash_or_take_tx(
             deposit_outpoint,
             kickoff_utxo,
             &operator_xonly_pk,
@@ -102,7 +102,7 @@ impl Aggregator {
         agg_nonce: &MuSigAggNonce,
         partial_sigs: Vec<MuSigPartialSignature>,
     ) -> Result<[u8; 64], BridgeError> {
-        let move_tx_handler = TransactionBuilder::create_move_tx(
+        let move_tx_handler = transaction_builder::create_move_tx(
             deposit_outpoint,
             &EVMAddress([0u8; 20]),
             Address::p2tr(
@@ -121,7 +121,7 @@ impl Aggregator {
             txid: move_tx_handler.tx.compute_txid(),
             vout: 0,
         };
-        let slash_or_take_tx_handler = TransactionBuilder::create_slash_or_take_tx(
+        let slash_or_take_tx_handler = transaction_builder::create_slash_or_take_tx(
             deposit_outpoint,
             kickoff_utxo,
             operator_xonly_pk,
@@ -144,7 +144,7 @@ impl Aggregator {
         //     serde_json::to_string(&slash_or_take_utxo)?
         // );
 
-        let mut tx_handler = TransactionBuilder::create_operator_takes_tx(
+        let mut tx_handler = transaction_builder::create_operator_takes_tx(
             bridge_fund_outpoint,
             slash_or_take_utxo,
             operator_xonly_pk,
@@ -184,7 +184,7 @@ impl Aggregator {
         agg_nonce: &MuSigAggNonce,
         partial_sigs: Vec<MuSigPartialSignature>,
     ) -> Result<[u8; 64], BridgeError> {
-        let mut tx = TransactionBuilder::create_move_tx(
+        let mut tx = transaction_builder::create_move_tx(
             deposit_outpoint,
             evm_address,
             recovery_taproot_address,
@@ -309,7 +309,7 @@ impl Aggregator {
 
         let move_tx_sig = secp256k1::schnorr::Signature::from_slice(&agg_move_tx_final_sig)?;
 
-        let mut move_tx_handler = TransactionBuilder::create_move_tx(
+        let mut move_tx_handler = transaction_builder::create_move_tx(
             deposit_outpoint,
             &evm_address,
             &recovery_taproot_address,

--- a/core/src/database/common.rs
+++ b/core/src/database/common.rs
@@ -1238,34 +1238,4 @@ mod tests {
         let res = db.get_deposit_kickoff_generator_tx(txid).await.unwrap();
         assert!(res.is_none());
     }
-
-    // #[tokio::test]
-    // async fn test_kickoff_root_1() {
-    //     let config = create_test_config_with_thread_name("test_config.toml", None).await;
-    //     let db = Database::new(config).await.unwrap();
-
-    //     let outpoint = OutPoint {
-    //         txid: Txid::from_byte_array([1u8; 32]),
-    //         vout: 1,
-    //     };
-    //     let root = [1u8; 32];
-    //     db.save_kickoff_root(outpoint, root).await.unwrap();
-    //     let db_root = db.get_kickoff_root(outpoint).await.unwrap().unwrap();
-
-    //     // Sanity check
-    //     assert_eq!(db_root, root);
-    // }
-
-    // #[tokio::test]
-    // async fn test_kickoff_root_2() {
-    //     let config = create_test_config_with_thread_name("test_config.toml", None).await;
-    //     let db = Database::new(config).await.unwrap();
-
-    //     let outpoint = OutPoint {
-    //         txid: Txid::from_byte_array([1u8; 32]),
-    //         vout: 1,
-    //     };
-    //     let res = db.get_kickoff_root(outpoint).await.unwrap();
-    //     assert!(res.is_none());
-    // }
 }

--- a/core/src/database/common.rs
+++ b/core/src/database/common.rs
@@ -4,6 +4,7 @@
 //! directly talks with PostgreSQL. It is expected that PostgreSQL is properly
 //! installed and configured.
 
+use super::wrapper::{AddressDB, EVMAddressDB, OutPointDB, SignatureDB, TxOutDB, TxidDB, UTXODB};
 use crate::musig2::{MuSigAggNonce, MuSigPubNonce, MuSigSecNonce, MuSigSigHash};
 use crate::{config::BridgeConfig, errors::BridgeError};
 use crate::{EVMAddress, UTXO};
@@ -11,8 +12,6 @@ use bitcoin::address::NetworkUnchecked;
 use bitcoin::{Address, OutPoint, Txid};
 use secp256k1::schnorr;
 use sqlx::{Pool, Postgres, QueryBuilder};
-
-use super::wrapper::{AddressDB, EVMAddressDB, OutPointDB, SignatureDB, TxOutDB, TxidDB, UTXODB};
 
 #[derive(Clone, Debug)]
 pub struct Database {
@@ -124,10 +123,7 @@ impl Database {
     pub async fn begin_transaction(
         &self,
     ) -> Result<sqlx::Transaction<'_, sqlx::Postgres>, BridgeError> {
-        match self.connection.begin().await {
-            Ok(t) => Ok(t),
-            Err(e) => Err(BridgeError::DatabaseError(e)),
-        }
+        Ok(self.connection.begin().await?)
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
@@ -140,17 +136,6 @@ impl Database {
             .await?;
         Ok(())
     }
-
-    // #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    // pub async fn unlock_operators_kickoff_utxo_table(
-    //     &self,
-    //     tx: &mut sqlx::Transaction<'_, Postgres>,
-    // ) -> Result<(), BridgeError> {
-    //     sqlx::query("UNLOCK TABLE operators_kickoff_utxo;")
-    //         .execute(&mut **tx)
-    //         .await?;
-    //     Ok(())
-    // }
 
     /// Operator: If operator already created a kickoff UTXO for this deposit UTXO, return it.
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
@@ -221,15 +206,14 @@ impl Database {
             }
             Err(sqlx::Error::RowNotFound) => Ok(None),
             Err(e) => {
-                let db_error = e.as_database_error().ok_or(BridgeError::PgDatabaseError(
-                    "THIS SHOULD NOT HAPPEN".to_string(),
-                ))?;
-                // if error is 23514, it means there is no more unused kickoffs
-                if db_error.is_check_violation() {
-                    Ok(None)
-                } else {
-                    Err(BridgeError::PgDatabaseError(db_error.to_string()))
-                }
+                if let Some(postgresql_error) = e.as_database_error() {
+                    // if error is 23514 (check_violation), it means there is no more unused kickoffs
+                    if postgresql_error.is_check_violation() {
+                        return Ok(None);
+                    }
+                };
+
+                Err(BridgeError::DatabaseError(e))
             }
         }
     }
@@ -1177,7 +1161,7 @@ mod tests {
                 .await
                 .unwrap()
                 .unwrap();
-            tracing::info!("unused_utxo: {:?}", unused_utxo);
+            println!("unused_utxo: {:?}", unused_utxo);
 
             // Sanity check
             assert_eq!(unused_utxo.outpoint.txid, txid);

--- a/core/src/database/operator.rs
+++ b/core/src/database/operator.rs
@@ -1,7 +1,8 @@
 use super::common::Database;
 use crate::config::BridgeConfig;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 
+/// TODO: Remove this wrapper and use Database directly.
 #[derive(Debug, Clone)]
 pub struct OperatorDB {
     database: Database,
@@ -20,11 +21,5 @@ impl Deref for OperatorDB {
 
     fn deref(&self) -> &Self::Target {
         &self.database
-    }
-}
-
-impl DerefMut for OperatorDB {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.database
     }
 }

--- a/core/src/database/verifier.rs
+++ b/core/src/database/verifier.rs
@@ -1,7 +1,8 @@
 use super::common::Database;
 use crate::config::BridgeConfig;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 
+/// TODO: Remove this wrapper and use Database directly.
 #[derive(Debug, Clone)]
 pub struct VerifierDB {
     database: Database,
@@ -20,11 +21,5 @@ impl Deref for VerifierDB {
 
     fn deref(&self) -> &Self::Target {
         &self.database
-    }
-}
-
-impl DerefMut for VerifierDB {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.database
     }
 }

--- a/core/src/database/wrapper.rs
+++ b/core/src/database/wrapper.rs
@@ -237,7 +237,7 @@ mod tests {
         );
 
         let evmaddress = EVMAddress([0x45u8; 20]);
-        let evmaddressdb = EVMAddressDB(evmaddress.clone());
+        let evmaddressdb = EVMAddressDB(evmaddress);
 
         let mut hex: PgArgumentBuffer = PgArgumentBuffer::default();
         if let IsNull::Yes = evmaddressdb.clone().encode(&mut hex) {
@@ -253,7 +253,7 @@ mod tests {
         );
 
         let txid = Txid::all_zeros();
-        let txiddb = TxidDB(txid.clone());
+        let txiddb = TxidDB(txid);
 
         let mut hex: PgArgumentBuffer = PgArgumentBuffer::default();
         if let IsNull::Yes = txiddb.clone().encode(&mut hex) {
@@ -269,7 +269,7 @@ mod tests {
         );
 
         let signature = Signature::from_slice(&[0u8; 64]).unwrap();
-        let signaturedb = SignatureDB(signature.clone());
+        let signaturedb = SignatureDB(signature);
 
         let mut hex: PgArgumentBuffer = PgArgumentBuffer::default();
         if let IsNull::Yes = signaturedb.clone().encode(&mut hex) {

--- a/core/src/database/wrapper.rs
+++ b/core/src/database/wrapper.rs
@@ -1,30 +1,28 @@
-use std::str::FromStr;
-
+use crate::EVMAddress;
 use bitcoin::{address::NetworkUnchecked, Address, OutPoint, TxOut, Txid};
 use serde::{Deserialize, Serialize};
 use sqlx::{
     postgres::{PgArgumentBuffer, PgValueRef},
     Decode, Encode, Postgres,
 };
+use std::str::FromStr;
 
-use crate::EVMAddress;
-
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OutPointDB(pub OutPoint);
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TxOutDB(pub TxOut);
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, Clone)]
 pub struct AddressDB(pub Address<NetworkUnchecked>);
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct EVMAddressDB(pub EVMAddress);
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TxidDB(pub Txid);
 
-#[derive(Serialize, Deserialize, sqlx::FromRow)]
+#[derive(Serialize, Deserialize, sqlx::FromRow, Debug, Clone)]
 pub struct SignatureDB(pub secp256k1::schnorr::Signature);
 
 #[derive(Serialize, Deserialize, sqlx::FromRow)]
@@ -41,8 +39,8 @@ impl sqlx::Type<sqlx::Postgres> for OutPointDB {
 
 impl<'q> Encode<'q, Postgres> for OutPointDB {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> sqlx::encode::IsNull {
-        // Encode as &str
         let s = self.0.to_string();
+
         <&str as Encode<Postgres>>::encode_by_ref(&s.as_str(), buf)
     }
 }
@@ -50,6 +48,7 @@ impl<'q> Encode<'q, Postgres> for OutPointDB {
 impl<'r> Decode<'r, Postgres> for OutPointDB {
     fn decode(value: PgValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
         let s = <&str as Decode<Postgres>>::decode(value)?;
+
         Ok(OutPointDB(OutPoint::from_str(s)?))
     }
 }
@@ -156,5 +155,125 @@ impl<'r> Decode<'r, Postgres> for SignatureDB {
         let s = <&str as Decode<Postgres>>::decode(value)?;
         let x: secp256k1::schnorr::Signature = secp256k1::schnorr::Signature::from_str(s)?;
         Ok(SignatureDB(x))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OutPointDB;
+    use crate::{
+        database::wrapper::{AddressDB, EVMAddressDB, SignatureDB, TxOutDB, TxidDB},
+        utils, EVMAddress,
+    };
+    use bitcoin::{hashes::Hash, Amount, OutPoint, ScriptBuf, TxOut, Txid};
+    use secp256k1::schnorr::Signature;
+    use sqlx::{encode::IsNull, postgres::PgArgumentBuffer, Encode, Type};
+
+    #[test]
+    fn outpointdb() {
+        assert_eq!(
+            OutPointDB::type_info(),
+            sqlx::postgres::PgTypeInfo::with_name("TEXT")
+        );
+
+        let outpoint = OutPoint {
+            txid: Txid::all_zeros(),
+            vout: 0x45,
+        };
+        let outpointdb = OutPointDB(outpoint);
+
+        let mut hex: PgArgumentBuffer = PgArgumentBuffer::default();
+        if let IsNull::Yes = outpointdb.clone().encode(&mut hex) {
+            panic!("Couldn't write {:?} to the buffer!", outpointdb);
+        }
+    }
+
+    #[test]
+    fn txoutdb() {
+        assert_eq!(
+            TxOutDB::type_info(),
+            sqlx::postgres::PgTypeInfo::with_name("TEXT")
+        );
+
+        let txout = TxOut {
+            value: Amount::from_sat(0x45),
+            script_pubkey: ScriptBuf::new(),
+        };
+        let txoutdb = TxOutDB(txout);
+
+        let mut hex: PgArgumentBuffer = PgArgumentBuffer::default();
+        if let IsNull::Yes = txoutdb.clone().encode(&mut hex) {
+            panic!("Couldn't write {:?} to the buffer!", txoutdb);
+        }
+    }
+
+    #[test]
+    fn addressdb() {
+        assert_eq!(
+            AddressDB::type_info(),
+            sqlx::postgres::PgTypeInfo::with_name("TEXT")
+        );
+
+        let address = bitcoin::Address::p2tr(
+            &utils::SECP,
+            *utils::UNSPENDABLE_XONLY_PUBKEY,
+            None,
+            bitcoin::Network::Regtest,
+        );
+        let address = address.as_unchecked();
+        let addressdb = AddressDB(address.clone());
+
+        let mut hex: PgArgumentBuffer = PgArgumentBuffer::default();
+        if let IsNull::Yes = addressdb.clone().encode(&mut hex) {
+            panic!("Couldn't write {:?} to the buffer!", addressdb);
+        }
+    }
+
+    #[test]
+    fn evmaddressdb() {
+        assert_eq!(
+            EVMAddressDB::type_info(),
+            sqlx::postgres::PgTypeInfo::with_name("TEXT")
+        );
+
+        let evmaddress = EVMAddress([0x45u8; 20]);
+        let evmaddressdb = EVMAddressDB(evmaddress.clone());
+
+        let mut hex: PgArgumentBuffer = PgArgumentBuffer::default();
+        if let IsNull::Yes = evmaddressdb.clone().encode(&mut hex) {
+            panic!("Couldn't write {:?} to the buffer!", evmaddressdb);
+        }
+    }
+
+    #[test]
+    fn txiddb() {
+        assert_eq!(
+            TxidDB::type_info(),
+            sqlx::postgres::PgTypeInfo::with_name("TEXT")
+        );
+
+        let txid = Txid::all_zeros();
+        let txiddb = TxidDB(txid.clone());
+
+        let mut hex: PgArgumentBuffer = PgArgumentBuffer::default();
+        if let IsNull::Yes = txiddb.clone().encode(&mut hex) {
+            panic!("Couldn't write {:?} to the buffer!", txiddb);
+        }
+    }
+
+    #[test]
+    fn signaturedb() {
+        assert_eq!(
+            SignatureDB::type_info(),
+            sqlx::postgres::PgTypeInfo::with_name("TEXT")
+        );
+
+        let signature = Signature::from_slice(&[0u8; 64]).unwrap();
+        let signaturedb = SignatureDB(signature.clone());
+
+        let mut hex: PgArgumentBuffer = PgArgumentBuffer::default();
+        if let IsNull::Yes = signaturedb.clone().encode(&mut hex) {
+            panic!("Couldn't write {:?} to the buffer!", signaturedb);
+        }
     }
 }

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 pub enum BridgeError {
     /// Returned when the secp256k1 crate returns an error
     #[error("Secpk256Error: {0}")]
-    Secpk256Error(#[from] secp256k1::Error),
+    Secp256k1Error(#[from] secp256k1::Error),
     /// Returned when the bitcoin crate returns an error in the sighash taproot module
     #[error("BitcoinSighashTaprootError: {0}")]
     BitcoinSighashTaprootError(#[from] bitcoin::sighash::TaprootError),

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -2,16 +2,10 @@
 //!
 //! This module defines errors, returned by the library.
 
-use bitcoin::{
-    consensus::encode::FromHexError,
-    merkle_tree::MerkleBlockError,
-    taproot::{TaprootBuilder, TaprootBuilderError},
-    Txid,
-};
+use bitcoin::{consensus::encode::FromHexError, merkle_tree::MerkleBlockError, Txid};
 use core::fmt::Debug;
 use jsonrpsee::types::ErrorObject;
 use musig2::secp::errors::InvalidScalarBytes;
-use std::array::TryFromSliceError;
 use thiserror::Error;
 
 /// Errors related to periods.
@@ -201,29 +195,5 @@ pub enum BridgeError {
 impl From<BridgeError> for ErrorObject<'static> {
     fn from(val: BridgeError) -> Self {
         ErrorObject::owned(-30000, format!("{:?}", val), Some(1))
-    }
-}
-
-impl From<Vec<u8>> for BridgeError {
-    fn from(_error: Vec<u8>) -> Self {
-        BridgeError::VecConversionError
-    }
-}
-
-impl From<TryFromSliceError> for BridgeError {
-    fn from(_error: TryFromSliceError) -> Self {
-        BridgeError::TryFromSliceError
-    }
-}
-
-impl From<TaprootBuilderError> for BridgeError {
-    fn from(_error: TaprootBuilderError) -> Self {
-        BridgeError::TaprootBuilderError
-    }
-}
-
-impl From<TaprootBuilder> for BridgeError {
-    fn from(_error: TaprootBuilder) -> Self {
-        BridgeError::TaprootBuilderError
     }
 }

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -8,24 +8,10 @@ use jsonrpsee::types::ErrorObject;
 use musig2::secp::errors::InvalidScalarBytes;
 use thiserror::Error;
 
-/// Errors related to periods.
-#[derive(Debug, Error)]
-pub enum InvalidPeriodError {
-    #[error("DepositPeriodMismatch")]
-    WithdrawalPeriodMismatch,
-    #[error("DepositPeriodMismatch")]
-    PreimageRevealPeriodMismatch,
-    #[error("DepositPeriodMismatch")]
-    InscriptionPeriodMismatch,
-}
-
 /// Errors returned by the bridge.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum BridgeError {
-    /// Returned when the period is invalid
-    #[error("InvalidPeriod")]
-    InvalidPeriod(InvalidPeriodError),
     /// Returned when the secp256k1 crate returns an error
     #[error("Secpk256Error: {0}")]
     Secpk256Error(#[from] secp256k1::Error),

--- a/core/src/extended_rpc.rs
+++ b/core/src/extended_rpc.rs
@@ -3,7 +3,7 @@
 //! This module provides helpful functions for Bitcoin RPC.
 
 use crate::errors::BridgeError;
-use crate::transaction_builder::TransactionBuilder;
+use crate::transaction_builder;
 use crate::EVMAddress;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::Address;
@@ -177,7 +177,7 @@ where
             return Err(BridgeError::DepositNotFinalized);
         }
 
-        let (deposit_address, _) = TransactionBuilder::generate_deposit_address(
+        let (deposit_address, _) = transaction_builder::generate_deposit_address(
             nofn_xonly_pk,
             recovery_taproot_address,
             evm_address,

--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -176,7 +176,7 @@ mod tests {
         actor::Actor,
         errors::BridgeError,
         musig2::{AggregateFromPublicKeys, MuSigPartialSignature},
-        transaction_builder::{TransactionBuilder, TxHandler},
+        transaction_builder::{self, TxHandler},
         utils, ByteArray32,
     };
     use bitcoin::{
@@ -435,7 +435,7 @@ mod tests {
             bitcoin::Network::Regtest,
         );
         let (sending_address, sending_address_spend_info) =
-            TransactionBuilder::create_taproot_address(
+            transaction_builder::create_taproot_address(
                 &scripts.clone(),
                 Some(untweaked_xonly_pubkey),
                 bitcoin::Network::Regtest,
@@ -448,12 +448,12 @@ mod tests {
             txid: Txid::from_byte_array([0u8; 32]),
             vout: 0,
         };
-        let tx_outs = TransactionBuilder::create_tx_outs(vec![(
+        let tx_outs = transaction_builder::create_tx_outs(vec![(
             Amount::from_sat(99_000_000),
             receiving_address.script_pubkey(),
         )]);
-        let tx_ins = TransactionBuilder::create_tx_ins(vec![utxo]);
-        let dummy_tx = TransactionBuilder::create_btc_tx(tx_ins, tx_outs);
+        let tx_ins = transaction_builder::create_tx_ins(vec![utxo]);
+        let dummy_tx = transaction_builder::create_btc_tx(tx_ins, tx_outs);
         let mut tx_details = TxHandler {
             tx: dummy_tx,
             prevouts: vec![prevout],
@@ -525,7 +525,7 @@ mod tests {
             bitcoin::Network::Regtest,
         );
         let (sending_address, sending_address_spend_info) =
-            TransactionBuilder::create_taproot_address(
+            transaction_builder::create_taproot_address(
                 &scripts.clone(),
                 None,
                 bitcoin::Network::Regtest,
@@ -538,12 +538,12 @@ mod tests {
             txid: Txid::from_byte_array([0u8; 32]),
             vout: 0,
         };
-        let tx_outs = TransactionBuilder::create_tx_outs(vec![(
+        let tx_outs = transaction_builder::create_tx_outs(vec![(
             Amount::from_sat(99_000_000),
             receiving_address.script_pubkey(),
         )]);
-        let tx_ins = TransactionBuilder::create_tx_ins(vec![utxo]);
-        let dummy_tx = TransactionBuilder::create_btc_tx(tx_ins, tx_outs);
+        let tx_ins = transaction_builder::create_tx_ins(vec![utxo]);
+        let dummy_tx = transaction_builder::create_btc_tx(tx_ins, tx_outs);
         let mut tx_details = TxHandler {
             tx: dummy_tx,
             prevouts: vec![prevout],

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -587,7 +587,7 @@ where
 
         let our_sig =
             self.signer
-                .sign_taproot_script_spend_tx_new(&mut slash_or_take_tx_handler, 0, 0)?;
+                .sign_taproot_script_spend_tx(&mut slash_or_take_tx_handler, 0, 0)?;
         // tracing::debug!("slash_or_take_tx_handler: {:#?}", slash_or_take_tx_handler);
         handle_taproot_witness_new(
             &mut slash_or_take_tx_handler,
@@ -643,7 +643,7 @@ where
 
         let our_sig = self
             .signer
-            .sign_taproot_script_spend_tx_new(&mut operator_takes_tx, 1, 0)?;
+            .sign_taproot_script_spend_tx(&mut operator_takes_tx, 1, 0)?;
 
         handle_taproot_witness_new(
             &mut operator_takes_tx,

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -791,6 +791,7 @@ mod tests {
 
         operator.0.set_funding_utxo_rpc(funding_utxo).await.unwrap();
 
-        // Currently, no way to retrive this data using rpc calls.
+        // TODO: Currently, no way to retrive this data using rpc calls. Add
+        // checks if added in the future.
     }
 }

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -710,6 +710,10 @@ where
             .await
     }
 
+    async fn set_funding_utxo_rpc(&self, funding_utxo: UTXO) -> Result<(), BridgeError> {
+        self.set_funding_utxo(funding_utxo).await
+    }
+
     async fn new_withdrawal_sig_rpc(
         &self,
         withdrawal_idx: u32,

--- a/core/src/script_builder.rs
+++ b/core/src/script_builder.rs
@@ -87,31 +87,3 @@ pub fn generate_relative_timelock_script(
         .push_opcode(OP_CHECKSIG)
         .into_script()
 }
-
-#[tracing::instrument(ret(level = tracing::Level::TRACE))]
-pub fn generate_absolute_timelock_script(actor_pk: &XOnlyPublicKey, block_count: u32) -> ScriptBuf {
-    Builder::new()
-        .push_int(block_count as i64)
-        .push_opcode(OP_CLTV)
-        .push_opcode(OP_DROP)
-        .push_x_only_key(actor_pk)
-        .push_opcode(OP_CHECKSIG)
-        .into_script()
-}
-
-#[tracing::instrument(ret(level = tracing::Level::TRACE))]
-pub fn generate_hash_script(hash: [u8; 32]) -> ScriptBuf {
-    Builder::new()
-        .push_opcode(OP_SHA256)
-        .push_slice(hash)
-        .push_opcode(OP_EQUAL)
-        .into_script()
-}
-
-#[tracing::instrument(ret(level = tracing::Level::TRACE))]
-pub fn generate_dust_script(evm_address: &EVMAddress) -> ScriptBuf {
-    Builder::new()
-        .push_opcode(OP_RETURN)
-        .push_slice(evm_address.0)
-        .into_script()
-}

--- a/core/src/traits/rpc.rs
+++ b/core/src/traits/rpc.rs
@@ -64,9 +64,6 @@ pub trait OperatorRpc {
         evm_address: EVMAddress,
     ) -> Result<(UTXO, secp256k1::schnorr::Signature), BridgeError>;
 
-    #[method(name = "set_funding_utxo")]
-    async fn set_funding_utxo_rpc(&self, funding_utxo: UTXO) -> Result<(), BridgeError>;
-
     #[method(name = "new_withdrawal_sig")]
     /// Gets the withdrawal utxo from citrea,
     /// checks wheter sig is for a correct withdrawal from citrea,

--- a/core/src/traits/rpc.rs
+++ b/core/src/traits/rpc.rs
@@ -64,6 +64,9 @@ pub trait OperatorRpc {
         evm_address: EVMAddress,
     ) -> Result<(UTXO, secp256k1::schnorr::Signature), BridgeError>;
 
+    #[method(name = "set_funding_utxo")]
+    async fn set_funding_utxo_rpc(&self, funding_utxo: UTXO) -> Result<(), BridgeError>;
+
     #[method(name = "new_withdrawal_sig")]
     /// Gets the withdrawal utxo from citrea,
     /// checks wheter sig is for a correct withdrawal from citrea,

--- a/core/src/transaction_builder.rs
+++ b/core/src/transaction_builder.rs
@@ -4,13 +4,11 @@ use crate::{script_builder, utils, EVMAddress, UTXO};
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::Hash;
 use bitcoin::script::PushBytesBuf;
-use bitcoin::Network;
 use bitcoin::{
     absolute,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, Amount, OutPoint, ScriptBuf, TxIn, TxOut, Witness,
 };
-use secp256k1::PublicKey;
 use secp256k1::XOnlyPublicKey;
 
 #[derive(Debug, Clone)]
@@ -23,468 +21,426 @@ pub struct TxHandler {
 
 pub type CreateAddressOutputs = (Address, TaprootSpendInfo);
 
-#[derive(Debug, Clone)]
-pub struct TransactionBuilder {
-    _verifiers_xonly_pks: Vec<XOnlyPublicKey>,
-    _verifiers_pks: Vec<PublicKey>,
-    _network: Network,
-}
-
 // TODO: Move these constants to a config file
 pub const MOVE_TX_MIN_RELAY_FEE: u64 = 190;
 pub const SLASH_OR_TAKE_TX_MIN_RELAY_FEE: u64 = 240;
 pub const OPERATOR_TAKES_TX_MIN_RELAY_FEE: u64 = 230;
 pub const KICKOFF_UTXO_AMOUNT_SATS: u64 = 100_000;
 
-impl TransactionBuilder {
-    /// Creates a new `TransactionBuilder`.
-    pub fn new(verifiers_pks: Vec<PublicKey>, network: Network) -> Self {
-        let verifiers_xonly_pks: Vec<XOnlyPublicKey> = verifiers_pks
-            .iter()
-            .map(|pk| PublicKey::x_only_public_key(pk).0)
-            .collect();
-        Self {
-            _verifiers_xonly_pks: verifiers_xonly_pks,
-            _verifiers_pks: verifiers_pks,
-            _network: network,
-        }
-    }
+// ADDRESS BUILDERS
 
-    // ADDRESS BUILDERS
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
+pub fn create_taproot_address(
+    scripts: &[ScriptBuf],
+    internal_key: Option<XOnlyPublicKey>,
+    network: bitcoin::Network,
+) -> CreateAddressOutputs {
+    let n = scripts.len();
 
-    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
-    pub fn create_taproot_address(
-        scripts: &[ScriptBuf],
-        internal_key: Option<XOnlyPublicKey>,
-        network: bitcoin::Network,
-    ) -> CreateAddressOutputs {
-        let n = scripts.len();
-
-        let taproot_builder = if n == 0 {
-            TaprootBuilder::new()
-        } else if n > 1 {
-            let m: u8 = ((n - 1).ilog2() + 1) as u8; // m = ceil(log(n))
-            let k = 2_usize.pow(m.into()) - n;
-            (0..n).fold(TaprootBuilder::new(), |acc, i| {
-                acc.add_leaf(m - ((i >= n - k) as u8), scripts[i].clone())
-                    .unwrap()
-            })
-        } else {
-            TaprootBuilder::new()
-                .add_leaf(0, scripts[0].clone())
+    let taproot_builder = if n == 0 {
+        TaprootBuilder::new()
+    } else if n > 1 {
+        let m: u8 = ((n - 1).ilog2() + 1) as u8; // m = ceil(log(n))
+        let k = 2_usize.pow(m.into()) - n;
+        (0..n).fold(TaprootBuilder::new(), |acc, i| {
+            acc.add_leaf(m - ((i >= n - k) as u8), scripts[i].clone())
                 .unwrap()
-        };
+        })
+    } else {
+        TaprootBuilder::new()
+            .add_leaf(0, scripts[0].clone())
+            .unwrap()
+    };
 
-        let tree_info = match internal_key {
-            Some(xonly_pk) => taproot_builder.finalize(&utils::SECP, xonly_pk).unwrap(),
-            None => taproot_builder
-                .finalize(&utils::SECP, *utils::UNSPENDABLE_XONLY_PUBKEY)
-                .unwrap(),
-        };
+    let tree_info = match internal_key {
+        Some(xonly_pk) => taproot_builder.finalize(&utils::SECP, xonly_pk).unwrap(),
+        None => taproot_builder
+            .finalize(&utils::SECP, *utils::UNSPENDABLE_XONLY_PUBKEY)
+            .unwrap(),
+    };
 
-        let taproot_address = match internal_key {
-            Some(xonly_pk) => {
-                Address::p2tr(&utils::SECP, xonly_pk, tree_info.merkle_root(), network)
-            }
-            None => Address::p2tr(
-                &utils::SECP,
-                *utils::UNSPENDABLE_XONLY_PUBKEY,
-                tree_info.merkle_root(),
-                network,
-            ),
-        };
+    let taproot_address = match internal_key {
+        Some(xonly_pk) => Address::p2tr(&utils::SECP, xonly_pk, tree_info.merkle_root(), network),
+        None => Address::p2tr(
+            &utils::SECP,
+            *utils::UNSPENDABLE_XONLY_PUBKEY,
+            tree_info.merkle_root(),
+            network,
+        ),
+    };
 
-        (taproot_address, tree_info)
+    (taproot_address, tree_info)
+}
+
+/// Generates a deposit address for the user. N-of-N or user takes after
+/// timelock script can be used to spend the funds.
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
+pub fn generate_deposit_address(
+    nofn_xonly_pk: &XOnlyPublicKey,
+    recovery_taproot_address: &Address<NetworkUnchecked>,
+    user_evm_address: &EVMAddress,
+    amount: u64,
+    network: bitcoin::Network,
+    user_takes_after: u32,
+) -> CreateAddressOutputs {
+    let deposit_script =
+        script_builder::create_deposit_script(nofn_xonly_pk, user_evm_address, amount);
+
+    let recovery_script_pubkey = recovery_taproot_address
+        .clone()
+        .assume_checked()
+        .script_pubkey();
+    let recovery_extracted_xonly_pk =
+        XOnlyPublicKey::from_slice(&recovery_script_pubkey.as_bytes()[2..34]).unwrap();
+
+    let script_timelock = script_builder::generate_relative_timelock_script(
+        &recovery_extracted_xonly_pk,
+        user_takes_after,
+    );
+
+    create_taproot_address(&[deposit_script, script_timelock], None, network)
+}
+
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
+pub fn create_musig2_address(
+    nofn_xonly_pk: XOnlyPublicKey,
+    network: bitcoin::Network,
+) -> CreateAddressOutputs {
+    create_taproot_address(&[], Some(nofn_xonly_pk), network)
+}
+
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
+pub fn create_kickoff_address(
+    nofn_xonly_pk: &XOnlyPublicKey,
+    operator_xonly_pk: &XOnlyPublicKey,
+    network: bitcoin::Network,
+) -> CreateAddressOutputs {
+    let musig2_and_operator_script = script_builder::create_musig2_and_operator_multisig_script(
+        nofn_xonly_pk,
+        operator_xonly_pk,
+    );
+    create_taproot_address(&[musig2_and_operator_script], None, network)
+}
+
+// TX BUILDERS
+
+/// Creates the move_tx to move the deposit.
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
+pub fn create_move_tx(
+    deposit_outpoint: OutPoint,
+    evm_address: &EVMAddress,
+    recovery_taproot_address: &Address<NetworkUnchecked>,
+    nofn_xonly_pk: &XOnlyPublicKey,
+    network: bitcoin::Network,
+    user_takes_after: u32,
+    bridge_amount_sats: u64,
+) -> TxHandler {
+    let anyone_can_spend_txout = script_builder::anyone_can_spend_txout();
+    let (musig2_address, _) = create_musig2_address(*nofn_xonly_pk, network);
+    let (deposit_address, deposit_taproot_spend_info) = generate_deposit_address(
+        nofn_xonly_pk,
+        recovery_taproot_address,
+        evm_address,
+        bridge_amount_sats,
+        network,
+        user_takes_after,
+    );
+    let move_txout = TxOut {
+        value: Amount::from_sat(bridge_amount_sats)
+            - Amount::from_sat(MOVE_TX_MIN_RELAY_FEE)
+            - anyone_can_spend_txout.value,
+        script_pubkey: musig2_address.script_pubkey(),
+    };
+    let tx_ins = create_tx_ins(vec![deposit_outpoint]);
+    let move_tx = create_btc_tx(tx_ins, vec![move_txout, anyone_can_spend_txout]);
+    let prevouts = vec![TxOut {
+        script_pubkey: deposit_address.script_pubkey(),
+        value: Amount::from_sat(bridge_amount_sats),
+    }];
+    let deposit_script = vec![script_builder::create_deposit_script(
+        nofn_xonly_pk,
+        evm_address,
+        bridge_amount_sats,
+    )];
+    TxHandler {
+        tx: move_tx,
+        prevouts,
+        scripts: vec![deposit_script],
+        taproot_spend_infos: vec![deposit_taproot_spend_info],
     }
+}
 
-    /// Generates a deposit address for the user. N-of-N or user takes after
-    /// timelock script can be used to spend the funds.
-    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
-    pub fn generate_deposit_address(
-        nofn_xonly_pk: &XOnlyPublicKey,
-        recovery_taproot_address: &Address<NetworkUnchecked>,
-        user_evm_address: &EVMAddress,
-        amount: u64,
-        network: bitcoin::Network,
-        user_takes_after: u32,
-    ) -> CreateAddressOutputs {
-        let deposit_script =
-            script_builder::create_deposit_script(nofn_xonly_pk, user_evm_address, amount);
+/// Creates the kickoff_tx for the operator. It also returns the change utxo
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
+pub fn create_kickoff_utxo_tx(
+    funding_utxo: &UTXO, // Make sure this comes from the operator's address.
+    nofn_xonly_pk: &XOnlyPublicKey,
+    operator_xonly_pk: &XOnlyPublicKey,
+    network: bitcoin::Network,
+    num_kickoff_utxos_per_tx: usize,
+) -> TxHandler {
+    // Here, we are calculating the minimum relay fee for the kickoff tx based on the number of kickoff utxos per tx.
+    // The formula is: 154 + 43 * num_kickoff_utxos_per_tx where
+    // 154 = (Signature as witness, 66 bytes + 2 bytes from flags) / 4
+    // + 43 * 2 from change and anyone can spend txouts
+    // + 41 from the single input (32 + 8 + 1)
+    // 4 + 4 + 1 + 1 from locktime, version, and VarInt bases of
+    // the number of inputs and outputs.
+    let kickoff_tx_min_relay_fee = match num_kickoff_utxos_per_tx {
+        0..=250 => 154 + 43 * num_kickoff_utxos_per_tx, // Handles all values from 0 to 250
+        _ => 156 + 43 * num_kickoff_utxos_per_tx,       // Handles all other values
+    };
 
-        let recovery_script_pubkey = recovery_taproot_address
-            .clone()
-            .assume_checked()
-            .script_pubkey();
-        let recovery_extracted_xonly_pk =
-            XOnlyPublicKey::from_slice(&recovery_script_pubkey.as_bytes()[2..34]).unwrap();
-
-        let script_timelock = script_builder::generate_relative_timelock_script(
-            &recovery_extracted_xonly_pk,
-            user_takes_after,
+    //  = 154 + 43 * num_kickoff_utxos_per_tx;
+    let tx_ins = create_tx_ins(vec![funding_utxo.outpoint]);
+    let musig2_and_operator_script = script_builder::create_musig2_and_operator_multisig_script(
+        nofn_xonly_pk,
+        operator_xonly_pk,
+    );
+    let (musig2_and_operator_address, _) =
+        create_taproot_address(&[musig2_and_operator_script], None, network);
+    let operator_address = Address::p2tr(&utils::SECP, *operator_xonly_pk, None, network);
+    let change_amount = funding_utxo.txout.value
+        - Amount::from_sat(KICKOFF_UTXO_AMOUNT_SATS * num_kickoff_utxos_per_tx as u64)
+        - script_builder::anyone_can_spend_txout().value
+        - Amount::from_sat(kickoff_tx_min_relay_fee as u64);
+    tracing::debug!("Change amount: {:?}", change_amount);
+    let mut tx_outs_raw = vec![
+        (
+            Amount::from_sat(KICKOFF_UTXO_AMOUNT_SATS),
+            musig2_and_operator_address.script_pubkey(),
         );
+        num_kickoff_utxos_per_tx
+    ];
 
-        TransactionBuilder::create_taproot_address(
-            &[deposit_script, script_timelock],
+    tx_outs_raw.push((change_amount, operator_address.script_pubkey()));
+    tx_outs_raw.push((
+        script_builder::anyone_can_spend_txout().value,
+        script_builder::anyone_can_spend_txout().script_pubkey,
+    ));
+    let tx_outs = create_tx_outs(tx_outs_raw);
+    let tx = create_btc_tx(tx_ins, tx_outs);
+    let prevouts = vec![funding_utxo.txout.clone()];
+    let scripts = vec![vec![]];
+    let taproot_spend_infos = vec![];
+    TxHandler {
+        tx,
+        prevouts,
+        scripts,
+        taproot_spend_infos,
+    }
+}
+
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
+pub fn create_slash_or_take_tx(
+    deposit_outpoint: OutPoint,
+    kickoff_utxo: UTXO,
+    operator_xonly_pk: &XOnlyPublicKey,
+    operator_idx: usize,
+    nofn_xonly_pk: &XOnlyPublicKey,
+    network: bitcoin::Network,
+    user_takes_after: u32,
+    operator_takes_after: u32,
+    bridge_amount_sats: u64,
+) -> TxHandler {
+    // First recreate the move_tx and move_txid. We can give dummy values for some of the parameters since we are only interested in txid.
+    let move_tx_handler = create_move_tx(
+        deposit_outpoint,
+        &EVMAddress([0u8; 20]),
+        Address::p2tr(
+            &utils::SECP,
+            *utils::UNSPENDABLE_XONLY_PUBKEY,
             None,
             network,
         )
+        .as_unchecked(),
+        nofn_xonly_pk,
+        network,
+        user_takes_after,
+        bridge_amount_sats,
+    );
+    let move_txid = move_tx_handler.tx.compute_txid();
+
+    let (kickoff_utxo_address, kickoff_utxo_spend_info) =
+        create_kickoff_address(nofn_xonly_pk, operator_xonly_pk, network);
+    // tracing::debug!(
+    //     "kickoff_utxo_script_pubkey: {:?}",
+    //     kickoff_utxo_address.script_pubkey()
+    // );
+    // tracing::debug!("kickoff_utxo_spend_info: {:?}", kickoff_utxo_spend_info);
+    // tracing::debug!("kickoff_utxooo: {:?}", kickoff_utxo);
+    let musig2_and_operator_script = script_builder::create_musig2_and_operator_multisig_script(
+        nofn_xonly_pk,
+        operator_xonly_pk,
+    );
+    // Sanity check
+    tracing::debug!(
+        "kickoff_utxo_script_pubkey: {:?}",
+        kickoff_utxo_address.script_pubkey()
+    );
+    tracing::debug!(
+        "kickoff_utxo_script_pubkey: {:?}",
+        kickoff_utxo.txout.script_pubkey
+    );
+    tracing::debug!("Operator index: {:?}", operator_idx);
+    tracing::debug!("Operator xonly pk: {:?}", operator_xonly_pk);
+    tracing::debug!("Deposit OutPoint: {:?}", deposit_outpoint);
+    assert!(kickoff_utxo_address.script_pubkey() == kickoff_utxo.txout.script_pubkey);
+    let ins = create_tx_ins(vec![kickoff_utxo.outpoint]);
+    let relative_timelock_script =
+        script_builder::generate_relative_timelock_script(operator_xonly_pk, operator_takes_after);
+    let (slash_or_take_address, _) = create_taproot_address(
+        &[relative_timelock_script.clone()],
+        Some(*nofn_xonly_pk),
+        network,
+    );
+    let mut op_return_script = move_txid.to_byte_array().to_vec();
+    op_return_script.extend(utils::usize_to_var_len_bytes(operator_idx));
+    let mut push_bytes = PushBytesBuf::new();
+    push_bytes.extend_from_slice(&op_return_script).unwrap();
+    let op_return_txout = script_builder::op_return_txout(push_bytes);
+    let outs = vec![
+        TxOut {
+            value: Amount::from_sat(
+                kickoff_utxo.txout.value.to_sat() - 330 - SLASH_OR_TAKE_TX_MIN_RELAY_FEE,
+            ),
+            script_pubkey: slash_or_take_address.script_pubkey(),
+        },
+        script_builder::anyone_can_spend_txout(),
+        op_return_txout,
+    ];
+    let tx = create_btc_tx(ins, outs);
+    let prevouts = vec![kickoff_utxo.txout.clone()];
+    let scripts = vec![vec![musig2_and_operator_script]];
+    tracing::debug!("slash_or_take_tx weight: {:?}", tx.weight());
+    TxHandler {
+        tx,
+        prevouts,
+        scripts,
+        taproot_spend_infos: vec![kickoff_utxo_spend_info],
     }
+}
 
-    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
-    pub fn create_musig2_address(
-        nofn_xonly_pk: XOnlyPublicKey,
-        network: bitcoin::Network,
-    ) -> CreateAddressOutputs {
-        TransactionBuilder::create_taproot_address(&[], Some(nofn_xonly_pk), network)
-    }
+#[tracing::instrument(ret(level = tracing::Level::TRACE))]
+pub fn create_operator_takes_tx(
+    bridge_fund_outpoint: OutPoint,
+    slash_or_take_utxo: UTXO,
+    operator_xonly_pk: &XOnlyPublicKey,
+    nofn_xonly_pk: &XOnlyPublicKey,
+    network: bitcoin::Network,
+    operator_takes_after: u32,
+    bridge_amount_sats: u64,
+    operator_wallet_address: Address<NetworkUnchecked>,
+) -> TxHandler {
+    let operator_wallet_address_checked = operator_wallet_address.require_network(network).unwrap();
+    let mut ins = create_tx_ins(vec![bridge_fund_outpoint]);
+    ins.extend(create_tx_ins_with_sequence(
+        vec![slash_or_take_utxo.outpoint],
+        operator_takes_after as u16,
+    ));
 
-    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
-    pub fn create_kickoff_address(
-        nofn_xonly_pk: &XOnlyPublicKey,
-        operator_xonly_pk: &XOnlyPublicKey,
-        network: bitcoin::Network,
-    ) -> CreateAddressOutputs {
-        let musig2_and_operator_script = script_builder::create_musig2_and_operator_multisig_script(
-            nofn_xonly_pk,
-            operator_xonly_pk,
-        );
-        TransactionBuilder::create_taproot_address(&[musig2_and_operator_script], None, network)
-    }
+    let (musig2_address, musig2_spend_info) = create_musig2_address(*nofn_xonly_pk, network);
 
-    // TX BUILDERS
+    let relative_timelock_script =
+        script_builder::generate_relative_timelock_script(operator_xonly_pk, operator_takes_after);
+    let (slash_or_take_address, slash_or_take_spend_info) = create_taproot_address(
+        &[relative_timelock_script.clone()],
+        Some(*nofn_xonly_pk),
+        network,
+    );
 
-    /// Creates the move_tx to move the deposit.
-    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
-    pub fn create_move_tx(
-        deposit_outpoint: OutPoint,
-        evm_address: &EVMAddress,
-        recovery_taproot_address: &Address<NetworkUnchecked>,
-        nofn_xonly_pk: &XOnlyPublicKey,
-        network: bitcoin::Network,
-        user_takes_after: u32,
-        bridge_amount_sats: u64,
-    ) -> TxHandler {
-        let anyone_can_spend_txout = script_builder::anyone_can_spend_txout();
-        let (musig2_address, _) = Self::create_musig2_address(*nofn_xonly_pk, network);
-        let (deposit_address, deposit_taproot_spend_info) =
-            TransactionBuilder::generate_deposit_address(
-                nofn_xonly_pk,
-                recovery_taproot_address,
-                evm_address,
-                bridge_amount_sats,
-                network,
-                user_takes_after,
-            );
-        let move_txout = TxOut {
+    // Sanity check
+    assert!(slash_or_take_address.script_pubkey() == slash_or_take_utxo.txout.script_pubkey);
+
+    let outs = vec![
+        TxOut {
+            value: Amount::from_sat(slash_or_take_utxo.txout.value.to_sat())
+                + Amount::from_sat(bridge_amount_sats)
+                - Amount::from_sat(MOVE_TX_MIN_RELAY_FEE)
+                - Amount::from_sat(OPERATOR_TAKES_TX_MIN_RELAY_FEE)
+                - script_builder::anyone_can_spend_txout().value
+                - script_builder::anyone_can_spend_txout().value,
+            script_pubkey: operator_wallet_address_checked.script_pubkey(),
+        },
+        script_builder::anyone_can_spend_txout(),
+    ];
+    let tx = create_btc_tx(ins, outs);
+    let prevouts = vec![
+        TxOut {
+            script_pubkey: musig2_address.script_pubkey(),
             value: Amount::from_sat(bridge_amount_sats)
                 - Amount::from_sat(MOVE_TX_MIN_RELAY_FEE)
-                - anyone_can_spend_txout.value,
-            script_pubkey: musig2_address.script_pubkey(),
-        };
-        let tx_ins = TransactionBuilder::create_tx_ins(vec![deposit_outpoint]);
-        let move_tx =
-            TransactionBuilder::create_btc_tx(tx_ins, vec![move_txout, anyone_can_spend_txout]);
-        let prevouts = vec![TxOut {
-            script_pubkey: deposit_address.script_pubkey(),
-            value: Amount::from_sat(bridge_amount_sats),
-        }];
-        let deposit_script = vec![script_builder::create_deposit_script(
-            nofn_xonly_pk,
-            evm_address,
-            bridge_amount_sats,
-        )];
-        TxHandler {
-            tx: move_tx,
-            prevouts,
-            scripts: vec![deposit_script],
-            taproot_spend_infos: vec![deposit_taproot_spend_info],
-        }
+                - script_builder::anyone_can_spend_txout().value,
+        },
+        slash_or_take_utxo.txout,
+    ];
+    let scripts = vec![vec![], vec![relative_timelock_script]];
+    let taproot_spend_infos = vec![musig2_spend_info, slash_or_take_spend_info];
+    TxHandler {
+        tx,
+        prevouts,
+        scripts,
+        taproot_spend_infos,
+    }
+}
+
+pub fn create_btc_tx(tx_ins: Vec<TxIn>, tx_outs: Vec<TxOut>) -> bitcoin::Transaction {
+    bitcoin::Transaction {
+        version: bitcoin::transaction::Version(2),
+        lock_time: absolute::LockTime::from_consensus(0),
+        input: tx_ins,
+        output: tx_outs,
+    }
+}
+
+pub fn create_tx_ins(outpoints: Vec<OutPoint>) -> Vec<TxIn> {
+    let mut tx_ins = Vec::new();
+
+    for utxo in outpoints {
+        tx_ins.push(TxIn {
+            previous_output: utxo,
+            sequence: bitcoin::transaction::Sequence::ENABLE_RBF_NO_LOCKTIME,
+            script_sig: ScriptBuf::default(),
+            witness: Witness::new(),
+        });
     }
 
-    /// Creates the kickoff_tx for the operator. It also returns the change utxo
-    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
-    pub fn create_kickoff_utxo_tx(
-        funding_utxo: &UTXO, // Make sure this comes from the operator's address.
-        nofn_xonly_pk: &XOnlyPublicKey,
-        operator_xonly_pk: &XOnlyPublicKey,
-        network: bitcoin::Network,
-        num_kickoff_utxos_per_tx: usize,
-    ) -> TxHandler {
-        // Here, we are calculating the minimum relay fee for the kickoff tx based on the number of kickoff utxos per tx.
-        // The formula is: 154 + 43 * num_kickoff_utxos_per_tx where
-        // 154 = (Signature as witness, 66 bytes + 2 bytes from flags) / 4
-        // + 43 * 2 from change and anyone can spend txouts
-        // + 41 from the single input (32 + 8 + 1)
-        // 4 + 4 + 1 + 1 from locktime, version, and VarInt bases of
-        // the number of inputs and outputs.
-        let kickoff_tx_min_relay_fee = match num_kickoff_utxos_per_tx {
-            0..=250 => 154 + 43 * num_kickoff_utxos_per_tx, // Handles all values from 0 to 250
-            _ => 156 + 43 * num_kickoff_utxos_per_tx,       // Handles all other values
-        };
+    tx_ins
+}
 
-        //  = 154 + 43 * num_kickoff_utxos_per_tx;
-        let tx_ins = TransactionBuilder::create_tx_ins(vec![funding_utxo.outpoint]);
-        let musig2_and_operator_script = script_builder::create_musig2_and_operator_multisig_script(
-            nofn_xonly_pk,
-            operator_xonly_pk,
-        );
-        let (musig2_and_operator_address, _) = TransactionBuilder::create_taproot_address(
-            &[musig2_and_operator_script],
-            None,
-            network,
-        );
-        let operator_address = Address::p2tr(&utils::SECP, *operator_xonly_pk, None, network);
-        let change_amount = funding_utxo.txout.value
-            - Amount::from_sat(KICKOFF_UTXO_AMOUNT_SATS * num_kickoff_utxos_per_tx as u64)
-            - script_builder::anyone_can_spend_txout().value
-            - Amount::from_sat(kickoff_tx_min_relay_fee as u64);
-        tracing::debug!("Change amount: {:?}", change_amount);
-        let mut tx_outs_raw = vec![
-            (
-                Amount::from_sat(KICKOFF_UTXO_AMOUNT_SATS),
-                musig2_and_operator_address.script_pubkey(),
-            );
-            num_kickoff_utxos_per_tx
-        ];
+pub fn create_tx_ins_with_sequence(utxos: Vec<OutPoint>, height: u16) -> Vec<TxIn> {
+    let mut tx_ins = Vec::new();
 
-        tx_outs_raw.push((change_amount, operator_address.script_pubkey()));
-        tx_outs_raw.push((
-            script_builder::anyone_can_spend_txout().value,
-            script_builder::anyone_can_spend_txout().script_pubkey,
-        ));
-        let tx_outs = TransactionBuilder::create_tx_outs(tx_outs_raw);
-        let tx = TransactionBuilder::create_btc_tx(tx_ins, tx_outs);
-        let prevouts = vec![funding_utxo.txout.clone()];
-        let scripts = vec![vec![]];
-        let taproot_spend_infos = vec![];
-        TxHandler {
-            tx,
-            prevouts,
-            scripts,
-            taproot_spend_infos,
-        }
+    for utxo in utxos {
+        tx_ins.push(TxIn {
+            previous_output: utxo,
+            sequence: bitcoin::transaction::Sequence::from_height(height),
+            script_sig: ScriptBuf::default(),
+            witness: Witness::new(),
+        });
     }
 
-    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
-    pub fn create_slash_or_take_tx(
-        deposit_outpoint: OutPoint,
-        kickoff_utxo: UTXO,
-        operator_xonly_pk: &XOnlyPublicKey,
-        operator_idx: usize,
-        nofn_xonly_pk: &XOnlyPublicKey,
-        network: bitcoin::Network,
-        user_takes_after: u32,
-        operator_takes_after: u32,
-        bridge_amount_sats: u64,
-    ) -> TxHandler {
-        // First recreate the move_tx and move_txid. We can give dummy values for some of the parameters since we are only interested in txid.
-        let move_tx_handler = TransactionBuilder::create_move_tx(
-            deposit_outpoint,
-            &EVMAddress([0u8; 20]),
-            Address::p2tr(
-                &utils::SECP,
-                *utils::UNSPENDABLE_XONLY_PUBKEY,
-                None,
-                network,
-            )
-            .as_unchecked(),
-            nofn_xonly_pk,
-            network,
-            user_takes_after,
-            bridge_amount_sats,
-        );
-        let move_txid = move_tx_handler.tx.compute_txid();
+    tx_ins
+}
 
-        let (kickoff_utxo_address, kickoff_utxo_spend_info) =
-            Self::create_kickoff_address(nofn_xonly_pk, operator_xonly_pk, network);
-        // tracing::debug!(
-        //     "kickoff_utxo_script_pubkey: {:?}",
-        //     kickoff_utxo_address.script_pubkey()
-        // );
-        // tracing::debug!("kickoff_utxo_spend_info: {:?}", kickoff_utxo_spend_info);
-        // tracing::debug!("kickoff_utxooo: {:?}", kickoff_utxo);
-        let musig2_and_operator_script = script_builder::create_musig2_and_operator_multisig_script(
-            nofn_xonly_pk,
-            operator_xonly_pk,
-        );
-        // Sanity check
-        tracing::debug!(
-            "kickoff_utxo_script_pubkey: {:?}",
-            kickoff_utxo_address.script_pubkey()
-        );
-        tracing::debug!(
-            "kickoff_utxo_script_pubkey: {:?}",
-            kickoff_utxo.txout.script_pubkey
-        );
-        tracing::debug!("Operator index: {:?}", operator_idx);
-        tracing::debug!("Operator xonly pk: {:?}", operator_xonly_pk);
-        tracing::debug!("Deposit OutPoint: {:?}", deposit_outpoint);
-        assert!(kickoff_utxo_address.script_pubkey() == kickoff_utxo.txout.script_pubkey);
-        let ins = Self::create_tx_ins(vec![kickoff_utxo.outpoint]);
-        let relative_timelock_script = script_builder::generate_relative_timelock_script(
-            operator_xonly_pk,
-            operator_takes_after,
-        );
-        let (slash_or_take_address, _) = TransactionBuilder::create_taproot_address(
-            &[relative_timelock_script.clone()],
-            Some(*nofn_xonly_pk),
-            network,
-        );
-        let mut op_return_script = move_txid.to_byte_array().to_vec();
-        op_return_script.extend(utils::usize_to_var_len_bytes(operator_idx));
-        let mut push_bytes = PushBytesBuf::new();
-        push_bytes.extend_from_slice(&op_return_script).unwrap();
-        let op_return_txout = script_builder::op_return_txout(push_bytes);
-        let outs = vec![
-            TxOut {
-                value: Amount::from_sat(
-                    kickoff_utxo.txout.value.to_sat() - 330 - SLASH_OR_TAKE_TX_MIN_RELAY_FEE,
-                ),
-                script_pubkey: slash_or_take_address.script_pubkey(),
-            },
-            script_builder::anyone_can_spend_txout(),
-            op_return_txout,
-        ];
-        let tx = TransactionBuilder::create_btc_tx(ins, outs);
-        let prevouts = vec![kickoff_utxo.txout.clone()];
-        let scripts = vec![vec![musig2_and_operator_script]];
-        tracing::debug!("slash_or_take_tx weight: {:?}", tx.weight());
-        TxHandler {
-            tx,
-            prevouts,
-            scripts,
-            taproot_spend_infos: vec![kickoff_utxo_spend_info],
-        }
+pub fn create_tx_outs(pairs: Vec<(Amount, ScriptBuf)>) -> Vec<TxOut> {
+    let mut tx_outs = Vec::new();
+
+    for pair in pairs {
+        tx_outs.push(TxOut {
+            value: pair.0,
+            script_pubkey: pair.1,
+        });
     }
 
-    #[tracing::instrument(ret(level = tracing::Level::TRACE))]
-    pub fn create_operator_takes_tx(
-        bridge_fund_outpoint: OutPoint,
-        slash_or_take_utxo: UTXO,
-        operator_xonly_pk: &XOnlyPublicKey,
-        nofn_xonly_pk: &XOnlyPublicKey,
-        network: bitcoin::Network,
-        operator_takes_after: u32,
-        bridge_amount_sats: u64,
-        operator_wallet_address: Address<NetworkUnchecked>,
-    ) -> TxHandler {
-        let operator_wallet_address_checked =
-            operator_wallet_address.require_network(network).unwrap();
-        let mut ins = TransactionBuilder::create_tx_ins(vec![bridge_fund_outpoint]);
-        ins.extend(TransactionBuilder::create_tx_ins_with_sequence(
-            vec![slash_or_take_utxo.outpoint],
-            operator_takes_after as u16,
-        ));
-
-        let (musig2_address, musig2_spend_info) =
-            TransactionBuilder::create_musig2_address(*nofn_xonly_pk, network);
-
-        let relative_timelock_script = script_builder::generate_relative_timelock_script(
-            operator_xonly_pk,
-            operator_takes_after,
-        );
-        let (slash_or_take_address, slash_or_take_spend_info) =
-            TransactionBuilder::create_taproot_address(
-                &[relative_timelock_script.clone()],
-                Some(*nofn_xonly_pk),
-                network,
-            );
-
-        // Sanity check
-        assert!(slash_or_take_address.script_pubkey() == slash_or_take_utxo.txout.script_pubkey);
-
-        let outs = vec![
-            TxOut {
-                value: Amount::from_sat(slash_or_take_utxo.txout.value.to_sat())
-                    + Amount::from_sat(bridge_amount_sats)
-                    - Amount::from_sat(MOVE_TX_MIN_RELAY_FEE)
-                    - Amount::from_sat(OPERATOR_TAKES_TX_MIN_RELAY_FEE)
-                    - script_builder::anyone_can_spend_txout().value
-                    - script_builder::anyone_can_spend_txout().value,
-                script_pubkey: operator_wallet_address_checked.script_pubkey(),
-            },
-            script_builder::anyone_can_spend_txout(),
-        ];
-        let tx = TransactionBuilder::create_btc_tx(ins, outs);
-        let prevouts = vec![
-            TxOut {
-                script_pubkey: musig2_address.script_pubkey(),
-                value: Amount::from_sat(bridge_amount_sats)
-                    - Amount::from_sat(MOVE_TX_MIN_RELAY_FEE)
-                    - script_builder::anyone_can_spend_txout().value,
-            },
-            slash_or_take_utxo.txout,
-        ];
-        let scripts = vec![vec![], vec![relative_timelock_script]];
-        let taproot_spend_infos = vec![musig2_spend_info, slash_or_take_spend_info];
-        TxHandler {
-            tx,
-            prevouts,
-            scripts,
-            taproot_spend_infos,
-        }
-    }
-
-    pub fn create_btc_tx(tx_ins: Vec<TxIn>, tx_outs: Vec<TxOut>) -> bitcoin::Transaction {
-        bitcoin::Transaction {
-            version: bitcoin::transaction::Version(2),
-            lock_time: absolute::LockTime::from_consensus(0),
-            input: tx_ins,
-            output: tx_outs,
-        }
-    }
-
-    pub fn create_tx_ins(outpoints: Vec<OutPoint>) -> Vec<TxIn> {
-        let mut tx_ins = Vec::new();
-
-        for utxo in outpoints {
-            tx_ins.push(TxIn {
-                previous_output: utxo,
-                sequence: bitcoin::transaction::Sequence::ENABLE_RBF_NO_LOCKTIME,
-                script_sig: ScriptBuf::default(),
-                witness: Witness::new(),
-            });
-        }
-
-        tx_ins
-    }
-
-    pub fn create_tx_ins_with_sequence(utxos: Vec<OutPoint>, height: u16) -> Vec<TxIn> {
-        let mut tx_ins = Vec::new();
-
-        for utxo in utxos {
-            tx_ins.push(TxIn {
-                previous_output: utxo,
-                sequence: bitcoin::transaction::Sequence::from_height(height),
-                script_sig: ScriptBuf::default(),
-                witness: Witness::new(),
-            });
-        }
-
-        tx_ins
-    }
-
-    pub fn create_tx_outs(pairs: Vec<(Amount, ScriptBuf)>) -> Vec<TxOut> {
-        let mut tx_outs = Vec::new();
-
-        for pair in pairs {
-            tx_outs.push(TxOut {
-                value: pair.0,
-                script_pubkey: pair.1,
-            });
-        }
-
-        tx_outs
-    }
+    tx_outs
 }
 
 #[cfg(test)]
 mod tests {
-
+    use crate::{musig2::AggregateFromPublicKeys, transaction_builder};
     use bitcoin::{Address, XOnlyPublicKey};
     use secp256k1::PublicKey;
-
-    use crate::{musig2::AggregateFromPublicKeys, transaction_builder::TransactionBuilder};
     use std::str::FromStr;
 
     #[test]
@@ -513,7 +469,7 @@ mod tests {
             Address::from_str("bcrt1p65yp9q9fxtf7dyvthyrx26xxm2czanvrnh9rtvphmlsjvhdt4k6qw4pkss")
                 .unwrap();
 
-        let deposit_address = TransactionBuilder::generate_deposit_address(
+        let deposit_address = transaction_builder::generate_deposit_address(
             &nofn_xonly_pk,
             recovery_taproot_address.as_unchecked(),
             &crate::EVMAddress(evm_address),

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -45,24 +45,14 @@ where
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn deposit_tx(
-        &self,
-        evm_address: EVMAddress,
-    ) -> Result<(OutPoint, XOnlyPublicKey, EVMAddress), BridgeError> {
-        let (deposit_address, _) = transaction_builder::generate_deposit_address(
-            &self.nofn_xonly_pk,
-            self.signer.address.as_unchecked(),
-            &evm_address,
-            self.config.bridge_amount_sats,
-            self.config.network,
-            self.config.user_takes_after,
-        );
+    pub fn deposit_tx(&self, evm_address: EVMAddress) -> Result<OutPoint, BridgeError> {
+        let deposit_address = self.get_deposit_address(evm_address)?;
 
         let deposit_outpoint = self
             .rpc
             .send_to_address(&deposit_address, self.config.bridge_amount_sats)?;
 
-        Ok((deposit_outpoint, self.signer.xonly_public_key, evm_address))
+        Ok(deposit_outpoint)
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
@@ -110,5 +100,47 @@ where
             Some(TapSighashType::SinglePlusAnyoneCanPay),
         )?;
         Ok((dust_utxo, txout, sig))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::extended_rpc::ExtendedRpc;
+    use crate::user::User;
+    use crate::EVMAddress;
+    use crate::{create_extended_rpc, mock::database::create_test_config};
+    use secp256k1::{rand, SecretKey};
+
+    #[tokio::test]
+    async fn deposit_tx() {
+        let mut config = create_test_config("deposit_tx", "test_config.toml").await;
+        let rpc = create_extended_rpc!(config);
+
+        let evm_address = EVMAddress([0x45u8; 20]);
+        let sk = SecretKey::new(&mut rand::thread_rng());
+        let user = User::new(rpc.clone(), sk, config.clone());
+
+        let deposit_utxo = user.deposit_tx(evm_address).unwrap();
+        let deposit_txout = rpc.get_raw_transaction(&deposit_utxo.txid, None).unwrap();
+
+        assert_eq!(
+            deposit_txout
+                .output
+                .get(deposit_utxo.vout as usize)
+                .unwrap()
+                .value
+                .to_sat(),
+            config.bridge_amount_sats
+        );
+
+        let deposit_address = user.get_deposit_address(evm_address).unwrap();
+        assert_eq!(
+            deposit_txout
+                .output
+                .get(deposit_utxo.vout as usize)
+                .unwrap()
+                .script_pubkey,
+            deposit_address.script_pubkey()
+        );
     }
 }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -3,11 +3,9 @@ use crate::config::BridgeConfig;
 use crate::errors::BridgeError;
 use crate::transaction_builder::TxHandler;
 use bitcoin;
-use bitcoin::consensus::Decodable;
 use bitcoin::sighash::SighashCache;
 use bitcoin::taproot::LeafVersion;
 use bitcoin::XOnlyPublicKey;
-use hex;
 use std::borrow::BorrowMut;
 use std::process::exit;
 use std::str::FromStr;
@@ -38,19 +36,6 @@ lazy_static::lazy_static! {
 
 lazy_static::lazy_static! {
     pub static ref NETWORK : bitcoin::Network = bitcoin::Network::Regtest;
-}
-
-#[deprecated(note = "Use bitcoin::consensus::encode::deserialize_hex(tx_hex) instead")]
-pub fn parse_hex_to_btc_tx(
-    tx_hex: &str,
-) -> Result<bitcoin::blockdata::transaction::Transaction, bitcoin::consensus::encode::Error> {
-    if let Ok(reader) = hex::decode(tx_hex) {
-        bitcoin::blockdata::transaction::Transaction::consensus_decode(&mut &reader[..])
-    } else {
-        Err(bitcoin::consensus::encode::Error::ParseFailed(
-            "Could not decode hex",
-        ))
-    }
 }
 
 /// Gets configuration from CLI, for binaries. If there are any errors, print

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -575,3 +575,24 @@ where
             .await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::extended_rpc::ExtendedRpc;
+    use crate::verifier::Verifier;
+    use crate::{create_extended_rpc, mock::database::create_test_config};
+
+    #[tokio::test]
+    async fn verifier_new_public_key_check() {
+        let mut config =
+            create_test_config("verifier_new_public_key_check", "test_config.toml").await;
+        let rpc = create_extended_rpc!(config);
+
+        // Test config file has correct keys.
+        Verifier::new(rpc.clone(), config.clone()).await.unwrap();
+
+        // Clearing them should result in error.
+        config.verifiers_public_keys.clear();
+        assert!(Verifier::new(rpc, config).await.is_err());
+    }
+}

--- a/core/tests/musig2.rs
+++ b/core/tests/musig2.rs
@@ -13,7 +13,7 @@ use clementine_core::{
     config::BridgeConfig,
     extended_rpc::ExtendedRpc,
     musig2::{create_key_agg_ctx, nonce_pair, partial_sign, MuSigNoncePair},
-    transaction_builder::{TransactionBuilder, TxHandler},
+    transaction_builder::{self, TxHandler},
     utils, ByteArray66,
 };
 use secp256k1::{Keypair, Message};
@@ -50,20 +50,20 @@ async fn test_musig2_key_spend() {
     let untweaked_xonly_pubkey: secp256k1::XOnlyPublicKey =
         secp256k1::XOnlyPublicKey::from_slice(&untweaked_pubkey.x_only_public_key().0.serialize())
             .unwrap();
-    let (to_address, _) = TransactionBuilder::create_taproot_address(&[], None, config.network);
-    let (from_address, from_address_spend_info) = TransactionBuilder::create_taproot_address(
+    let (to_address, _) = transaction_builder::create_taproot_address(&[], None, config.network);
+    let (from_address, from_address_spend_info) = transaction_builder::create_taproot_address(
         &[],
         Some(untweaked_xonly_pubkey),
         config.network,
     );
     let utxo = rpc.send_to_address(&from_address, 100_000_000).unwrap();
     let prevout = rpc.get_txout_from_outpoint(&utxo).unwrap();
-    let tx_outs = TransactionBuilder::create_tx_outs(vec![(
+    let tx_outs = transaction_builder::create_tx_outs(vec![(
         Amount::from_sat(99_000_000),
         to_address.script_pubkey(),
     )]);
-    let tx_ins = TransactionBuilder::create_tx_ins(vec![utxo]);
-    let dummy_tx = TransactionBuilder::create_btc_tx(tx_ins, tx_outs);
+    let tx_ins = transaction_builder::create_tx_ins(vec![utxo]);
+    let dummy_tx = transaction_builder::create_btc_tx(tx_ins, tx_outs);
     let mut tx_details = TxHandler {
         tx: dummy_tx,
         prevouts: vec![prevout],
@@ -156,20 +156,20 @@ async fn test_musig2_key_spend_with_script() {
             .unwrap();
     let dummy_script = script::Builder::new().push_int(1).into_script();
     let scripts: Vec<ScriptBuf> = vec![dummy_script];
-    let (to_address, _) = TransactionBuilder::create_taproot_address(&[], None, config.network);
-    let (from_address, from_address_spend_info) = TransactionBuilder::create_taproot_address(
+    let (to_address, _) = transaction_builder::create_taproot_address(&[], None, config.network);
+    let (from_address, from_address_spend_info) = transaction_builder::create_taproot_address(
         &scripts,
         Some(untweaked_xonly_pubkey),
         config.network,
     );
     let utxo = rpc.send_to_address(&from_address, 100_000_000).unwrap();
     let prevout = rpc.get_txout_from_outpoint(&utxo).unwrap();
-    let tx_outs = TransactionBuilder::create_tx_outs(vec![(
+    let tx_outs = transaction_builder::create_tx_outs(vec![(
         Amount::from_sat(99_000_000),
         to_address.script_pubkey(),
     )]);
-    let tx_ins = TransactionBuilder::create_tx_ins(vec![utxo]);
-    let dummy_tx = TransactionBuilder::create_btc_tx(tx_ins, tx_outs);
+    let tx_ins = transaction_builder::create_tx_ins(vec![utxo]);
+    let dummy_tx = transaction_builder::create_btc_tx(tx_ins, tx_outs);
     let mut tx_details = TxHandler {
         tx: dummy_tx,
         prevouts: vec![prevout],
@@ -272,15 +272,15 @@ async fn test_musig2_script_spend() {
         bitcoin::Network::Regtest,
     );
     let (from_address, from_address_spend_info) =
-        TransactionBuilder::create_taproot_address(&scripts, None, bitcoin::Network::Regtest);
+        transaction_builder::create_taproot_address(&scripts, None, bitcoin::Network::Regtest);
     let utxo = rpc.send_to_address(&from_address, 100_000_000).unwrap();
     let prevout = rpc.get_txout_from_outpoint(&utxo).unwrap();
-    let tx_outs = TransactionBuilder::create_tx_outs(vec![(
+    let tx_outs = transaction_builder::create_tx_outs(vec![(
         Amount::from_sat(99_000_000),
         to_address.script_pubkey(),
     )]);
-    let tx_ins = TransactionBuilder::create_tx_ins(vec![utxo]);
-    let dummy_tx = TransactionBuilder::create_btc_tx(tx_ins, tx_outs);
+    let tx_ins = transaction_builder::create_tx_ins(vec![utxo]);
+    let dummy_tx = transaction_builder::create_btc_tx(tx_ins, tx_outs);
     let mut tx_details = TxHandler {
         tx: dummy_tx,
         prevouts: vec![prevout],


### PR DESCRIPTION
# Description

This PR adds unit tests to various modules that lacks code coverage.

## Testing

Comment out `#[tracing::instrument]` bits in the code and then run:

```sh
cargo llvm-cov --html
```

Then, open `target/llvm-cov/html/index.html` in a browser.

## Code Coverage Improvements

Numbers stated here could be misleading. Looks like macros sometimes cause wrong coverage reports. Results after disabling `#[tracing::instrument]`s:

Before:

![image](https://github.com/user-attachments/assets/825ded74-ad81-45e4-80ae-350646f33e15)

After:

![image](https://github.com/user-attachments/assets/990e3dbe-cac4-4f35-a241-f93f77968c8b)

## Skipped Code Portions

- `operator.rs`: Skipped testing code that checks and does some operations if Citrea client is present
- General database/encode/decode operations: Some operations can throw errors. Most of the cases, the error is caused by the module itself or user. It is not possible mimic a module failure or corrupt user data, mid-test.
- ? are ignored: They are mostly caused by the user and handled by the Rust itself. No need to check if error is not generated by the Clementine itself. It is a binary's responsible to handle these checks and print a helpful information.
- `tracing::debug!` like macros are reported as not covered. They are ignored. But it is noted that they are lowering code coverage percentage.