### PR TITLE
cargo: Remove debug flags and add release flags.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,16 +29,10 @@ sqlx = { version = "0.7.4", default-features = false }
 bitcoin-mock-rpc = { git = "https://github.com/chainwayxyz/bitcoin-mock-rpc", tag = "v0.0.11" }
 musig2 = { version = "0.0.11", features = ["serde"] }
 
-# Always optimize; building and running the guest takes much longer without optimization.
-[profile.dev]
-opt-level = 3
-
-[profile.dev.build-override]
-opt-level = 3
-
 [profile.release]
-debug = 1
 lto = true
-
-[profile.release.build-override]
-opt-level = 3
+strip = true
+codegen-units = 1
+# TODO: Abort on panic can be enabled to save binary space. But needs a proper
+# error management infrastructure to not lose crash report.
+# panic = "abort"


### PR DESCRIPTION
# Description

This PR modifies Cargo flags to achieve faster compilation times in tests and faster binaries in release mode.

Using default configuration for dev/test builds lowered compiling times significantly (on a Linux machine with 12th gen i5):

- Optimization level 3 (previous): 85.3s | 239M
- Optimization level z (for size): 57.6s | 150M
- Optimization level 0 (Cargo default): 21.6s | 180M

For debug/test builds, lower compilation times are king.

For release mode, some optimizations are enabled to lower binary size and improve execution speed. But resulted with increased compilation times.

## Linked Issues

- Closes #162 

## Testing

Build times are compared with Cargo's `--timings` flag. Binary sizes are compared with `du`.

All existing tests are checked if they are running correctly.