### PR TITLE
Use async Bitcoin RPC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serial_test = "3.2.0"
 bitcoin = "0.32.3"
 bitcoincore-rpc = "0.18.0"
 musig2 = { version = "0.0.11", features = ["serde"] }
-secp256k1 = { version = "0.29.1", features = ["serde"] }
+secp256k1 = { version = "0.29.1", features = ["serde", "rand-std"] }
 
 # async + gRPC
 tonic = { version = "0.12.3", features = [ "tls" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serial_test = "3.2.0"
 
 # bitcoin
 bitcoin = "0.32.3"
-bitcoincore-rpc = "0.19.0"
+bitcoincore-rpc = "0.18.0"
 musig2 = { version = "0.0.11", features = ["serde"] }
 secp256k1 = { version = "0.29.1", features = ["serde"] }
 
@@ -38,6 +38,9 @@ k256 = { version = "=0.13.3", default-features = false }
 risc0-build = "1.1.3"
 risc0-zkvm = { version = "1.1.3" }
 circuits = { git = "https://github.com/chainwayxyz/risc0-to-bitvm2" }
+
+[patch.crates-io]
+bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "ca3cfa2" }
 
 [profile.release]
 lto = true

--- a/core/src/bin/server.rs
+++ b/core/src/bin/server.rs
@@ -18,7 +18,8 @@ async fn main() {
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
-    );
+    )
+    .await;
 
     Database::run_schema_script(&config).await.unwrap();
 

--- a/core/src/extended_rpc.rs
+++ b/core/src/extended_rpc.rs
@@ -11,7 +11,6 @@ use bitcoin::Amount;
 use bitcoin::BlockHash;
 use bitcoin::OutPoint;
 use bitcoin::ScriptBuf;
-use bitcoin::Transaction;
 use bitcoin::TxOut;
 use bitcoin::XOnlyPublicKey;
 use bitcoincore_rpc::Auth;
@@ -127,48 +126,6 @@ impl ExtendedRpc {
         let txout = tx.output[outpoint.vout as usize].clone();
 
         Ok(txout)
-    }
-
-    // Following methods are just wrappers around the bitcoincore_rpc::Client methods
-    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub async fn fund_raw_transaction(
-        &self,
-        tx: &Transaction,
-        options: Option<&bitcoincore_rpc::json::FundRawTransactionOptions>,
-        is_witness: Option<bool>,
-    ) -> Result<bitcoincore_rpc::json::FundRawTransactionResult, bitcoincore_rpc::Error> {
-        self.client
-            .fund_raw_transaction(tx, options, is_witness)
-            .await
-    }
-
-    #[tracing::instrument(skip(self, tx, sighash_type), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub async fn sign_raw_transaction_with_wallet<T: bitcoincore_rpc::RawTx>(
-        &self,
-        tx: T,
-        utxos: Option<&[bitcoincore_rpc::json::SignRawTransactionInput]>,
-        sighash_type: Option<bitcoincore_rpc::json::SigHashType>,
-    ) -> Result<bitcoincore_rpc::json::SignRawTransactionResult, bitcoincore_rpc::Error> {
-        self.client
-            .sign_raw_transaction_with_wallet(tx, utxos, sighash_type)
-            .await
-    }
-
-    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub async fn get_raw_transaction(
-        &self,
-        txid: &bitcoin::Txid,
-        block_hash: Option<&bitcoin::BlockHash>,
-    ) -> Result<bitcoin::Transaction, bitcoincore_rpc::Error> {
-        self.client.get_raw_transaction(txid, block_hash).await
-    }
-
-    #[tracing::instrument(skip(self, tx), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub async fn send_raw_transaction<T: bitcoincore_rpc::RawTx>(
-        &self,
-        tx: T,
-    ) -> Result<bitcoin::Txid, bitcoincore_rpc::Error> {
-        self.client.send_raw_transaction(tx).await
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]

--- a/core/src/extended_rpc.rs
+++ b/core/src/extended_rpc.rs
@@ -31,10 +31,11 @@ impl ExtendedRpc {
     /// # Panics
     ///
     /// Panics if it cannot connect to Bitcoin RPC.
-    pub fn new(url: String, user: String, password: String) -> Self {
+    pub async fn new(url: String, user: String, password: String) -> Self {
         let auth = Auth::UserPass(user, password);
 
         let rpc = Client::new(&url, auth.clone())
+            .await
             .unwrap_or_else(|e| panic!("Failed to connect to Bitcoin RPC: {}", e));
 
         Self {
@@ -45,8 +46,8 @@ impl ExtendedRpc {
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn confirmation_blocks(&self, txid: &bitcoin::Txid) -> Result<u32, BridgeError> {
-        let raw_transaction_results = self.client.get_raw_transaction_info(txid, None)?;
+    pub async fn confirmation_blocks(&self, txid: &bitcoin::Txid) -> Result<u32, BridgeError> {
+        let raw_transaction_results = self.client.get_raw_transaction_info(txid, None).await?;
 
         raw_transaction_results
             .confirmations
@@ -54,13 +55,16 @@ impl ExtendedRpc {
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn check_utxo_address_and_amount(
+    pub async fn check_utxo_address_and_amount(
         &self,
         outpoint: &OutPoint,
         address: &ScriptBuf,
         amount_sats: Amount,
     ) -> Result<bool, BridgeError> {
-        let tx = self.client.get_raw_transaction(&outpoint.txid, None)?;
+        let tx = self
+            .client
+            .get_raw_transaction(&outpoint.txid, None)
+            .await?;
 
         let current_output = tx.output[outpoint.vout as usize].clone();
 
@@ -73,48 +77,53 @@ impl ExtendedRpc {
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn is_utxo_spent(&self, outpoint: &OutPoint) -> Result<bool, BridgeError> {
+    pub async fn is_utxo_spent(&self, outpoint: &OutPoint) -> Result<bool, BridgeError> {
         let res = self
             .client
-            .get_tx_out(&outpoint.txid, outpoint.vout, Some(true))?;
+            .get_tx_out(&outpoint.txid, outpoint.vout, Some(true))
+            .await?;
 
         Ok(res.is_none())
     }
 
     /// Mines blocks to a new address.
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn mine_blocks(&self, block_num: u64) -> Result<Vec<BlockHash>, BridgeError> {
-        let new_address = self.client.get_new_address(None, None)?.assume_checked();
+    pub async fn mine_blocks(&self, block_num: u64) -> Result<Vec<BlockHash>, BridgeError> {
+        let new_address = self
+            .client
+            .get_new_address(None, None)
+            .await?
+            .assume_checked();
 
-        Ok(self.client.generate_to_address(block_num, &new_address)?)
+        Ok(self
+            .client
+            .generate_to_address(block_num, &new_address)
+            .await?)
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn send_to_address(
+    pub async fn send_to_address(
         &self,
         address: &Address,
         amount_sats: Amount,
     ) -> Result<OutPoint, BridgeError> {
-        let txid = self.client.send_to_address(
-            address,
-            amount_sats,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        )?;
+        let txid = self
+            .client
+            .send_to_address(address, amount_sats, None, None, None, None, None, None)
+            .await?;
 
-        let tx_result = self.client.get_transaction(&txid, None)?;
+        let tx_result = self.client.get_transaction(&txid, None).await?;
         let vout = tx_result.details[0].vout;
 
         Ok(OutPoint { txid, vout })
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn get_txout_from_outpoint(&self, outpoint: &OutPoint) -> Result<TxOut, BridgeError> {
-        let tx = self.client.get_raw_transaction(&outpoint.txid, None)?;
+    pub async fn get_txout_from_outpoint(&self, outpoint: &OutPoint) -> Result<TxOut, BridgeError> {
+        let tx = self
+            .client
+            .get_raw_transaction(&outpoint.txid, None)
+            .await?;
         let txout = tx.output[outpoint.vout as usize].clone();
 
         Ok(txout)
@@ -122,17 +131,19 @@ impl ExtendedRpc {
 
     // Following methods are just wrappers around the bitcoincore_rpc::Client methods
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn fund_raw_transaction(
+    pub async fn fund_raw_transaction(
         &self,
         tx: &Transaction,
         options: Option<&bitcoincore_rpc::json::FundRawTransactionOptions>,
         is_witness: Option<bool>,
     ) -> Result<bitcoincore_rpc::json::FundRawTransactionResult, bitcoincore_rpc::Error> {
-        self.client.fund_raw_transaction(tx, options, is_witness)
+        self.client
+            .fund_raw_transaction(tx, options, is_witness)
+            .await
     }
 
     #[tracing::instrument(skip(self, tx, sighash_type), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn sign_raw_transaction_with_wallet<T: bitcoincore_rpc::RawTx>(
+    pub async fn sign_raw_transaction_with_wallet<T: bitcoincore_rpc::RawTx>(
         &self,
         tx: T,
         utxos: Option<&[bitcoincore_rpc::json::SignRawTransactionInput]>,
@@ -140,27 +151,28 @@ impl ExtendedRpc {
     ) -> Result<bitcoincore_rpc::json::SignRawTransactionResult, bitcoincore_rpc::Error> {
         self.client
             .sign_raw_transaction_with_wallet(tx, utxos, sighash_type)
+            .await
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn get_raw_transaction(
+    pub async fn get_raw_transaction(
         &self,
         txid: &bitcoin::Txid,
         block_hash: Option<&bitcoin::BlockHash>,
     ) -> Result<bitcoin::Transaction, bitcoincore_rpc::Error> {
-        self.client.get_raw_transaction(txid, block_hash)
+        self.client.get_raw_transaction(txid, block_hash).await
     }
 
     #[tracing::instrument(skip(self, tx), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn send_raw_transaction<T: bitcoincore_rpc::RawTx>(
+    pub async fn send_raw_transaction<T: bitcoincore_rpc::RawTx>(
         &self,
         tx: T,
     ) -> Result<bitcoin::Txid, bitcoincore_rpc::Error> {
-        self.client.send_raw_transaction(tx)
+        self.client.send_raw_transaction(tx).await
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn check_deposit_utxo(
+    pub async fn check_deposit_utxo(
         &self,
         nofn_xonly_pk: XOnlyPublicKey,
         deposit_outpoint: &OutPoint,
@@ -171,7 +183,7 @@ impl ExtendedRpc {
         network: bitcoin::Network,
         user_takes_after: u32,
     ) -> Result<(), BridgeError> {
-        if self.confirmation_blocks(&deposit_outpoint.txid)? < confirmation_block_count {
+        if self.confirmation_blocks(&deposit_outpoint.txid).await? < confirmation_block_count {
             return Err(BridgeError::DepositNotFinalized);
         }
 
@@ -184,15 +196,18 @@ impl ExtendedRpc {
             user_takes_after,
         );
 
-        if !self.check_utxo_address_and_amount(
-            deposit_outpoint,
-            &deposit_address.script_pubkey(),
-            amount_sats,
-        )? {
+        if !self
+            .check_utxo_address_and_amount(
+                deposit_outpoint,
+                &deposit_address.script_pubkey(),
+                amount_sats,
+            )
+            .await?
+        {
             return Err(BridgeError::InvalidDepositUTXO);
         }
 
-        if self.is_utxo_spent(deposit_outpoint)? {
+        if self.is_utxo_spent(deposit_outpoint).await? {
             return Err(BridgeError::UTXOSpent);
         }
 
@@ -202,7 +217,7 @@ impl ExtendedRpc {
 
 impl Clone for ExtendedRpc {
     fn clone(&self) -> Self {
-        let new_client = Client::new(&self.url, self.auth.clone())
+        let new_client = futures::executor::block_on(Client::new(&self.url, self.auth.clone()))
             .unwrap_or_else(|e| panic!("Failed to clone Bitcoin RPC client: {}", e));
 
         Self {

--- a/core/src/header_chain_prover/blockgazer.rs
+++ b/core/src/header_chain_prover/blockgazer.rs
@@ -77,7 +77,10 @@ impl HeaderChainProver {
         } else {
             let new_height = db_tip_height + BATCH_DEEPNESS - BATCH_DEEPNESS_SAFETY_BARRIER;
 
-            (new_height, self.rpc.client.get_block_hash(new_height).await?)
+            (
+                new_height,
+                self.rpc.client.get_block_hash(new_height).await?,
+            )
         };
         tracing::debug!("Fetching blocks between {db_tip_height}-{height}");
 
@@ -93,7 +96,8 @@ impl HeaderChainProver {
             prev_block_hash = self
                 .rpc
                 .client
-                .get_block_header(&current_block_hash).await?
+                .get_block_header(&current_block_hash)
+                .await?
                 .prev_blockhash;
 
             let header = self
@@ -212,18 +216,20 @@ mod tests {
     async fn mine_and_save_blocks(prover: &HeaderChainProver, height: u64) -> Vec<BlockHash> {
         let mut fork_block_hashes = Vec::new();
         for _ in 0..height {
-            prover.rpc.mine_blocks(1).unwrap();
+            prover.rpc.mine_blocks(1).await.unwrap();
 
             let current_tip_height = prover.rpc.client.get_block_count().await.unwrap();
             let current_tip_hash: BlockHash = prover
                 .rpc
                 .client
-                .get_block_hash(current_tip_height).await
+                .get_block_hash(current_tip_height)
+                .await
                 .unwrap();
             let current_block_header = prover
                 .rpc
                 .client
-                .get_block(&current_tip_hash).await
+                .get_block(&current_tip_hash)
+                .await
                 .unwrap()
                 .header;
 
@@ -252,7 +258,8 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
         let prover = HeaderChainProver::new(&config, rpc.clone()).await.unwrap();
 
         // Save current blockchain tip.
@@ -285,7 +292,8 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
         let prover = HeaderChainProver::new(&config, rpc.clone()).await.unwrap();
 
         // Mine initial block and save it to database.
@@ -295,17 +303,18 @@ mod tests {
             BlockFetchStatus::UpToDate
         );
         assert_eq!(block_hashes.len(), 1);
-        let current_tip_height = rpc.client.get_block_count().unwrap();
+        let current_tip_height = rpc.client.get_block_count().await.unwrap();
         println!(
             "Initial block height is {current_tip_height} and hash is {}",
             *block_hashes.first().unwrap()
         );
 
         // Mine a block but don't save it to database.
-        rpc.mine_blocks(1).unwrap();
+        rpc.mine_blocks(1).await.unwrap();
         let current_tip_hash = rpc
             .client
-            .get_block_hash(rpc.client.get_block_count().unwrap())
+            .get_block_hash(rpc.client.get_block_count().await.unwrap())
+            .await
             .unwrap();
         assert_ne!(current_tip_hash, *block_hashes.first().unwrap());
 
@@ -324,7 +333,8 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
         let prover = HeaderChainProver::new(&config, rpc.clone()).await.unwrap();
 
         // Mine initial block and save it to database.
@@ -333,11 +343,11 @@ mod tests {
             prover.check_for_new_blocks().await.unwrap(),
             BlockFetchStatus::UpToDate
         );
-        let initial_tip_height = rpc.client.get_block_count().unwrap();
+        let initial_tip_height = rpc.client.get_block_count().await.unwrap();
 
         // Mine some blocks but don't save them to database.
         let amount = BATCH_DEEPNESS - BATCH_DEEPNESS_SAFETY_BARRIER - 1;
-        let block_hashes = rpc.mine_blocks(amount).unwrap();
+        let block_hashes = rpc.mine_blocks(amount).await.unwrap();
 
         // Falling behind some blocks should return those blocks' hash.
         assert_eq!(
@@ -354,21 +364,22 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
         let prover = HeaderChainProver::new(&config, rpc.clone()).await.unwrap();
 
         // Save initial block.
         mine_and_save_blocks(&prover, 1).await;
-        let initial_tip_height = rpc.client.get_block_count().unwrap();
+        let initial_tip_height = rpc.client.get_block_count().await.unwrap();
 
         // Save the next 3 blocks to database, then invalidate.
         let mut fork_block_hashes = mine_and_save_blocks(&prover, 3).await;
         fork_block_hashes.reverse();
-        fork_block_hashes
-            .iter()
-            .for_each(|hash| rpc.client.invalidate_block(hash).unwrap());
+        fork_block_hashes.iter().for_each(|hash| {
+            futures::executor::block_on(rpc.client.invalidate_block(hash)).unwrap()
+        });
 
-        let hashes = rpc.mine_blocks(3).unwrap();
+        let hashes = rpc.mine_blocks(3).await.unwrap();
 
         // Same thing as not saving 3 blocks after they are mined.
         assert_eq!(
@@ -385,15 +396,16 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
         let prover = HeaderChainProver::new(&config, rpc.clone()).await.unwrap();
 
         // Save current blockchain tip.
         mine_and_save_blocks(&prover, 1).await;
-        let current_tip_height = rpc.client.get_block_count().unwrap();
+        let current_tip_height = rpc.client.get_block_count().await.unwrap();
 
         // Falling behind some blocks.
-        let hash = rpc.mine_blocks(1).unwrap();
+        let hash = rpc.mine_blocks(1).await.unwrap();
         assert_eq!(
             prover.check_for_new_blocks().await.unwrap(),
             BlockFetchStatus::FallenBehind(current_tip_height, hash.clone())
@@ -418,15 +430,16 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
         let prover = HeaderChainProver::new(&config, rpc.clone()).await.unwrap();
 
         // Save current blockchain tip.
         mine_and_save_blocks(&prover, 1).await;
-        let current_tip_height = rpc.client.get_block_count().unwrap();
+        let current_tip_height = rpc.client.get_block_count().await.unwrap();
 
         // Falling behind some blocks.
-        let hash = rpc.mine_blocks(10).unwrap();
+        let hash = rpc.mine_blocks(10).await.unwrap();
         assert_eq!(
             prover.check_for_new_blocks().await.unwrap(),
             BlockFetchStatus::FallenBehind(current_tip_height, hash.clone())
@@ -451,15 +464,16 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
         let prover = HeaderChainProver::new(&config, rpc.clone()).await.unwrap();
 
         // Save current blockchain tip.
         mine_and_save_blocks(&prover, 1).await;
-        let current_tip_height = rpc.client.get_block_count().unwrap();
+        let current_tip_height = rpc.client.get_block_count().await.unwrap();
 
         // Falling behind some blocks and recovering from it.
-        let hash = rpc.mine_blocks(10).unwrap();
+        let hash = rpc.mine_blocks(10).await.unwrap();
         prover
             .sync_blockchain(current_tip_height, hash.clone())
             .await
@@ -470,8 +484,11 @@ mod tests {
         );
 
         // Latest block got invalidated, later to be replaced with new block.
-        rpc.client.invalidate_block(hash.last().unwrap()).unwrap();
-        let current_tip_height = rpc.client.get_block_count().unwrap();
+        rpc.client
+            .invalidate_block(hash.last().unwrap())
+            .await
+            .unwrap();
+        let current_tip_height = rpc.client.get_block_count().await.unwrap();
         // Beware that this state will never be present in Bitcoin.
         assert_ne!(
             prover.check_for_new_blocks().await.unwrap(),
@@ -479,7 +496,7 @@ mod tests {
         );
 
         // Synching should recover state after mining new blocks.
-        let hashes = rpc.mine_blocks(1).unwrap();
+        let hashes = rpc.mine_blocks(1).await.unwrap();
         prover
             .sync_blockchain(current_tip_height, hashes)
             .await

--- a/core/src/header_chain_prover/prover.rs
+++ b/core/src/header_chain_prover/prover.rs
@@ -165,7 +165,8 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
         let prover = HeaderChainProver::new(&config, rpc.clone()).await.unwrap();
 
         let receipt = prover.prove_block_headers(None, vec![]).await.unwrap();
@@ -188,7 +189,8 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
         let prover = HeaderChainProver::new(&config, rpc.clone()).await.unwrap();
 
         // Prove genesis block and get it's receipt.
@@ -214,7 +216,8 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
         let prover = HeaderChainProver::new(&config, rpc.clone()).await.unwrap();
         let block_headers = get_headers();
 

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -81,7 +81,9 @@ impl Operator {
         // check if there is any time tx from the current operator
         let time_txs = db.get_time_txs(Some(&mut tx), idx as i32).await?;
         if time_txs.is_empty() {
-            let outpoint = rpc.send_to_address(&signer.address, Amount::from_sat(200_000_000))?; // TODO: Is this OK to be a fixed value
+            let outpoint = rpc
+                .send_to_address(&signer.address, Amount::from_sat(200_000_000))
+                .await?; // TODO: Is this OK to be a fixed value
             db.set_time_tx(Some(&mut tx), idx as i32, 0, outpoint.txid, 0)
                 .await?;
         }
@@ -138,16 +140,18 @@ impl Operator {
         );
 
         // 1. Check if the deposit UTXO is valid, finalized (6 blocks confirmation) and not spent
-        self.rpc.check_deposit_utxo(
-            self.nofn_xonly_pk,
-            &deposit_outpoint,
-            &recovery_taproot_address,
-            evm_address,
-            self.config.bridge_amount_sats,
-            self.config.confirmation_threshold,
-            self.config.network,
-            self.config.user_takes_after,
-        )?;
+        self.rpc
+            .check_deposit_utxo(
+                self.nofn_xonly_pk,
+                &deposit_outpoint,
+                &recovery_taproot_address,
+                evm_address,
+                self.config.bridge_amount_sats,
+                self.config.confirmation_threshold,
+                self.config.network,
+                self.config.user_takes_after,
+            )
+            .await?;
 
         let mut tx = self.db.begin_transaction().await?;
 
@@ -466,17 +470,19 @@ impl Operator {
                     estimate_mode: None,
                 }),
                 None,
-            )?
+            )
+            .await?
             .hex;
 
         let signed_tx: Transaction = deserialize(
             &self
                 .rpc
-                .sign_raw_transaction_with_wallet(&funded_tx, None, None)?
+                .sign_raw_transaction_with_wallet(&funded_tx, None, None)
+                .await?
                 .hex,
         )?;
 
-        Ok(self.rpc.send_raw_transaction(&signed_tx)?)
+        Ok(self.rpc.send_raw_transaction(&signed_tx).await?)
     }
 
     /// Checks Citrea if a withdrawal is finalized.
@@ -577,6 +583,7 @@ impl Operator {
             if self
                 .rpc
                 .get_raw_transaction(&current_searching_txid, None)
+                .await
                 .is_ok()
             {
                 found_txid = true;
@@ -737,7 +744,8 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
 
         let operator = Operator::new(config, rpc).await.unwrap();
 
@@ -769,7 +777,8 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
         let operator = create_operator_server(config, rpc).await.unwrap();
 
         let funding_utxo = UTXO {
@@ -796,7 +805,8 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
 
         config.bridge_amount_sats = Amount::from_sat(0x45);
         config.operator_withdrawal_fee_sats = Some(Amount::from_sat(0x1F));

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -15,7 +15,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::script::PushBytesBuf;
 use bitcoin::sighash::SighashCache;
 use bitcoin::{Address, Amount, OutPoint, TapSighash, Transaction, TxOut, Txid};
-use bitcoincore_rpc::RawTx;
+use bitcoincore_rpc::{RawTx, RpcApi};
 use jsonrpsee::core::async_trait;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClientBuilder;
@@ -454,6 +454,7 @@ impl Operator {
 
         let funded_tx = self
             .rpc
+            .client
             .fund_raw_transaction(
                 &tx,
                 Some(&bitcoincore_rpc::json::FundRawTransactionOptions {
@@ -477,12 +478,13 @@ impl Operator {
         let signed_tx: Transaction = deserialize(
             &self
                 .rpc
+                .client
                 .sign_raw_transaction_with_wallet(&funded_tx, None, None)
                 .await?
                 .hex,
         )?;
 
-        Ok(self.rpc.send_raw_transaction(&signed_tx).await?)
+        Ok(self.rpc.client.send_raw_transaction(&signed_tx).await?)
     }
 
     /// Checks Citrea if a withdrawal is finalized.
@@ -582,6 +584,7 @@ impl Operator {
         for _ in 0..25 {
             if self
                 .rpc
+                .client
                 .get_raw_transaction(&current_searching_txid, None)
                 .await
                 .is_ok()

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -139,7 +139,8 @@ pub async fn create_verifiers_and_operators(
         config.bitcoin_rpc_url,
         config.bitcoin_rpc_user,
         config.bitcoin_rpc_password,
-    );
+    )
+    .await;
     let all_verifiers_secret_keys = config.all_verifiers_secret_keys.clone().unwrap_or_else(|| {
         panic!("All secret keys of the verifiers are required for testing");
     });
@@ -335,7 +336,8 @@ pub async fn create_verifiers_and_operators_grpc(
         config.bitcoin_rpc_url,
         config.bitcoin_rpc_user,
         config.bitcoin_rpc_password,
-    );
+    )
+    .await;
     let all_verifiers_secret_keys = config.all_verifiers_secret_keys.clone().unwrap_or_else(|| {
         panic!("All secret keys of the verifiers are required for testing");
     });

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -41,12 +41,13 @@ impl User {
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn deposit_tx(&self, evm_address: EVMAddress) -> Result<OutPoint, BridgeError> {
+    pub async fn deposit_tx(&self, evm_address: EVMAddress) -> Result<OutPoint, BridgeError> {
         let deposit_address = self.get_deposit_address(evm_address)?;
 
         let deposit_outpoint = self
             .rpc
-            .send_to_address(&deposit_address, self.config.bridge_amount_sats)?;
+            .send_to_address(&deposit_address, self.config.bridge_amount_sats)
+            .await?;
 
         Ok(deposit_outpoint)
     }
@@ -73,14 +74,15 @@ impl User {
     /// - `TxOut`: Withdrawal transaction output
     /// - `Signature`: Schnorr signature of the withdrawal transaction
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    pub fn generate_withdrawal_transaction_and_signature(
+    pub async fn generate_withdrawal_transaction_and_signature(
         &self,
         withdrawal_address: Address,
         withdrawal_amount: Amount,
     ) -> Result<(UTXO, TxOut, schnorr::Signature), BridgeError> {
         let dust_outpoint = self
             .rpc
-            .send_to_address(&self.signer.address, WITHDRAWAL_EMPTY_UTXO_SATS)?;
+            .send_to_address(&self.signer.address, WITHDRAWAL_EMPTY_UTXO_SATS)
+            .await?;
         let dust_utxo = UTXO {
             outpoint: dust_outpoint,
             txout: TxOut {
@@ -126,14 +128,18 @@ mod tests {
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
-        );
+        )
+        .await;
 
         let evm_address = EVMAddress([0x45u8; 20]);
         let sk = SecretKey::new(&mut rand::thread_rng());
         let user = User::new(rpc.clone(), sk, config.clone());
 
-        let deposit_utxo = user.deposit_tx(evm_address).unwrap();
-        let deposit_txout = rpc.get_raw_transaction(&deposit_utxo.txid, None).unwrap();
+        let deposit_utxo = user.deposit_tx(evm_address).await.unwrap();
+        let deposit_txout = rpc
+            .get_raw_transaction(&deposit_utxo.txid, None)
+            .await
+            .unwrap();
 
         assert_eq!(
             deposit_txout

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -118,6 +118,7 @@ mod tests {
     use crate::mock::database::create_test_config_with_thread_name;
     use crate::user::User;
     use crate::EVMAddress;
+    use bitcoincore_rpc::RpcApi;
     use secp256k1::{rand, SecretKey};
 
     #[tokio::test]
@@ -137,6 +138,7 @@ mod tests {
 
         let deposit_utxo = user.deposit_tx(evm_address).await.unwrap();
         let deposit_txout = rpc
+            .client
             .get_raw_transaction(&deposit_utxo.txid, None)
             .await
             .unwrap();

--- a/core/tests/common/deposit.rs
+++ b/core/tests/common/deposit.rs
@@ -27,7 +27,8 @@ pub async fn run_multiple_deposits(test_config_name: &str) {
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
-    );
+    )
+    .await;
     let secp = secp256k1::Secp256k1::new();
     let (verifiers, operators, aggregator) =
         create_verifiers_and_operators("test_config.toml").await;
@@ -49,9 +50,10 @@ pub async fn run_multiple_deposits(test_config_name: &str) {
     for _ in 0..config.operator_num_kickoff_utxos_per_tx + 1 {
         let deposit_outpoint = rpc
             .send_to_address(&deposit_address, config.bridge_amount_sats)
+            .await
             .unwrap();
 
-        rpc.mine_blocks(18).unwrap();
+        rpc.mine_blocks(18).await.unwrap();
 
         let mut pub_nonces = Vec::new();
 
@@ -152,7 +154,7 @@ pub async fn run_multiple_deposits(test_config_name: &str) {
         let move_tx: Transaction = deserialize_hex(&move_tx).unwrap();
 
         println!("Move tx weight: {:?}", move_tx.weight());
-        let move_txid = rpc.send_raw_transaction(&move_tx).unwrap();
+        let move_txid = rpc.send_raw_transaction(&move_tx).await.unwrap();
         println!("Move txid: {:?}", move_txid);
         deposit_outpoints.push(deposit_outpoint);
     }
@@ -170,6 +172,7 @@ pub async fn run_multiple_deposits(test_config_name: &str) {
                     - 2 * config.operator_withdrawal_fee_sats.unwrap().to_sat(),
             ),
         )
+        .await
         .unwrap();
     let withdrawal_provide_txid = operators[0]
         .0
@@ -191,6 +194,7 @@ pub async fn run_multiple_deposits(test_config_name: &str) {
                     - 2 * config.operator_withdrawal_fee_sats.unwrap().to_sat(),
             ),
         )
+        .await
         .unwrap();
     let withdrawal_provide_txid = operators[1]
         .0
@@ -220,6 +224,7 @@ pub async fn run_multiple_deposits(test_config_name: &str) {
                     - 2 * config.operator_withdrawal_fee_sats.unwrap().to_sat(),
             ),
         )
+        .await
         .unwrap();
     let withdrawal_provide_txid = operators[0]
         .0
@@ -254,7 +259,8 @@ pub async fn run_single_deposit(
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
-    );
+    )
+    .await;
 
     let secret_key = secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng());
     let signer_address = Actor::new(secret_key, config.network)
@@ -272,8 +278,9 @@ pub async fn run_single_deposit(
 
     let deposit_outpoint = rpc
         .send_to_address(&deposit_address, config.bridge_amount_sats)
+        .await
         .unwrap();
-    rpc.mine_blocks(18).unwrap();
+    rpc.mine_blocks(18).await.unwrap();
 
     // for every verifier, we call new_deposit
     // aggregate nonces
@@ -383,7 +390,7 @@ pub async fn run_single_deposit(
     let move_tx: Transaction = deserialize_hex(&move_tx).unwrap();
     println!("Move tx weight: {:?}", move_tx.weight());
 
-    let move_txid = rpc.send_raw_transaction(&move_tx).unwrap();
+    let move_txid = rpc.send_raw_transaction(&move_tx).await.unwrap();
     println!("Move txid: {:?}", move_txid);
 
     Ok((verifiers, operators, config, deposit_outpoint))

--- a/core/tests/common/deposit.rs
+++ b/core/tests/common/deposit.rs
@@ -5,6 +5,7 @@ use bitcoin::Address;
 use bitcoin::Amount;
 use bitcoin::OutPoint;
 use bitcoin::Transaction;
+use bitcoincore_rpc::RpcApi;
 use clementine_core::actor::Actor;
 use clementine_core::config::BridgeConfig;
 use clementine_core::errors::BridgeError;
@@ -154,7 +155,7 @@ pub async fn run_multiple_deposits(test_config_name: &str) {
         let move_tx: Transaction = deserialize_hex(&move_tx).unwrap();
 
         println!("Move tx weight: {:?}", move_tx.weight());
-        let move_txid = rpc.send_raw_transaction(&move_tx).await.unwrap();
+        let move_txid = rpc.client.send_raw_transaction(&move_tx).await.unwrap();
         println!("Move txid: {:?}", move_txid);
         deposit_outpoints.push(deposit_outpoint);
     }
@@ -390,7 +391,7 @@ pub async fn run_single_deposit(
     let move_tx: Transaction = deserialize_hex(&move_tx).unwrap();
     println!("Move tx weight: {:?}", move_tx.weight());
 
-    let move_txid = rpc.send_raw_transaction(&move_tx).await.unwrap();
+    let move_txid = rpc.client.send_raw_transaction(&move_tx).await.unwrap();
     println!("Move txid: {:?}", move_txid);
 
     Ok((verifiers, operators, config, deposit_outpoint))

--- a/core/tests/deposit.rs
+++ b/core/tests/deposit.rs
@@ -22,7 +22,8 @@ async fn deposit_with_retry_checks() {
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
-    );
+    )
+    .await;
 
     let secret_key = secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng());
     let signer_address = Actor::new(secret_key, config.network)
@@ -36,8 +37,10 @@ async fn deposit_with_retry_checks() {
 
     let deposit_outpoint = rpc
         .send_to_address(&deposit_address, config.bridge_amount_sats)
+        .await
         .unwrap();
     rpc.mine_blocks((config.confirmation_threshold + 2).into())
+        .await
         .unwrap();
 
     let (verifiers, operators, aggregator) =

--- a/core/tests/flow.rs
+++ b/core/tests/flow.rs
@@ -28,7 +28,8 @@ async fn honest_operator_takes_refund() {
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
-    );
+    )
+    .await;
 
     let user_sk = SecretKey::from_slice(&[13u8; 32]).unwrap();
     let user = User::new(rpc.clone(), user_sk, config.clone());
@@ -49,6 +50,7 @@ async fn honest_operator_takes_refund() {
 
     let (empty_utxo, withdrawal_tx_out, user_sig) = user
         .generate_withdrawal_transaction_and_signature(withdrawal_address, withdrawal_amount)
+        .await
         .unwrap();
 
     let _withdrawal_provide_txid = operators[1]
@@ -64,17 +66,22 @@ async fn honest_operator_takes_refund() {
         .unwrap();
 
     for tx in txs_to_be_sent.iter().take(txs_to_be_sent.len() - 1) {
-        rpc.send_raw_transaction(tx.clone()).unwrap();
-        rpc.mine_blocks(1).unwrap();
+        rpc.send_raw_transaction(tx.clone()).await.unwrap();
+        rpc.mine_blocks(1).await.unwrap();
     }
     rpc.mine_blocks(1 + config.operator_takes_after as u64)
+        .await
         .unwrap();
 
     // Send last transaction.
     let operator_take_txid = rpc
         .send_raw_transaction(txs_to_be_sent.last().unwrap().clone())
+        .await
         .unwrap();
-    let operator_take_tx = rpc.get_raw_transaction(&operator_take_txid, None).unwrap();
+    let operator_take_tx = rpc
+        .get_raw_transaction(&operator_take_txid, None)
+        .await
+        .unwrap();
 
     assert!(operator_take_tx.output[0].value > withdrawal_amount);
 
@@ -95,7 +102,8 @@ async fn withdrawal_fee_too_low() {
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
-    );
+    )
+    .await;
 
     let user_sk = SecretKey::from_slice(&[12u8; 32]).unwrap();
     let withdrawal_address = Address::p2tr(
@@ -113,6 +121,7 @@ async fn withdrawal_fee_too_low() {
             withdrawal_address,
             Amount::from_sat(config.bridge_amount_sats.to_sat()),
         )
+        .await
         .unwrap();
 
     // Operator will reject because it its not profitable.

--- a/core/tests/flow.rs
+++ b/core/tests/flow.rs
@@ -5,6 +5,7 @@
 use std::str::FromStr;
 
 use bitcoin::{Address, Amount, Txid};
+use bitcoincore_rpc::RpcApi;
 use clementine_core::errors::BridgeError;
 use clementine_core::extended_rpc::ExtendedRpc;
 use clementine_core::rpc::clementine::clementine_aggregator_client::ClementineAggregatorClient;
@@ -66,7 +67,7 @@ async fn honest_operator_takes_refund() {
         .unwrap();
 
     for tx in txs_to_be_sent.iter().take(txs_to_be_sent.len() - 1) {
-        rpc.send_raw_transaction(tx.clone()).await.unwrap();
+        rpc.client.send_raw_transaction(tx.clone()).await.unwrap();
         rpc.mine_blocks(1).await.unwrap();
     }
     rpc.mine_blocks(1 + config.operator_takes_after as u64)
@@ -75,10 +76,12 @@ async fn honest_operator_takes_refund() {
 
     // Send last transaction.
     let operator_take_txid = rpc
+        .client
         .send_raw_transaction(txs_to_be_sent.last().unwrap().clone())
         .await
         .unwrap();
     let operator_take_tx = rpc
+        .client
         .get_raw_transaction(&operator_take_txid, None)
         .await
         .unwrap();

--- a/core/tests/musig2.rs
+++ b/core/tests/musig2.rs
@@ -1,5 +1,6 @@
 use bitcoin::opcodes::all::OP_CHECKSIG;
 use bitcoin::{hashes::Hash, script, Amount, ScriptBuf};
+use bitcoincore_rpc::RpcApi;
 use clementine_core::builder::transaction::TxHandler;
 use clementine_core::mock::database::create_test_config_with_thread_name;
 use clementine_core::musig2::{
@@ -147,7 +148,10 @@ async fn key_spend() {
     .unwrap();
 
     tx_details.tx.input[0].witness.push(final_signature);
-    rpc.send_raw_transaction(&tx_details.tx).await.unwrap();
+    rpc.client
+        .send_raw_transaction(&tx_details.tx)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -241,7 +245,10 @@ async fn key_spend_with_script() {
     .unwrap();
 
     tx_details.tx.input[0].witness.push(final_signature);
-    rpc.send_raw_transaction(&tx_details.tx).await.unwrap();
+    rpc.client
+        .send_raw_transaction(&tx_details.tx)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -341,5 +348,8 @@ async fn script_spend() {
     let witness_elements = vec![schnorr_sig.as_ref()];
     handle_taproot_witness_new(&mut tx_details, &witness_elements, 0, Some(0)).unwrap();
 
-    rpc.send_raw_transaction(&tx_details.tx).await.unwrap();
+    rpc.client
+        .send_raw_transaction(&tx_details.tx)
+        .await
+        .unwrap();
 }

--- a/core/tests/musig2.rs
+++ b/core/tests/musig2.rs
@@ -70,7 +70,8 @@ async fn key_spend() {
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
-    );
+    )
+    .await;
 
     let (verifiers_secret_public_keys, untweaked_xonly_pubkey, verifier_public_keys) =
         get_verifiers_keys(&config);
@@ -82,8 +83,9 @@ async fn key_spend() {
 
     let utxo = rpc
         .send_to_address(&from_address, Amount::from_sat(100_000_000))
+        .await
         .unwrap();
-    let prevout = rpc.get_txout_from_outpoint(&utxo).unwrap();
+    let prevout = rpc.get_txout_from_outpoint(&utxo).await.unwrap();
 
     let tx_ins = builder::transaction::create_tx_ins(vec![utxo]);
     let tx_outs = builder::transaction::create_tx_outs(vec![(
@@ -145,7 +147,7 @@ async fn key_spend() {
     .unwrap();
 
     tx_details.tx.input[0].witness.push(final_signature);
-    rpc.send_raw_transaction(&tx_details.tx).unwrap();
+    rpc.send_raw_transaction(&tx_details.tx).await.unwrap();
 }
 
 #[tokio::test]
@@ -156,7 +158,8 @@ async fn key_spend_with_script() {
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
-    );
+    )
+    .await;
 
     let (verifiers_secret_public_keys, untweaked_xonly_pubkey, verifier_public_keys) =
         get_verifiers_keys(&config);
@@ -174,8 +177,9 @@ async fn key_spend_with_script() {
 
     let utxo = rpc
         .send_to_address(&from_address, Amount::from_sat(100_000_000))
+        .await
         .unwrap();
-    let prevout = rpc.get_txout_from_outpoint(&utxo).unwrap();
+    let prevout = rpc.get_txout_from_outpoint(&utxo).await.unwrap();
     let tx_outs = builder::transaction::create_tx_outs(vec![(
         Amount::from_sat(99_000_000),
         to_address.script_pubkey(),
@@ -237,7 +241,7 @@ async fn key_spend_with_script() {
     .unwrap();
 
     tx_details.tx.input[0].witness.push(final_signature);
-    rpc.send_raw_transaction(&tx_details.tx).unwrap();
+    rpc.send_raw_transaction(&tx_details.tx).await.unwrap();
 }
 
 #[tokio::test]
@@ -248,7 +252,8 @@ async fn script_spend() {
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
-    );
+    )
+    .await;
 
     let (verifiers_secret_public_keys, _untweaked_xonly_pubkey, verifier_public_keys) =
         get_verifiers_keys(&config);
@@ -279,8 +284,9 @@ async fn script_spend() {
 
     let utxo = rpc
         .send_to_address(&from_address, Amount::from_sat(100_000_000))
+        .await
         .unwrap();
-    let prevout = rpc.get_txout_from_outpoint(&utxo).unwrap();
+    let prevout = rpc.get_txout_from_outpoint(&utxo).await.unwrap();
     let tx_outs = builder::transaction::create_tx_outs(vec![(
         Amount::from_sat(99_000_000),
         to_address.script_pubkey(),
@@ -335,5 +341,5 @@ async fn script_spend() {
     let witness_elements = vec![schnorr_sig.as_ref()];
     handle_taproot_witness_new(&mut tx_details, &witness_elements, 0, Some(0)).unwrap();
 
-    rpc.send_raw_transaction(&tx_details.tx).unwrap();
+    rpc.send_raw_transaction(&tx_details.tx).await.unwrap();
 }

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -17,7 +17,8 @@ async fn create_address_and_transaction_then_sign_transaction() {
         config.bitcoin_rpc_url,
         config.bitcoin_rpc_user,
         config.bitcoin_rpc_password,
-    );
+    )
+    .await;
 
     let (xonly_pk, _) = config.secret_key.public_key(&SECP).x_only_public_key();
     let address = Address::p2tr(&SECP, xonly_pk, None, config.network);
@@ -47,6 +48,7 @@ async fn create_address_and_transaction_then_sign_transaction() {
     // Create a new transaction.
     let utxo = rpc
         .send_to_address(&taproot_address, Amount::from_sat(1000))
+        .await
         .unwrap();
     let tx_ins = builder::transaction::create_tx_ins(vec![utxo]);
     let tx_outs = vec![TxOut {
@@ -73,5 +75,5 @@ async fn create_address_and_transaction_then_sign_transaction() {
     handle_taproot_witness_new(&mut tx_details, &[sig.as_ref()], 0, Some(0)).unwrap();
 
     // New transaction should be OK to send.
-    rpc.send_raw_transaction(&tx_details.tx).unwrap();
+    rpc.send_raw_transaction(&tx_details.tx).await.unwrap();
 }

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -2,6 +2,7 @@ use bitcoin::hashes::{Hash, HashEngine};
 use bitcoin::opcodes::all::OP_CHECKSIG;
 use bitcoin::script::Builder;
 use bitcoin::{Address, Amount, TapTweakHash, TxOut, XOnlyPublicKey};
+use bitcoincore_rpc::RpcApi;
 use clementine_core::actor::Actor;
 use clementine_core::builder::transaction::TxHandler;
 use clementine_core::builder::{self};
@@ -75,5 +76,8 @@ async fn create_address_and_transaction_then_sign_transaction() {
     handle_taproot_witness_new(&mut tx_details, &[sig.as_ref()], 0, Some(0)).unwrap();
 
     // New transaction should be OK to send.
-    rpc.send_raw_transaction(&tx_details.tx).await.unwrap();
+    rpc.client
+        .send_raw_transaction(&tx_details.tx)
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
# Description

This PR adds async patch to `bitcoincore-rpc`. Also removed some direct RPC calls from `ExtendedRpc` because they are redundant.

## Linked Issues

- Closes #369 