### PR TITLE
Mock crate separation from binaries

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -330,9 +330,11 @@ impl Actor {
 #[cfg(test)]
 mod tests {
     use super::Actor;
+    use crate::config::BridgeConfig;
+    use crate::utils::initialize_logger;
     use crate::{
         actor::WinternitzDerivationPath, builder::transaction::TxHandler,
-        mock::database::create_test_config_with_thread_name,
+        create_test_config_with_thread_name, database::Database, initialize_database,
     };
     use bitcoin::{
         absolute::Height, transaction::Version, Amount, Network, OutPoint, Transaction, TxIn, TxOut,
@@ -345,7 +347,9 @@ mod tests {
         treepp::script,
     };
     use secp256k1::{rand, Secp256k1, SecretKey};
+    use std::env;
     use std::str::FromStr;
+    use std::thread;
 
     /// Returns a valid [`TxHandler`].
     fn create_valid_mock_tx_handler(actor: &Actor) -> TxHandler {
@@ -508,7 +512,7 @@ mod tests {
 
     #[tokio::test]
     async fn derive_winternitz_pk_uniqueness() {
-        let config = create_test_config_with_thread_name("test_config.toml", None).await;
+        let config = create_test_config_with_thread_name!("test_config.toml", None);
         let actor = Actor::new(
             config.secret_key,
             config.winternitz_secret_key,
@@ -527,7 +531,7 @@ mod tests {
 
     #[tokio::test]
     async fn derive_winternitz_pk_fixed_pk() {
-        let config = create_test_config_with_thread_name("test_config.toml", None).await;
+        let config = create_test_config_with_thread_name!("test_config.toml", None);
         let actor = Actor::new(
             config.secret_key,
             Some(
@@ -549,7 +553,7 @@ mod tests {
 
     #[tokio::test]
     async fn sign_winternitz_signature() {
-        let config = create_test_config_with_thread_name("test_config.toml", None).await;
+        let config = create_test_config_with_thread_name!("test_config.toml", None);
         let actor = Actor::new(
             config.secret_key,
             Some(

--- a/core/src/database/mod.rs
+++ b/core/src/database/mod.rs
@@ -68,7 +68,7 @@ impl Database {
     ///
     /// Will return [`BridgeError`] if there was a problem with database
     /// connection.
-    async fn create_database(config: &BridgeConfig) -> Result<(), BridgeError> {
+    pub async fn create_database(config: &BridgeConfig) -> Result<(), BridgeError> {
         let url = Database::get_postgresql_url(config);
         let conn = sqlx::PgPool::connect(url.as_str()).await?;
 
@@ -90,7 +90,7 @@ impl Database {
     /// Will return [`BridgeError`] if there was a problem with database
     /// connection. It won't return any errors if the database does not already
     /// exist.
-    async fn drop_database(config: &BridgeConfig) -> Result<(), BridgeError> {
+    pub async fn drop_database(config: &BridgeConfig) -> Result<(), BridgeError> {
         let url = Database::get_postgresql_url(config);
         let conn = sqlx::PgPool::connect(url.as_str()).await?;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::too_many_arguments)]
 
 use bitcoin::{OutPoint, Txid};
-// use clementine_circuits::{HashType, PreimageType};
 use serde::{Deserialize, Serialize};
 
 pub mod actor;
@@ -32,6 +31,9 @@ pub mod user;
 pub mod utils;
 pub mod verifier;
 pub mod watchtower;
+
+#[cfg(test)]
+mod mock_macro;
 
 pub type ConnectorUTXOTree = Vec<Vec<OutPoint>>;
 // pub type HashTree = Vec<Vec<HashType>>;

--- a/core/src/mock_macro.rs
+++ b/core/src/mock_macro.rs
@@ -1,0 +1,74 @@
+//! # Mock
+
+/// Creates a temporary database for testing, using current thread's name as the
+/// database name.
+///
+/// # Parameters
+///
+/// - `config_file`: Test configuration file in `str` type. Rest of the config
+///   will be read from here and only `db_name` will be overwritten.
+/// - `suffix`: Optional suffix added to the thread handle in `Option<str>`
+///   type.
+///
+/// # Returns
+///
+/// - [`BridgeConfig`]: Modified configuration struct
+///
+/// # Required Imports
+///
+/// ## Unit Tests
+///
+/// ```rust
+/// use crate::{config::BridgeConfig, utils::initialize_logger};
+/// use crate::database::Database;
+/// use std::{env, thread};
+/// ```
+///
+/// ## Integration Tests And Binaries
+#[macro_export]
+macro_rules! create_test_config_with_thread_name {
+    ($config_file:expr, $suffix:expr) => {{
+        let suffix = $suffix.unwrap_or(&String::default()).to_string();
+
+        let handle = thread::current()
+            .name()
+            .unwrap()
+            .split(':')
+            .last()
+            .unwrap()
+            .to_owned()
+            + &suffix;
+
+        // Use maximum log level for tests.
+        initialize_logger(5).unwrap();
+
+        // Read specified configuration file from `tests/data` directory.
+        let mut config = BridgeConfig::try_parse_file(
+            format!("{}/tests/data/{}", env!("CARGO_MANIFEST_DIR"), $config_file).into(),
+        )
+        .unwrap();
+
+        // Check environment for an overwrite config. TODO: Convert this to env vars.
+        let env_config: Option<BridgeConfig> = if let Ok(config_file_path) = env::var("TEST_CONFIG")
+        {
+            Some(BridgeConfig::try_parse_file(config_file_path.into()).unwrap())
+        } else {
+            None
+        };
+
+        // Overwrite user's environment to test's hard coded data if environment
+        // file is specified.
+        if let Some(env_config) = env_config {
+            config.db_host = env_config.db_host;
+            config.db_port = env_config.db_port;
+            config.db_user = env_config.db_user;
+            config.db_password = env_config.db_password;
+            config.db_name = env_config.db_name;
+        };
+
+        config.db_name = handle.to_string();
+        Database::initialize_database(&config).await.unwrap();
+
+        config
+    }};
+}

--- a/core/src/mock_macro.rs
+++ b/core/src/mock_macro.rs
@@ -19,8 +19,7 @@
 /// ## Unit Tests
 ///
 /// ```rust
-/// use crate::{config::BridgeConfig, utils::initialize_logger};
-/// use crate::database::Database;
+/// use crate::{config::BridgeConfig, initialize_database, utils::initialize_logger};
 /// use std::{env, thread};
 /// ```
 ///
@@ -67,8 +66,39 @@ macro_rules! create_test_config_with_thread_name {
         };
 
         config.db_name = handle.to_string();
-        Database::initialize_database(&config).await.unwrap();
+        initialize_database!(&config);
 
         config
+    }};
+}
+
+/// Initializes a new database with given configuration. If the database is
+/// already initialized, it will be dropped before initialization. Meaning,
+/// a clean state is guaranteed.
+///
+/// [`Database::new`] must be called after this to connect to the
+/// initialized database.
+///
+/// # Parameters
+///
+/// - `config`: Configuration options in `BridgeConfig` type.
+///
+/// # Required Imports
+///
+/// ## Unit Tests
+///
+/// ```rust
+/// use crate::database::Database;
+/// ```
+///
+/// ## Integration Tests And Binaries
+#[macro_export]
+macro_rules! initialize_database {
+    ($config:expr) => {{
+        Database::drop_database($config).await.unwrap();
+
+        Database::create_database($config).await.unwrap();
+
+        Database::run_schema_script($config).await.unwrap();
     }};
 }

--- a/core/tests/common/mod.rs
+++ b/core/tests/common/mod.rs
@@ -3,3 +3,6 @@
 mod deposit;
 
 pub use deposit::*;
+
+#[path = "../../src/mock_macro.rs"]
+mod mock_macro;


### PR DESCRIPTION
# Description

Converts all the testing functions into macros. This way, release binaries has no way to use these "testing only" functions/macros.

Let's assume we have a testing function, in `mock.rs`:

```rust
use crate::config::BridgeConfig;

pub fn test_config() -> BridgeConfig {
    BridgeConfig::default()
}
```

Unit tests will happily import this `mock.rs` and use `test_config()`. But in case of binaries and integration tests, they will complain that there is no such thing as `config::BridgeConfig` in crate root. This problem is simply solved with converting testing functions into macros. Now, every module needs to import the structures and functions used by their preference.

## Linked Issues

- Closes #181 