### PR TITLE
`create_test_config_with_thread_name` simplification

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -512,7 +512,7 @@ mod tests {
 
     #[tokio::test]
     async fn derive_winternitz_pk_uniqueness() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let actor = Actor::new(
             config.secret_key,
             config.winternitz_secret_key,
@@ -531,7 +531,7 @@ mod tests {
 
     #[tokio::test]
     async fn derive_winternitz_pk_fixed_pk() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let actor = Actor::new(
             config.secret_key,
             Some(
@@ -553,7 +553,7 @@ mod tests {
 
     #[tokio::test]
     async fn sign_winternitz_signature() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let actor = Actor::new(
             config.secret_key,
             Some(

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -11,9 +11,11 @@
 //! described in `BridgeConfig` struct.
 
 use crate::errors::BridgeError;
-use bitcoin::Network;
 use bitcoin::{address::NetworkUnchecked, Amount};
+use bitcoin::{Address, Network, XOnlyPublicKey};
+use secp256k1::{PublicKey, SecretKey};
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 use std::{fs::File, io::Read, path::PathBuf};
 
 /// Configuration options for any Clementine target (tests, binaries etc.).
@@ -131,42 +133,163 @@ impl Default for BridgeConfig {
     fn default() -> Self {
         Self {
             host: "127.0.0.1".to_string(),
-            port: 3030,
+            port: 17000,
             index: 0,
-            secret_key: secp256k1::SecretKey::new(&mut secp256k1::rand::thread_rng()),
-            verifiers_public_keys: vec![],
+
+            secret_key: secp256k1::SecretKey::from_str(
+                "3333333333333333333333333333333333333333333333333333333333333333",
+            )
+            .unwrap(),
+
             num_verifiers: 7,
-            operators_xonly_pks: vec![],
-            operator_wallet_addresses: vec![],
+            verifiers_public_keys: vec![
+                PublicKey::from_str(
+                    "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
+                )
+                .unwrap(),
+                PublicKey::from_str(
+                    "02466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
+                )
+                .unwrap(),
+                PublicKey::from_str(
+                    "023c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1",
+                )
+                .unwrap(),
+                PublicKey::from_str(
+                    "032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991",
+                )
+                .unwrap(),
+                PublicKey::from_str(
+                    "029ac20335eb38768d2052be1dbbc3c8f6178407458e51e6b4ad22f1d91758895b",
+                )
+                .unwrap(),
+                PublicKey::from_str(
+                    "035ab4689e400a4a160cf01cd44730845a54768df8547dcdf073d964f109f18c30",
+                )
+                .unwrap(),
+                PublicKey::from_str(
+                    "037962d45b38e8bcf82fa8efa8432a01f20c9a53e24c7d3f11df197cb8e70926da",
+                )
+                .unwrap(),
+            ],
+
             num_operators: 3,
             num_watchtowers: 4,
             num_time_txs: 10,
-            operator_withdrawal_fee_sats: None,
-            user_takes_after: 5,
+            operators_xonly_pks: vec![
+                XOnlyPublicKey::from_str(
+                    "4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
+                )
+                .unwrap(),
+                XOnlyPublicKey::from_str(
+                    "466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
+                )
+                .unwrap(),
+                XOnlyPublicKey::from_str(
+                    "3c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1",
+                )
+                .unwrap(),
+            ],
+
             operator_takes_after: 5,
-            bridge_amount_sats: Amount::from_sat(100_000_000),
+
+            operator_wallet_addresses: vec![
+                Address::from_str(
+                    "bcrt1pvaua4gvvglk27al5trh337xz8l8zzhgzageky0xt0dgv64xee8tqwwvzmf",
+                )
+                .unwrap(),
+                Address::from_str(
+                    "bcrt1pvaua4gvvglk27al5trh337xz8l8zzhgzageky0xt0dgv64xee8tqwwvzmf",
+                )
+                .unwrap(),
+                Address::from_str(
+                    "bcrt1pvaua4gvvglk27al5trh337xz8l8zzhgzageky0xt0dgv64xee8tqwwvzmf",
+                )
+                .unwrap(),
+            ],
+            operator_withdrawal_fee_sats: Some(Amount::from_sat(100000)),
+
             operator_num_kickoff_utxos_per_tx: 10,
-            confirmation_threshold: 1,
+
+            user_takes_after: 200,
+
             network: Network::Regtest,
             bitcoin_rpc_url: "http://127.0.0.1:18443".to_string(),
             bitcoin_rpc_user: "admin".to_string(),
             bitcoin_rpc_password: "admin".to_string(),
-            all_verifiers_secret_keys: None,
-            all_operators_secret_keys: None,
+
+            db_host: "127.0.0.1".to_string(),
+            db_port: 5432,
+            db_user: "clementine".to_string(),
+            db_password: "clementine".to_string(),
+            db_name: "clementine".to_string(),
+
+            bridge_amount_sats: Amount::from_sat(100_000_000),
+
+            confirmation_threshold: 1,
+
+            citrea_rpc_url: "".to_string(),
+            bridge_contract_address: "3100000000000000000000000000000000000002".to_string(),
+
+            header_chain_proof_path: Some(
+                PathBuf::from_str("../core/tests/data/first_1.bin").unwrap(),
+            ),
+
+            all_verifiers_secret_keys: Some(vec![
+                SecretKey::from_str(
+                    "1111111111111111111111111111111111111111111111111111111111111111",
+                )
+                .unwrap(),
+                SecretKey::from_str(
+                    "2222222222222222222222222222222222222222222222222222222222222222",
+                )
+                .unwrap(),
+                SecretKey::from_str(
+                    "3333333333333333333333333333333333333333333333333333333333333333",
+                )
+                .unwrap(),
+                SecretKey::from_str(
+                    "4444444444444444444444444444444444444444444444444444444444444444",
+                )
+                .unwrap(),
+                SecretKey::from_str(
+                    "5555555555555555555555555555555555555555555555555555555555555555",
+                )
+                .unwrap(),
+                SecretKey::from_str(
+                    "6666666666666666666666666666666666666666666666666666666666666666",
+                )
+                .unwrap(),
+                SecretKey::from_str(
+                    "7777777777777777777777777777777777777777777777777777777777777777",
+                )
+                .unwrap(),
+            ]),
+            all_operators_secret_keys: Some(vec![
+                SecretKey::from_str(
+                    "1111111111111111111111111111111111111111111111111111111111111111",
+                )
+                .unwrap(),
+                SecretKey::from_str(
+                    "2222222222222222222222222222222222222222222222222222222222222222",
+                )
+                .unwrap(),
+                SecretKey::from_str(
+                    "3333333333333333333333333333333333333333333333333333333333333333",
+                )
+                .unwrap(),
+            ]),
+
+            winternitz_secret_key: Some(
+                secp256k1::SecretKey::from_str(
+                    "2222222222222222222222222222222222222222222222222222222222222222",
+                )
+                .unwrap(),
+            ),
+
             verifier_endpoints: None,
             operator_endpoints: None,
             watchtower_endpoints: None,
-            db_host: "127.0.0.1".to_string(),
-            db_port: 5432,
-            db_user: "postgres".to_string(),
-            db_password: "postgres".to_string(),
-            db_name: "postgres".to_string(),
-            citrea_rpc_url: "http://127.0.0.1:12345".to_string(),
-            bridge_contract_address: "3100000000000000000000000000000000000002".to_string(),
-            header_chain_proof_path: None,
-            winternitz_secret_key: Some(secp256k1::SecretKey::new(
-                &mut secp256k1::rand::thread_rng(),
-            )),
         }
     }
 }

--- a/core/src/database/common.rs
+++ b/core/src/database/common.rs
@@ -1004,7 +1004,7 @@ mod tests {
 
     #[tokio::test]
     async fn save_get_timeout_tx_sigs() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let database = Database::new(&config).await.unwrap();
 
         let signatures: Vec<schnorr::Signature> = (0..0x45)
@@ -1023,7 +1023,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_database_gets_previously_saved_operator_take_signature() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let database = Database::new(&config).await.unwrap();
 
         let deposit_outpoint = OutPoint::null();
@@ -1061,7 +1061,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_save_and_get_deposit_info() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let database = Database::new(&config).await.unwrap();
 
         let secp = Secp256k1::new();
@@ -1094,7 +1094,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_nonces_1() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
         let secp = Secp256k1::new();
 
@@ -1139,7 +1139,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_nonces_2() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
         let secp = Secp256k1::new();
 
@@ -1183,7 +1183,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_nonces_3() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
         let secp = Secp256k1::new();
 
@@ -1231,7 +1231,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_pub_nonces_1() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
         let secp = Secp256k1::new();
 
@@ -1264,7 +1264,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_pub_nonces_2() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
         let outpoint = OutPoint {
             txid: Txid::from_byte_array([1u8; 32]),
@@ -1276,7 +1276,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_operators_kickoff_utxo_1() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let outpoint = OutPoint {
@@ -1301,7 +1301,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_operators_kickoff_utxo_2() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let outpoint = OutPoint {
@@ -1314,7 +1314,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_verifiers_kickoff_utxos_1() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let outpoint = OutPoint {
@@ -1351,7 +1351,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_verifiers_kickoff_utxos_2() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let outpoint = OutPoint {
@@ -1364,7 +1364,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_operators_funding_utxo_1() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let utxo = UTXO {
@@ -1386,7 +1386,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_operators_funding_utxo_2() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let db_utxo = db.get_funding_utxo(None).await.unwrap();
@@ -1396,7 +1396,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_deposit_kickoff_generator_tx_0() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let raw_hex = "02000000000101eb87b1a80d47b7f5bd5082b77653f5ca37e566951742b80c361875ba0e5c478f0a00000000fdffffff0ca086010000000000225120b23da6d2e0390018b953f7d74e3582da4da30fd0fd157cc84a2d2753003d1ca3a086010000000000225120b23da6d2e0390018b953f7d74e3582da4da30fd0fd157cc84a2d2753003d1ca3a086010000000000225120b23da6d2e0390018b953f7d74e3582da4da30fd0fd157cc84a2d2753003d1ca3a086010000000000225120b23da6d2e0390018b953f7d74e3582da4da30fd0fd157cc84a2d2753003d1ca3a086010000000000225120b23da6d2e0390018b953f7d74e3582da4da30fd0fd157cc84a2d2753003d1ca3a086010000000000225120b23da6d2e0390018b953f7d74e3582da4da30fd0fd157cc84a2d2753003d1ca3a086010000000000225120b23da6d2e0390018b953f7d74e3582da4da30fd0fd157cc84a2d2753003d1ca3a086010000000000225120b23da6d2e0390018b953f7d74e3582da4da30fd0fd157cc84a2d2753003d1ca3a086010000000000225120b23da6d2e0390018b953f7d74e3582da4da30fd0fd157cc84a2d2753003d1ca3a086010000000000225120b23da6d2e0390018b953f7d74e3582da4da30fd0fd157cc84a2d2753003d1ca35c081777000000002251202a64b1ee3375f3bb4b367b8cb8384a47f73cf231717f827c6c6fbbf5aecf0c364a010000000000002200204ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260014005a41e6f4a4bcfcc5cd3ef602687215f97c18949019a491df56af7413c5dce9292ba3966edc4564a39d9bc0d6c0faae19030f1cedf4d931a6cdc57cc5b83c8ef00000000".to_string();
@@ -1442,7 +1442,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_deposit_kickoff_generator_tx_2() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let txid = Txid::from_byte_array([1u8; 32]);
@@ -1452,7 +1452,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_deposit_kickoff_generator_tx_1() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let raw_hex = "01000000000101308d840c736eefd114a8fad04cb0d8338b4a3034a2b517250e5498701b25eb360100000000fdffffff02401f00000000000022512024985a1ab5724a5164ae5e0026b3e7e22031e83948eedf99d438b866857946b81f7e000000000000225120f7298da2a2be5b6e02a076ff7d35a1fe6b54a2bc7938c1c86bede23cadb7d9650140ad2fdb01ec5e2772f682867c8c6f30697c63f622e338f7390d3abc6c905b9fd7e96496fdc34cb9e872387758a6a334ec1307b3505b73121e0264fe2ba546d78ad11b0d00".to_string();
@@ -1502,7 +1502,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_deposit_kickoff_generator_tx_3() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let txid = Txid::from_byte_array([1u8; 32]);
@@ -1512,7 +1512,7 @@ mod tests {
 
     #[tokio::test]
     async fn save_get_new_block() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let block = block::Block {
@@ -1541,7 +1541,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_block_header() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let block = block::Block {
@@ -1578,7 +1578,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn get_latest_chain_proof_height() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         let mut block = block::Block {
@@ -1634,7 +1634,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn save_get_block_proof() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         // Save dummy block.
@@ -1678,7 +1678,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn get_non_proven_block() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let db = Database::new(&config).await.unwrap();
 
         assert!(db.get_non_proven_block(None).await.is_err());
@@ -1754,7 +1754,7 @@ mod tests {
 
     #[tokio::test]
     async fn save_get_winternitz_public_key() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let database = Database::new(&config).await.unwrap();
 
         // Assuming there are 2 time_txs.

--- a/core/src/database/mod.rs
+++ b/core/src/database/mod.rs
@@ -99,7 +99,7 @@ mod tests {
 
     #[tokio::test]
     async fn valid_database_connection() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
 
         Database::new(&config).await.unwrap();
     }

--- a/core/src/header_chain_prover/blockgazer.rs
+++ b/core/src/header_chain_prover/blockgazer.rs
@@ -257,7 +257,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn check_for_new_blocks_uptodate() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -291,7 +291,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn check_for_new_blocks_fallen_behind_single() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -332,7 +332,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn check_for_new_blocks_fallen_behind_multiple() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -363,7 +363,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn check_for_new_blocks_fork_and_mine_new() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -395,7 +395,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn sync_blockchain_single_block() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -429,7 +429,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn sync_blockchain_multiple_blocks() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -463,7 +463,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn sync_blockchain_multiple_blocks_with_fork() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),

--- a/core/src/header_chain_prover/mod.rs
+++ b/core/src/header_chain_prover/mod.rs
@@ -115,7 +115,7 @@ mod tests {
 
     #[tokio::test]
     async fn new() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -129,7 +129,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn new_with_proof_assumption() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -156,7 +156,7 @@ mod tests {
     #[serial_test::serial]
     #[ignore = "This test is very host dependent and needs a human observer"]
     async fn start_header_chain_prover() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),

--- a/core/src/header_chain_prover/prover.rs
+++ b/core/src/header_chain_prover/prover.rs
@@ -164,7 +164,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn prove_block_headers_genesis() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -188,7 +188,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn prove_block_headers_second() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -215,7 +215,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn save_and_get_proof() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -710,7 +710,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_funding_utxo() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -743,7 +743,7 @@ mod tests {
 
     #[tokio::test]
     async fn is_profitable() {
-        let mut config = create_test_config_with_thread_name!("test_config.toml", None);
+        let mut config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -421,7 +421,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn aggregator_double_setup_fail() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
 
         let (_, _, aggregator, _) = create_actors!(config, 0);
         let mut aggregator_client =
@@ -443,7 +443,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn aggregator_setup_winternitz_public_keys() {
-        let mut config = create_test_config_with_thread_name!("test_config.toml", None);
+        let mut config = create_test_config_with_thread_name!(None);
 
         let (_verifiers, _operators, aggregator, _watchtowers) = create_actors!(config.clone(), 1);
         let mut aggregator_client =

--- a/core/src/rpc/watchtower.rs
+++ b/core/src/rpc/watchtower.rs
@@ -52,7 +52,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn watchtower_get_params() {
-        let mut config = create_test_config_with_thread_name!("test_config.toml", None);
+        let mut config = create_test_config_with_thread_name!(None);
         let (verifiers, operators, _, _watchtowers) = create_actors!(config.clone(), 2);
 
         config.verifier_endpoints = Some(

--- a/core/src/test_utils.rs
+++ b/core/src/test_utils.rs
@@ -52,16 +52,7 @@ macro_rules! create_test_config_with_thread_name {
         // Use maximum log level for tests.
         initialize_logger(5).unwrap();
 
-        // Read specified configuration file from `tests/data` directory.
-        let mut config = BridgeConfig::try_parse_file(
-            format!(
-                "{}/tests/data/{}",
-                env!("CARGO_MANIFEST_DIR"),
-                "test_config.toml"
-            )
-            .into(),
-        )
-        .unwrap();
+        let mut config = BridgeConfig::default();
 
         // Check environment for an overwrite config. TODO: Convert this to env vars.
         let env_config: Option<BridgeConfig> = if let Ok(config_file_path) = env::var("TEST_CONFIG")

--- a/core/src/test_utils.rs
+++ b/core/src/test_utils.rs
@@ -37,7 +37,7 @@
 /// ```
 #[macro_export]
 macro_rules! create_test_config_with_thread_name {
-    ($config_file:expr, $suffix:expr) => {{
+    ($suffix:expr) => {{
         let suffix = $suffix.unwrap_or(&String::default()).to_string();
 
         let handle = thread::current()
@@ -54,7 +54,12 @@ macro_rules! create_test_config_with_thread_name {
 
         // Read specified configuration file from `tests/data` directory.
         let mut config = BridgeConfig::try_parse_file(
-            format!("{}/tests/data/{}", env!("CARGO_MANIFEST_DIR"), $config_file).into(),
+            format!(
+                "{}/tests/data/{}",
+                env!("CARGO_MANIFEST_DIR"),
+                "test_config.toml"
+            )
+            .into(),
         )
         .unwrap();
 

--- a/core/src/user.rs
+++ b/core/src/user.rs
@@ -127,7 +127,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::parallel]
     async fn deposit_tx() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -602,7 +602,7 @@ mod tests {
 
     #[tokio::test]
     async fn verifier_new_public_key_check() {
-        let mut config = create_test_config_with_thread_name!("test_config.toml", None);
+        let mut config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),
@@ -621,7 +621,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn new_deposit_nonce_checks() {
-        let config = create_test_config_with_thread_name!("test_config.toml", None);
+        let config = create_test_config_with_thread_name!(None);
         let rpc = ExtendedRpc::new(
             config.bitcoin_rpc_url.clone(),
             config.bitcoin_rpc_user.clone(),

--- a/core/src/watchtower.rs
+++ b/core/src/watchtower.rs
@@ -91,7 +91,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn new_watchtower() {
-        let mut config = create_test_config_with_thread_name!("test_config.toml", None);
+        let mut config = create_test_config_with_thread_name!(None);
         let (verifiers, operators, _, _should_not_panic) = create_actors!(config.clone(), 1);
 
         config.verifier_endpoints = Some(
@@ -113,7 +113,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn get_winternitz_public_keys() {
-        let mut config = create_test_config_with_thread_name!("test_config.toml", None);
+        let mut config = create_test_config_with_thread_name!(None);
         let (verifiers, operators, _, _watchtowers) = create_actors!(config.clone(), 2);
 
         config.verifier_endpoints = Some(

--- a/core/tests/deposit.rs
+++ b/core/tests/deposit.rs
@@ -16,7 +16,7 @@
 // #[tokio::test]
 // #[serial_test::serial]
 // async fn deposit_with_retry_checks() {
-// let config = create_test_config_with_thread_name!("test_config.toml", None);
+// let config = create_test_config_with_thread_name!(None);
 // let rpc = ExtendedRpc::new(
 //     config.bitcoin_rpc_url.clone(),
 //     config.bitcoin_rpc_user.clone(),

--- a/core/tests/flow.rs
+++ b/core/tests/flow.rs
@@ -144,7 +144,7 @@ mod common;
 #[tokio::test]
 #[serial_test::serial]
 async fn grpc_flow() {
-    let config = create_test_config_with_thread_name!("test_config.toml", None);
+    let config = create_test_config_with_thread_name!(None);
     let (_verifiers, _operators, aggregator, _watchtowers) = create_actors!(config, 0);
 
     let x: Uri = format!("http://{}", aggregator.0).parse().unwrap();

--- a/core/tests/musig2.rs
+++ b/core/tests/musig2.rs
@@ -69,7 +69,7 @@ fn get_nonces(verifiers_secret_public_keys: Vec<Keypair>) -> (Vec<MuSigNoncePair
 #[tokio::test]
 #[serial_test::serial]
 async fn key_spend() {
-    let config = create_test_config_with_thread_name!("test_config.toml", None);
+    let config = create_test_config_with_thread_name!(None);
     let rpc = ExtendedRpc::new(
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
@@ -160,7 +160,7 @@ async fn key_spend() {
 #[tokio::test]
 #[serial_test::serial]
 async fn key_spend_with_script() {
-    let config = create_test_config_with_thread_name!("test_config.toml", None);
+    let config = create_test_config_with_thread_name!(None);
     let rpc = ExtendedRpc::new(
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
@@ -257,7 +257,7 @@ async fn key_spend_with_script() {
 #[tokio::test]
 #[serial_test::serial]
 async fn script_spend() {
-    let config = create_test_config_with_thread_name!("test_config.toml", None);
+    let config = create_test_config_with_thread_name!(None);
     let rpc = ExtendedRpc::new(
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -16,7 +16,7 @@ mod common;
 #[tokio::test]
 #[serial_test::serial]
 async fn create_address_and_transaction_then_sign_transaction() {
-    let config = create_test_config_with_thread_name!("test_config.toml", None);
+    let config = create_test_config_with_thread_name!(None);
     let rpc = ExtendedRpc::new(
         config.bitcoin_rpc_url,
         config.bitcoin_rpc_user,


### PR DESCRIPTION
# Description

`create_test_config_with_thread_name` now uses default `BridgeConfig` implementation, instead of config file.

## Linked Issues

- Closes #376 