### PR TITLE
Use global context for secp256k1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serial_test = "3.2.0"
 bitcoin = "0.32.5"
 bitcoincore-rpc = "0.18.0"
 musig2 = { version = "0.0.11", features = ["serde"] }
-secp256k1 = { version = "0.29.1", features = ["serde", "rand-std"] }
+secp256k1 = { version = "0.29.1", features = ["serde", "rand-std", "global-context"] }
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script", branch= "StructuredScript" }
 
 # async + gRPC

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -1,6 +1,5 @@
 use crate::builder::transaction::TxHandler;
 use crate::errors::BridgeError;
-use crate::utils;
 use bitcoin::sighash::SighashCache;
 use bitcoin::taproot::LeafVersion;
 use bitcoin::{
@@ -105,9 +104,9 @@ impl Actor {
         winternitz_secret_key: Option<secp256k1::SecretKey>,
         network: bitcoin::Network,
     ) -> Self {
-        let keypair = Keypair::from_secret_key(&SECP256K1, &sk);
+        let keypair = Keypair::from_secret_key(SECP256K1, &sk);
         let (xonly, _parity) = XOnlyPublicKey::from_keypair(&keypair);
-        let address = Address::p2tr(&SECP256K1, xonly, None, network);
+        let address = Address::p2tr(SECP256K1, xonly, None, network);
 
         Actor {
             keypair,
@@ -128,7 +127,7 @@ impl Actor {
         Ok(SECP256K1.sign_schnorr(
             &Message::from_digest_slice(sighash.as_byte_array()).expect("should be hash"),
             &self.keypair.add_xonly_tweak(
-                &SECP256K1,
+                SECP256K1,
                 &TapTweakHash::from_key_and_tweak(self.xonly_public_key, merkle_root).to_scalar(),
             )?,
         ))
@@ -436,8 +435,8 @@ mod tests {
         let actor = Actor::new(sk, None, network);
 
         assert_eq!(sk, actor._secret_key);
-        assert_eq!(sk.public_key(&SECP256K1), actor.public_key);
-        assert_eq!(sk.x_only_public_key(&SECP256K1).0, actor.xonly_public_key);
+        assert_eq!(sk.public_key(SECP256K1), actor.public_key);
+        assert_eq!(sk.x_only_public_key(SECP256K1).0, actor.xonly_public_key);
     }
 
     #[test]

--- a/core/src/builder/address.rs
+++ b/core/src/builder/address.rs
@@ -11,7 +11,7 @@ use bitcoin::{
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, ScriptBuf,
 };
-use secp256k1::XOnlyPublicKey;
+use secp256k1::{XOnlyPublicKey, SECP256K1};
 
 /// Creates a taproot address with either key path spend or script spend path
 /// addresses. This depends on given arguments.
@@ -53,16 +53,16 @@ pub fn create_taproot_address(
     };
 
     let tree_info = match internal_key {
-        Some(xonly_pk) => taproot_builder.finalize(&utils::SECP, xonly_pk).unwrap(),
+        Some(xonly_pk) => taproot_builder.finalize(&SECP256K1, xonly_pk).unwrap(),
         None => taproot_builder
-            .finalize(&utils::SECP, *utils::UNSPENDABLE_XONLY_PUBKEY)
+            .finalize(&SECP256K1, *utils::UNSPENDABLE_XONLY_PUBKEY)
             .unwrap(),
     };
 
     let taproot_address = match internal_key {
-        Some(xonly_pk) => Address::p2tr(&utils::SECP, xonly_pk, tree_info.merkle_root(), network),
+        Some(xonly_pk) => Address::p2tr(&SECP256K1, xonly_pk, tree_info.merkle_root(), network),
         None => Address::p2tr(
-            &utils::SECP,
+            &SECP256K1,
             *utils::UNSPENDABLE_XONLY_PUBKEY,
             tree_info.merkle_root(),
             network,
@@ -162,17 +162,17 @@ mod tests {
     use crate::{
         builder,
         musig2::AggregateFromPublicKeys,
-        utils::{self, SECP},
+        utils::{self},
     };
     use bitcoin::{key::TapTweak, Address, AddressType, Amount, ScriptBuf, XOnlyPublicKey};
-    use secp256k1::{rand, Keypair, PublicKey, SecretKey};
+    use secp256k1::{rand, Keypair, PublicKey, SecretKey, SECP256K1};
     use std::str::FromStr;
 
     #[test]
     fn create_taproot_address() {
         let secret_key = SecretKey::new(&mut rand::thread_rng());
         let internal_key =
-            XOnlyPublicKey::from_keypair(&Keypair::from_secret_key(&SECP, &secret_key)).0;
+            XOnlyPublicKey::from_keypair(&Keypair::from_secret_key(&SECP256K1, &secret_key)).0;
 
         // No internal key or scripts (key path spend).
         let (address, spend_info) =
@@ -180,7 +180,7 @@ mod tests {
         assert_eq!(address.address_type().unwrap(), AddressType::P2tr);
         assert!(address.is_related_to_xonly_pubkey(
             &utils::UNSPENDABLE_XONLY_PUBKEY
-                .tap_tweak(&SECP, spend_info.merkle_root())
+                .tap_tweak(&SECP256K1, spend_info.merkle_root())
                 .0
                 .to_inner()
         ));
@@ -196,7 +196,7 @@ mod tests {
         assert_eq!(address.address_type().unwrap(), AddressType::P2tr);
         assert!(address.is_related_to_xonly_pubkey(
             &internal_key
-                .tap_tweak(&SECP, spend_info.merkle_root())
+                .tap_tweak(&SECP256K1, spend_info.merkle_root())
                 .0
                 .to_inner()
         ));
@@ -212,7 +212,7 @@ mod tests {
         assert_eq!(address.address_type().unwrap(), AddressType::P2tr);
         assert!(address.is_related_to_xonly_pubkey(
             &internal_key
-                .tap_tweak(&SECP, spend_info.merkle_root())
+                .tap_tweak(&SECP256K1, spend_info.merkle_root())
                 .0
                 .to_inner()
         ));
@@ -228,7 +228,7 @@ mod tests {
         assert_eq!(address.address_type().unwrap(), AddressType::P2tr);
         assert!(address.is_related_to_xonly_pubkey(
             &internal_key
-                .tap_tweak(&SECP, spend_info.merkle_root())
+                .tap_tweak(&SECP256K1, spend_info.merkle_root())
                 .0
                 .to_inner()
         ));

--- a/core/src/builder/address.rs
+++ b/core/src/builder/address.rs
@@ -53,16 +53,16 @@ pub fn create_taproot_address(
     };
 
     let tree_info = match internal_key {
-        Some(xonly_pk) => taproot_builder.finalize(&SECP256K1, xonly_pk).unwrap(),
+        Some(xonly_pk) => taproot_builder.finalize(SECP256K1, xonly_pk).unwrap(),
         None => taproot_builder
-            .finalize(&SECP256K1, *utils::UNSPENDABLE_XONLY_PUBKEY)
+            .finalize(SECP256K1, *utils::UNSPENDABLE_XONLY_PUBKEY)
             .unwrap(),
     };
 
     let taproot_address = match internal_key {
-        Some(xonly_pk) => Address::p2tr(&SECP256K1, xonly_pk, tree_info.merkle_root(), network),
+        Some(xonly_pk) => Address::p2tr(SECP256K1, xonly_pk, tree_info.merkle_root(), network),
         None => Address::p2tr(
-            &SECP256K1,
+            SECP256K1,
             *utils::UNSPENDABLE_XONLY_PUBKEY,
             tree_info.merkle_root(),
             network,
@@ -172,7 +172,7 @@ mod tests {
     fn create_taproot_address() {
         let secret_key = SecretKey::new(&mut rand::thread_rng());
         let internal_key =
-            XOnlyPublicKey::from_keypair(&Keypair::from_secret_key(&SECP256K1, &secret_key)).0;
+            XOnlyPublicKey::from_keypair(&Keypair::from_secret_key(SECP256K1, &secret_key)).0;
 
         // No internal key or scripts (key path spend).
         let (address, spend_info) =
@@ -180,7 +180,7 @@ mod tests {
         assert_eq!(address.address_type().unwrap(), AddressType::P2tr);
         assert!(address.is_related_to_xonly_pubkey(
             &utils::UNSPENDABLE_XONLY_PUBKEY
-                .tap_tweak(&SECP256K1, spend_info.merkle_root())
+                .tap_tweak(SECP256K1, spend_info.merkle_root())
                 .0
                 .to_inner()
         ));
@@ -196,7 +196,7 @@ mod tests {
         assert_eq!(address.address_type().unwrap(), AddressType::P2tr);
         assert!(address.is_related_to_xonly_pubkey(
             &internal_key
-                .tap_tweak(&SECP256K1, spend_info.merkle_root())
+                .tap_tweak(SECP256K1, spend_info.merkle_root())
                 .0
                 .to_inner()
         ));
@@ -212,7 +212,7 @@ mod tests {
         assert_eq!(address.address_type().unwrap(), AddressType::P2tr);
         assert!(address.is_related_to_xonly_pubkey(
             &internal_key
-                .tap_tweak(&SECP256K1, spend_info.merkle_root())
+                .tap_tweak(SECP256K1, spend_info.merkle_root())
                 .0
                 .to_inner()
         ));
@@ -228,7 +228,7 @@ mod tests {
         assert_eq!(address.address_type().unwrap(), AddressType::P2tr);
         assert!(address.is_related_to_xonly_pubkey(
             &internal_key
-                .tap_tweak(&SECP256K1, spend_info.merkle_root())
+                .tap_tweak(SECP256K1, spend_info.merkle_root())
                 .0
                 .to_inner()
         ));

--- a/core/src/builder/transaction.rs
+++ b/core/src/builder/transaction.rs
@@ -16,7 +16,7 @@ use bitcoin::{
 };
 use bitcoin::{Network, Transaction, Txid};
 use bitvm::signatures::winternitz;
-use secp256k1::XOnlyPublicKey;
+use secp256k1::{XOnlyPublicKey, SECP256K1};
 
 /// Verbose information about a transaction.
 #[derive(Debug, Clone)]
@@ -335,7 +335,7 @@ pub fn create_kickoff_utxo_txhandler(
     );
     let (musig2_and_operator_address, _) =
         builder::address::create_taproot_address(&[musig2_and_operator_script], None, network);
-    let operator_address = Address::p2tr(&utils::SECP, operator_xonly_pk, None, network);
+    let operator_address = Address::p2tr(&SECP256K1, operator_xonly_pk, None, network);
     let change_amount = funding_utxo.txout.value
         - Amount::from_sat(KICKOFF_UTXO_AMOUNT_SATS.to_sat() * num_kickoff_utxos_per_tx as u64)
         // - builder::script::anyone_can_spend_txout().value
@@ -1123,9 +1123,9 @@ pub fn create_tx_outs(pairs: Vec<(Amount, ScriptBuf)>) -> Vec<TxOut> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{builder, utils::SECP};
+    use crate::builder;
     use bitcoin::{hashes::Hash, Amount, OutPoint, Txid, XOnlyPublicKey};
-    use secp256k1::{rand, Keypair, SecretKey};
+    use secp256k1::{rand, Keypair, SecretKey, SECP256K1};
 
     #[test]
     fn create_move_tx() {
@@ -1135,7 +1135,7 @@ mod tests {
         };
         let secret_key = SecretKey::new(&mut rand::thread_rng());
         let nofn_xonly_pk =
-            XOnlyPublicKey::from_keypair(&Keypair::from_secret_key(&SECP, &secret_key)).0;
+            XOnlyPublicKey::from_keypair(&Keypair::from_secret_key(&SECP256K1, &secret_key)).0;
         let bridge_amount_sats = Amount::from_sat(0x1F45);
         let network = bitcoin::Network::Regtest;
 

--- a/core/src/builder/transaction.rs
+++ b/core/src/builder/transaction.rs
@@ -335,7 +335,7 @@ pub fn create_kickoff_utxo_txhandler(
     );
     let (musig2_and_operator_address, _) =
         builder::address::create_taproot_address(&[musig2_and_operator_script], None, network);
-    let operator_address = Address::p2tr(&SECP256K1, operator_xonly_pk, None, network);
+    let operator_address = Address::p2tr(SECP256K1, operator_xonly_pk, None, network);
     let change_amount = funding_utxo.txout.value
         - Amount::from_sat(KICKOFF_UTXO_AMOUNT_SATS.to_sat() * num_kickoff_utxos_per_tx as u64)
         // - builder::script::anyone_can_spend_txout().value
@@ -1135,7 +1135,7 @@ mod tests {
         };
         let secret_key = SecretKey::new(&mut rand::thread_rng());
         let nofn_xonly_pk =
-            XOnlyPublicKey::from_keypair(&Keypair::from_secret_key(&SECP256K1, &secret_key)).0;
+            XOnlyPublicKey::from_keypair(&Keypair::from_secret_key(SECP256K1, &secret_key)).0;
         let bridge_amount_sats = Amount::from_sat(0x1F45);
         let network = bitcoin::Network::Regtest;
 

--- a/core/src/database/wrapper.rs
+++ b/core/src/database/wrapper.rs
@@ -344,7 +344,7 @@ mod tests {
         );
 
         let address = bitcoin::Address::p2tr(
-            &SECP256K1,
+            SECP256K1,
             *utils::UNSPENDABLE_XONLY_PUBKEY,
             None,
             bitcoin::Network::Regtest,

--- a/core/src/database/wrapper.rs
+++ b/core/src/database/wrapper.rs
@@ -295,7 +295,7 @@ mod tests {
         hashes::Hash,
         Amount, BlockHash, CompactTarget, OutPoint, ScriptBuf, TxMerkleNode, TxOut, Txid,
     };
-    use secp256k1::schnorr::Signature;
+    use secp256k1::{schnorr::Signature, SECP256K1};
     use sqlx::{encode::IsNull, postgres::PgArgumentBuffer, Encode, Type};
 
     #[test]
@@ -344,7 +344,7 @@ mod tests {
         );
 
         let address = bitcoin::Address::p2tr(
-            &utils::SECP,
+            &SECP256K1,
             *utils::UNSPENDABLE_XONLY_PUBKEY,
             None,
             bitcoin::Network::Regtest,

--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -174,17 +174,14 @@ mod tests {
         hashes::Hash, opcodes::all::OP_CHECKSIG, script, Amount, OutPoint, ScriptBuf, TapNodeHash,
         TxOut, Txid,
     };
-    use secp256k1::{rand::Rng, Keypair, Message, XOnlyPublicKey};
+    use secp256k1::{rand::Rng, Keypair, Message, XOnlyPublicKey, SECP256K1};
     use std::vec;
 
     // Generates a test setup with a given number of signers. Returns a vector of keypairs and a vector of nonce pairs.
     fn generate_test_setup(num_signers: usize) -> (Vec<Keypair>, Vec<MuSigNoncePair>) {
         let mut keypair_vec: Vec<Keypair> = Vec::new();
         for _ in 0..num_signers {
-            keypair_vec.push(Keypair::new(
-                &crate::utils::SECP,
-                &mut secp256k1::rand::thread_rng(),
-            ));
+            keypair_vec.push(Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng()));
         }
         let nonce_pair_vec: Vec<MuSigNoncePair> = keypair_vec
             .iter()
@@ -245,9 +242,9 @@ mod tests {
     // Test that the verification fails if one of the partial signatures is invalid.
     #[test]
     fn test_musig2_raw_fail() {
-        let kp_0 = secp256k1::Keypair::new(&utils::SECP, &mut secp256k1::rand::thread_rng());
-        let kp_1 = secp256k1::Keypair::new(&utils::SECP, &mut secp256k1::rand::thread_rng());
-        let kp_2 = secp256k1::Keypair::new(&utils::SECP, &mut secp256k1::rand::thread_rng());
+        let kp_0 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
+        let kp_1 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
+        let kp_2 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
         let message: [u8; 32] = secp256k1::rand::thread_rng().gen();
         let pks = vec![kp_0.public_key(), kp_1.public_key(), kp_2.public_key()];
         let (sec_nonce_0, pub_nonce_0) =
@@ -346,9 +343,9 @@ mod tests {
 
     #[test]
     fn test_musig2_tweak_fail() {
-        let kp_0 = secp256k1::Keypair::new(&utils::SECP, &mut secp256k1::rand::thread_rng());
-        let kp_1 = secp256k1::Keypair::new(&utils::SECP, &mut secp256k1::rand::thread_rng());
-        let kp_2 = secp256k1::Keypair::new(&utils::SECP, &mut secp256k1::rand::thread_rng());
+        let kp_0 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
+        let kp_1 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
+        let kp_2 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
         let message: [u8; 32] = secp256k1::rand::thread_rng().gen();
         let tweak: [u8; 32] = secp256k1::rand::thread_rng().gen();
         let pks = vec![kp_0.public_key(), kp_1.public_key(), kp_2.public_key()];
@@ -420,7 +417,7 @@ mod tests {
         let dummy_script = script::Builder::new().push_int(1).into_script();
         let scripts: Vec<ScriptBuf> = vec![dummy_script];
         let receiving_address = bitcoin::Address::p2tr(
-            &utils::SECP,
+            &SECP256K1,
             *utils::UNSPENDABLE_XONLY_PUBKEY,
             None,
             bitcoin::Network::Regtest,
@@ -486,7 +483,7 @@ mod tests {
             XOnlyPublicKey::from_musig2_pks(pks, merkle_root, true);
         // musig2::verify_single(musig_agg_pubkey, &final_signature, message)
         //     .expect("Verification failed!");
-        utils::SECP
+        SECP256K1
             .verify_schnorr(
                 &secp256k1::schnorr::Signature::from_slice(&final_signature).unwrap(),
                 &Message::from_digest(message),
@@ -513,7 +510,7 @@ mod tests {
             .into_script();
         let scripts: Vec<ScriptBuf> = vec![musig2_script];
         let receiving_address = bitcoin::Address::p2tr(
-            &utils::SECP,
+            &SECP256K1,
             *utils::UNSPENDABLE_XONLY_PUBKEY,
             None,
             bitcoin::Network::Regtest,
@@ -577,7 +574,7 @@ mod tests {
         .unwrap();
         // musig2::verify_single(musig_agg_pubkey, &final_signature, message)
         //     .expect("Verification failed!");
-        utils::SECP
+        SECP256K1
             .verify_schnorr(
                 &secp256k1::schnorr::Signature::from_slice(&final_signature).unwrap(),
                 &Message::from_digest(message),

--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -181,7 +181,7 @@ mod tests {
     fn generate_test_setup(num_signers: usize) -> (Vec<Keypair>, Vec<MuSigNoncePair>) {
         let mut keypair_vec: Vec<Keypair> = Vec::new();
         for _ in 0..num_signers {
-            keypair_vec.push(Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng()));
+            keypair_vec.push(Keypair::new(SECP256K1, &mut secp256k1::rand::thread_rng()));
         }
         let nonce_pair_vec: Vec<MuSigNoncePair> = keypair_vec
             .iter()
@@ -242,9 +242,9 @@ mod tests {
     // Test that the verification fails if one of the partial signatures is invalid.
     #[test]
     fn test_musig2_raw_fail() {
-        let kp_0 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
-        let kp_1 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
-        let kp_2 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
+        let kp_0 = secp256k1::Keypair::new(SECP256K1, &mut secp256k1::rand::thread_rng());
+        let kp_1 = secp256k1::Keypair::new(SECP256K1, &mut secp256k1::rand::thread_rng());
+        let kp_2 = secp256k1::Keypair::new(SECP256K1, &mut secp256k1::rand::thread_rng());
         let message: [u8; 32] = secp256k1::rand::thread_rng().gen();
         let pks = vec![kp_0.public_key(), kp_1.public_key(), kp_2.public_key()];
         let (sec_nonce_0, pub_nonce_0) =
@@ -343,9 +343,9 @@ mod tests {
 
     #[test]
     fn test_musig2_tweak_fail() {
-        let kp_0 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
-        let kp_1 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
-        let kp_2 = secp256k1::Keypair::new(&SECP256K1, &mut secp256k1::rand::thread_rng());
+        let kp_0 = secp256k1::Keypair::new(SECP256K1, &mut secp256k1::rand::thread_rng());
+        let kp_1 = secp256k1::Keypair::new(SECP256K1, &mut secp256k1::rand::thread_rng());
+        let kp_2 = secp256k1::Keypair::new(SECP256K1, &mut secp256k1::rand::thread_rng());
         let message: [u8; 32] = secp256k1::rand::thread_rng().gen();
         let tweak: [u8; 32] = secp256k1::rand::thread_rng().gen();
         let pks = vec![kp_0.public_key(), kp_1.public_key(), kp_2.public_key()];
@@ -417,7 +417,7 @@ mod tests {
         let dummy_script = script::Builder::new().push_int(1).into_script();
         let scripts: Vec<ScriptBuf> = vec![dummy_script];
         let receiving_address = bitcoin::Address::p2tr(
-            &SECP256K1,
+            SECP256K1,
             *utils::UNSPENDABLE_XONLY_PUBKEY,
             None,
             bitcoin::Network::Regtest,
@@ -510,7 +510,7 @@ mod tests {
             .into_script();
         let scripts: Vec<ScriptBuf> = vec![musig2_script];
         let receiving_address = bitcoin::Address::p2tr(
-            &SECP256K1,
+            SECP256K1,
             *utils::UNSPENDABLE_XONLY_PUBKEY,
             None,
             bitcoin::Network::Regtest,

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -20,7 +20,7 @@ use bitvm::signatures::winternitz;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::rpc_params;
-use secp256k1::{schnorr, Message};
+use secp256k1::{schnorr, Message, SECP256K1};
 use serde_json::json;
 
 #[derive(Debug, Clone)]
@@ -442,7 +442,7 @@ impl Operator {
         };
         tx.input[0].witness.push(user_sig_wrapped.serialize());
 
-        utils::SECP.verify_schnorr(
+        SECP256K1.verify_schnorr(
             &user_sig,
             &Message::from_digest(*sighash.as_byte_array()),
             &user_xonly_pk,

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     errors::BridgeError,
     musig2::{self, MuSigPubNonce, MuSigSecNonce},
-    sha256_hash, utils,
+    sha256_hash,
     verifier::{NofN, NonceSession, Verifier},
     ByteArray32, ByteArray66, EVMAddress,
 };
@@ -253,7 +253,7 @@ impl ClementineVerifier for Verifier {
             session_id
         };
 
-        let public_key = secp256k1::PublicKey::from_secret_key(&SECP256K1, &private_key)
+        let public_key = secp256k1::PublicKey::from_secret_key(SECP256K1, &private_key)
             .serialize()
             .to_vec();
         let public_key_hash = sha256_hash!(&public_key);

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -19,7 +19,7 @@ use bitvm::{
     bridge::transactions::signing_winternitz::WinternitzPublicKey, signatures::winternitz,
 };
 use futures::StreamExt;
-use secp256k1::{schnorr, Message, XOnlyPublicKey};
+use secp256k1::{schnorr, Message, XOnlyPublicKey, SECP256K1};
 use std::{pin::pin, str::FromStr};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -127,7 +127,7 @@ impl ClementineVerifier for Verifier {
         timeout_tx_sighash_stream
             .enumerate()
             .map(|(i, sighash)| {
-                utils::SECP
+                SECP256K1
                     .verify_schnorr(
                         &timeout_tx_sigs[i],
                         &Message::from(sighash?),
@@ -253,7 +253,7 @@ impl ClementineVerifier for Verifier {
             session_id
         };
 
-        let public_key = secp256k1::PublicKey::from_secret_key(&utils::SECP, &private_key)
+        let public_key = secp256k1::PublicKey::from_secret_key(&SECP256K1, &private_key)
             .serialize()
             .to_vec();
         let public_key_hash = sha256_hash!(&public_key);
@@ -515,7 +515,7 @@ impl ClementineVerifier for Verifier {
             };
 
             tracing::debug!("Verifying Final Signature");
-            utils::SECP
+            SECP256K1
                 .verify_schnorr(
                     &final_sig,
                     &secp256k1::Message::from(sighash),

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -13,11 +13,6 @@ use tracing::level_filters::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{fmt, EnvFilter, Registry};
 
-// lazy_static::lazy_static! {
-//     /// Global secp context.
-//     pub static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
-// }
-
 lazy_static::lazy_static! {
     /// This is an unspendable pubkey.
     ///

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -13,10 +13,10 @@ use tracing::level_filters::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{fmt, EnvFilter, Registry};
 
-lazy_static::lazy_static! {
-    /// Global secp context.
-    pub static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
-}
+// lazy_static::lazy_static! {
+//     /// Global secp context.
+//     pub static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
+// }
 
 lazy_static::lazy_static! {
     /// This is an unspendable pubkey.

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -18,7 +18,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::Address;
 use bitcoin::{secp256k1, OutPoint};
 use bitcoincore_rpc::RawTx;
-use secp256k1::{rand, schnorr};
+use secp256k1::{rand, schnorr, SECP256K1};
 
 #[derive(Debug)]
 pub struct NonceSession {
@@ -236,7 +236,7 @@ impl Verifier {
             );
 
             // Check if they are really the operators that sent these kickoff_utxos
-            utils::SECP.verify_schnorr(
+            SECP256K1.verify_schnorr(
                 &operators_kickoff_sigs[i],
                 &secp256k1::Message::from_digest(kickoff_sig_hash),
                 &self.config.operators_xonly_pks[i],
@@ -400,7 +400,7 @@ impl Verifier {
                     Actor::convert_tx_to_sighash_script_spend(&mut slash_or_take_tx_handler, 0, 0)
                         .unwrap();
 
-                utils::SECP
+                SECP256K1
                     .verify_schnorr(
                         &slash_or_take_sigs[index],
                         &secp256k1::Message::from_digest(slash_or_take_sighash.to_byte_array()),
@@ -477,7 +477,7 @@ impl Verifier {
         let (kickoff_utxos, mut move_tx_handler, bridge_fund_outpoint) =
             self.create_deposit_details(deposit_outpoint).await?;
         let nofn_taproot_xonly_pk = secp256k1::XOnlyPublicKey::from_slice(
-            &Address::p2tr(&utils::SECP, self.nofn_xonly_pk, None, self.config.network)
+            &Address::p2tr(&SECP256K1, self.nofn_xonly_pk, None, self.config.network)
                 .script_pubkey()
                 .as_bytes()[2..34],
         )?;
@@ -523,7 +523,7 @@ impl Verifier {
                     Actor::convert_tx_to_sighash_pubkey_spend(&mut operator_takes_tx, 0).unwrap();
 
                 // verify the operator_take_sigs
-                utils::SECP
+                SECP256K1
                     .verify_schnorr(
                         &operator_take_sigs[index],
                         &secp256k1::Message::from_digest(sig_hash.to_byte_array()),

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -12,7 +12,7 @@ use crate::musig2::{
     self, AggregateFromPublicKeys, MuSigAggNonce, MuSigPartialSignature, MuSigPubNonce,
     MuSigSecNonce, MuSigSigHash,
 };
-use crate::{utils, ByteArray32, ByteArray64, ByteArray66, EVMAddress, UTXO};
+use crate::{ByteArray32, ByteArray64, ByteArray66, EVMAddress, UTXO};
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::Hash;
 use bitcoin::Address;
@@ -477,7 +477,7 @@ impl Verifier {
         let (kickoff_utxos, mut move_tx_handler, bridge_fund_outpoint) =
             self.create_deposit_details(deposit_outpoint).await?;
         let nofn_taproot_xonly_pk = secp256k1::XOnlyPublicKey::from_slice(
-            &Address::p2tr(&SECP256K1, self.nofn_xonly_pk, None, self.config.network)
+            &Address::p2tr(SECP256K1, self.nofn_xonly_pk, None, self.config.network)
                 .script_pubkey()
                 .as_bytes()[2..34],
         )?;

--- a/core/tests/musig2.rs
+++ b/core/tests/musig2.rs
@@ -28,7 +28,7 @@ fn get_verifiers_keys(
 
     let verifiers_secret_public_keys: Vec<Keypair> = verifiers_secret_keys
         .iter()
-        .map(|sk| Keypair::from_secret_key(&SECP256K1, sk))
+        .map(|sk| Keypair::from_secret_key(SECP256K1, sk))
         .collect();
 
     let verifier_public_keys = verifiers_secret_public_keys
@@ -295,7 +295,7 @@ async fn script_spend() {
     let scripts: Vec<ScriptBuf> = vec![musig2_script];
 
     let to_address = bitcoin::Address::p2tr(
-        &SECP256K1,
+        SECP256K1,
         *utils::UNSPENDABLE_XONLY_PUBKEY,
         None,
         bitcoin::Network::Regtest,

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -25,8 +25,8 @@ async fn create_address_and_transaction_then_sign_transaction() {
     )
     .await;
 
-    let (xonly_pk, _) = config.secret_key.public_key(&SECP256K1).x_only_public_key();
-    let address = Address::p2tr(&SECP256K1, xonly_pk, None, config.network);
+    let (xonly_pk, _) = config.secret_key.public_key(SECP256K1).x_only_public_key();
+    let address = Address::p2tr(SECP256K1, xonly_pk, None, config.network);
     let script = address.script_pubkey();
     let tweaked_pk_script: [u8; 32] = script.as_bytes()[2..].try_into().unwrap();
 
@@ -35,7 +35,7 @@ async fn create_address_and_transaction_then_sign_transaction() {
     hasher.input(&xonly_pk.serialize());
     xonly_pk
         .add_tweak(
-            &SECP256K1,
+            SECP256K1,
             &secp256k1::Scalar::from_be_bytes(TapTweakHash::from_engine(hasher).to_byte_array())
                 .unwrap(),
         )

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -7,8 +7,9 @@ use clementine_core::actor::Actor;
 use clementine_core::builder::transaction::TxHandler;
 use clementine_core::builder::{self};
 use clementine_core::extended_rpc::ExtendedRpc;
-use clementine_core::utils::{handle_taproot_witness_new, SECP};
+use clementine_core::utils::handle_taproot_witness_new;
 use clementine_core::{config::BridgeConfig, database::Database, utils::initialize_logger};
+use secp256k1::SECP256K1;
 use std::{env, thread};
 
 mod common;
@@ -24,8 +25,8 @@ async fn create_address_and_transaction_then_sign_transaction() {
     )
     .await;
 
-    let (xonly_pk, _) = config.secret_key.public_key(&SECP).x_only_public_key();
-    let address = Address::p2tr(&SECP, xonly_pk, None, config.network);
+    let (xonly_pk, _) = config.secret_key.public_key(&SECP256K1).x_only_public_key();
+    let address = Address::p2tr(&SECP256K1, xonly_pk, None, config.network);
     let script = address.script_pubkey();
     let tweaked_pk_script: [u8; 32] = script.as_bytes()[2..].try_into().unwrap();
 
@@ -34,7 +35,7 @@ async fn create_address_and_transaction_then_sign_transaction() {
     hasher.input(&xonly_pk.serialize());
     xonly_pk
         .add_tweak(
-            &SECP,
+            &SECP256K1,
             &secp256k1::Scalar::from_be_bytes(TapTweakHash::from_engine(hasher).to_byte_array())
                 .unwrap(),
         )


### PR DESCRIPTION
# Description
This PR introduces the global context provided by secp256k1 crate to reduce unnecessary operations for curve operations.

## Linked Issues
- Closes #406 .