### PR TITLE
Convert Owned Vec to Ref in API signatures

### DIFF
--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -120,10 +120,10 @@ impl Aggregator {
         );
         // tracing::debug!("aggregate SLASH_OR_TAKE_TX message: {:?}", message);
         let final_sig = aggregate_partial_signatures(
-            self.config.verifiers_public_keys.clone(),
+            &self.config.verifiers_public_keys,
             None,
             *agg_nonce,
-            partial_sigs,
+            &partial_sigs,
             message,
         )?;
         // tracing::debug!("aggregate SLASH_OR_TAKE_TX final_sig: {:?}", final_sig);
@@ -202,10 +202,10 @@ impl Aggregator {
             Actor::convert_tx_to_sighash_pubkey_spend(&mut tx_handler, 0)?.to_byte_array(),
         );
         let final_sig = aggregate_partial_signatures(
-            self.config.verifiers_public_keys.clone(),
+            &self.config.verifiers_public_keys,
             Some(Musig2Mode::OnlyKeySpend),
             *agg_nonce,
-            partial_sigs,
+            &partial_sigs,
             message,
         )?;
         // tracing::debug!("OPERATOR_TAKES_TX final_sig: {:?}", final_sig);
@@ -236,10 +236,10 @@ impl Aggregator {
             Actor::convert_tx_to_sighash_script_spend(&mut tx, 0, 0)?.to_byte_array(),
         );
         let final_sig = aggregate_partial_signatures(
-            self.config.verifiers_public_keys.clone(),
+            &self.config.verifiers_public_keys,
             None,
             *agg_nonce,
-            partial_sigs,
+            &partial_sigs,
             message,
         )?;
 
@@ -255,11 +255,11 @@ impl Aggregator {
         for i in 0..pub_nonces[0].len() {
             let pub_nonces = pub_nonces
                 .iter()
-                .map(|ith_pub_nonces| ith_pub_nonces.get(i).cloned())
+                .map(|ith_pub_nonces| ith_pub_nonces.get(i))
                 .collect::<Option<Vec<_>>>()
                 .ok_or(BridgeError::NoncesNotFound)?;
 
-            agg_nonces.push(aggregate_nonces(pub_nonces));
+            agg_nonces.push(aggregate_nonces(&pub_nonces));
         }
 
         Ok(agg_nonces)

--- a/core/src/builder/sighash.rs
+++ b/core/src/builder/sighash.rs
@@ -207,7 +207,7 @@ pub fn create_nofn_sighash_stream(
                             &kickoff_txhandler,
                             config.num_watchtowers as u32,
                             &watchtower_pks,
-                            watchtower_wots.clone(),
+                            &watchtower_wots,
                             network,
                         );
 
@@ -272,7 +272,7 @@ pub fn create_nofn_sighash_stream(
                         &assert_tx_addrs,
                         &root_hash,
                         nofn_xonly_pk,
-                        public_input_wots,
+                        &public_input_wots,
                         network,
                     );
                     yield convert_tx_to_pubkey_spend(

--- a/core/src/builder/transaction.rs
+++ b/core/src/builder/transaction.rs
@@ -500,7 +500,7 @@ pub fn create_watchtower_challenge_kickoff_txhandler(
     kickoff_tx_handler: &TxHandler,
     num_watchtowers: u32,
     watchtower_xonly_pks: &[XOnlyPublicKey],
-    watchtower_wots: Vec<Vec<[u8; 20]>>,
+    watchtower_wots: &[Vec<[u8; 20]>],
     network: bitcoin::Network,
 ) -> TxHandler {
     let tx_ins = create_tx_ins(
@@ -520,8 +520,7 @@ pub fn create_watchtower_challenge_kickoff_txhandler(
 
     let mut tx_outs = (0..num_watchtowers)
         .map(|i| {
-            let mut x =
-                verifier.checksig_verify(&wots_params, watchtower_wots[i as usize].as_ref());
+            let mut x = verifier.checksig_verify(&wots_params, &watchtower_wots[i as usize]);
             x = x.push_x_only_key(&watchtower_xonly_pks[i as usize]);
             x = x.push_opcode(OP_CHECKSIG); // TODO: Add checksig in the beginning
             let x = x.compile();
@@ -731,7 +730,7 @@ pub fn create_assert_end_txhandler(
     assert_tx_addrs: &[ScriptBuf],
     root_hash: &[u8; 32],
     nofn_xonly_pk: XOnlyPublicKey,
-    _public_input_wots: Vec<[u8; 20]>,
+    _public_input_wots: &[[u8; 20]],
     network: bitcoin::Network,
 ) -> TxHandler {
     let mut last_mini_assert_txid =

--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -76,11 +76,14 @@ lazy_static! {
 }
 
 fn create_key_agg_cache(
-    public_keys: Vec<PublicKey>,
+    public_keys: impl AsRef<[PublicKey]>,
     mode: Option<Musig2Mode>,
 ) -> Result<MusigKeyAggCache, BridgeError> {
-    let secp_pubkeys: Vec<secp256k1::PublicKey> =
-        public_keys.iter().map(|pk| to_secp_pk(*pk)).collect();
+    let secp_pubkeys: Vec<secp256k1::PublicKey> = public_keys
+        .as_ref()
+        .iter()
+        .map(|pk| to_secp_pk(*pk))
+        .collect();
     let pubkeys_ref: Vec<&secp256k1::PublicKey> = secp_pubkeys.iter().collect();
     let pubkeys_ref = pubkeys_ref.as_slice();
 
@@ -140,21 +143,19 @@ impl AggregateFromPublicKeys for XOnlyPublicKey {
 }
 
 // Aggregates the public nonces into a single aggregated nonce.
-pub fn aggregate_nonces(pub_nonces: Vec<MusigPubNonce>) -> MusigAggNonce {
-    let pub_nonces = pub_nonces.iter().collect::<Vec<_>>();
-
-    MusigAggNonce::new(SECP256K1, pub_nonces.as_slice())
+pub fn aggregate_nonces(pub_nonces: &[&MusigPubNonce]) -> MusigAggNonce {
+    MusigAggNonce::new(SECP256K1, pub_nonces)
 }
 
 // Aggregates the partial signatures into a single aggregated signature.
 pub fn aggregate_partial_signatures(
-    pks: Vec<PublicKey>,
+    pks: &[PublicKey],
     tweak: Option<Musig2Mode>,
     agg_nonce: MusigAggNonce,
-    partial_sigs: Vec<MusigPartialSignature>,
+    partial_sigs: &[MusigPartialSignature],
     message: Message,
 ) -> Result<schnorr::Signature, BridgeError> {
-    let musig_key_agg_cache = create_key_agg_cache(pks, tweak)?;
+    let musig_key_agg_cache: MusigKeyAggCache = create_key_agg_cache(pks, tweak)?;
     let secp_message = to_secp_msg(&message);
 
     let session = MusigSession::new(SECP256K1, &musig_key_agg_cache, agg_nonce, secp_message);
@@ -274,8 +275,9 @@ mod tests {
         let aggregated_nonce = super::aggregate_nonces(
             nonce_pairs
                 .iter()
-                .map(|(_, musig_pub_nonce)| *musig_pub_nonce)
-                .collect(),
+                .map(|(_, musig_pub_nonce)| musig_pub_nonce)
+                .collect::<Vec<_>>()
+                .as_slice(),
         );
 
         let partial_sigs = key_pairs
@@ -295,10 +297,10 @@ mod tests {
             .collect::<Vec<_>>();
 
         let final_signature = super::aggregate_partial_signatures(
-            public_keys.clone(),
+            &public_keys,
             None,
             aggregated_nonce,
-            partial_sigs,
+            &partial_sigs,
             message,
         )
         .unwrap();
@@ -324,7 +326,7 @@ mod tests {
         let (sec_nonce_2, pub_nonce_2) =
             super::nonce_pair(&kp_2, &mut secp256k1::rand::thread_rng()).unwrap();
 
-        let agg_nonce = super::aggregate_nonces(vec![pub_nonce_0, pub_nonce_1, pub_nonce_2]);
+        let agg_nonce = super::aggregate_nonces(&[&pub_nonce_0, &pub_nonce_1, &pub_nonce_2]);
 
         let partial_sig_0 =
             super::partial_sign(pks.clone(), None, sec_nonce_0, agg_nonce, kp_0, message).unwrap();
@@ -345,7 +347,7 @@ mod tests {
         let partial_sigs = vec![partial_sig_0, partial_sig_1, partial_sig_2];
 
         let final_signature: Result<schnorr::Signature, BridgeError> =
-            super::aggregate_partial_signatures(pks, None, agg_nonce, partial_sigs, message);
+            super::aggregate_partial_signatures(&pks, None, agg_nonce, &partial_sigs, message);
 
         assert!(final_signature.is_err());
     }
@@ -371,8 +373,9 @@ mod tests {
         let aggregated_nonce = super::aggregate_nonces(
             nonce_pairs
                 .iter()
-                .map(|(_, musig_pub_nonce)| *musig_pub_nonce)
-                .collect(),
+                .map(|(_, musig_pub_nonce)| musig_pub_nonce)
+                .collect::<Vec<_>>()
+                .as_slice(),
         );
 
         let partial_sigs = key_pairs
@@ -394,12 +397,12 @@ mod tests {
             .collect::<Vec<_>>();
 
         let final_signature = super::aggregate_partial_signatures(
-            public_keys,
+            &public_keys,
             Some(Musig2Mode::KeySpendWithScript(
                 TapNodeHash::from_slice(&tweak).unwrap(),
             )),
             aggregated_nonce,
-            partial_sigs,
+            &partial_sigs,
             message,
         )
         .unwrap();
@@ -427,7 +430,7 @@ mod tests {
         let (sec_nonce_2, pub_nonce_2) =
             super::nonce_pair(&kp_2, &mut secp256k1::rand::thread_rng()).unwrap();
 
-        let agg_nonce = super::aggregate_nonces(vec![pub_nonce_0, pub_nonce_1, pub_nonce_2]);
+        let agg_nonce = super::aggregate_nonces(&[&pub_nonce_0, &pub_nonce_1, &pub_nonce_2]);
 
         let partial_sig_0 = super::partial_sign(
             pks.clone(),
@@ -457,12 +460,12 @@ mod tests {
         let partial_sigs = vec![partial_sig_0, partial_sig_1, partial_sig_2];
 
         let final_signature = super::aggregate_partial_signatures(
-            pks,
+            &pks,
             Some(Musig2Mode::KeySpendWithScript(
                 TapNodeHash::from_slice(&tweak).unwrap(),
             )),
             agg_nonce,
-            partial_sigs,
+            &partial_sigs,
             message,
         );
 
@@ -483,8 +486,9 @@ mod tests {
         let agg_nonce = super::aggregate_nonces(
             nonce_pairs
                 .iter()
-                .map(|(_, musig_pub_nonce)| *musig_pub_nonce)
-                .collect(),
+                .map(|(_, musig_pub_nonce)| musig_pub_nonce)
+                .collect::<Vec<_>>()
+                .as_slice(),
         );
 
         let dummy_script = script::Builder::new().push_int(1).into_script();
@@ -551,10 +555,10 @@ mod tests {
             .collect();
 
         let final_signature = super::aggregate_partial_signatures(
-            public_keys.clone(),
+            &public_keys,
             Some(Musig2Mode::KeySpendWithScript(merkle_root)),
             agg_nonce,
-            partial_sigs,
+            &partial_sigs,
             message,
         )
         .unwrap();
@@ -577,7 +581,13 @@ mod tests {
             .map(|key_pair| key_pair.public_key())
             .collect::<Vec<PublicKey>>();
 
-        let agg_nonce = super::aggregate_nonces(nonce_pairs.iter().map(|x| x.1).collect());
+        let agg_nonce = super::aggregate_nonces(
+            nonce_pairs
+                .iter()
+                .map(|x| &x.1)
+                .collect::<Vec<_>>()
+                .as_slice(),
+        );
         let musig_agg_xonly_pubkey_wrapped =
             XOnlyPublicKey::from_musig2_pks(public_keys.clone(), None).unwrap();
 
@@ -648,10 +658,10 @@ mod tests {
             .collect();
 
         let final_signature = super::aggregate_partial_signatures(
-            public_keys,
+            &public_keys,
             None,
             agg_nonce,
-            partial_sigs,
+            &partial_sigs,
             message,
         )
         .unwrap();
@@ -713,7 +723,7 @@ mod tests {
             nonce_pair(&kp1, &mut bitcoin::secp256k1::rand::thread_rng()).unwrap();
         let (sec_nonce2, pub_nonce2) =
             nonce_pair(&kp2, &mut bitcoin::secp256k1::rand::thread_rng()).unwrap();
-        let agg_nonce = aggregate_nonces(vec![pub_nonce1, pub_nonce2]);
+        let agg_nonce = aggregate_nonces(&[&pub_nonce1, &pub_nonce2]);
 
         let partial_sig1 = partial_sign(
             public_keys.clone(),
@@ -735,10 +745,10 @@ mod tests {
         .unwrap();
 
         let final_sig = aggregate_partial_signatures(
-            public_keys.clone(),
+            &public_keys,
             Some(key_spend_with_script_tweak),
             agg_nonce,
-            vec![partial_sig1, partial_sig2],
+            &[partial_sig1, partial_sig2],
             message,
         )
         .unwrap();

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -56,7 +56,7 @@ async fn nonce_aggregator(
         ))
         .await?;
 
-        let agg_nonce = aggregate_nonces(pub_nonces);
+        let agg_nonce = aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice());
 
         agg_nonce_sender
             .send(AggNonceQueueItem { agg_nonce, sighash })
@@ -84,7 +84,7 @@ async fn nonce_aggregator(
     }))
     .await?;
 
-    let agg_nonce = aggregate_nonces(pub_nonces);
+    let agg_nonce = aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice());
 
     Ok(agg_nonce)
 }
@@ -143,10 +143,10 @@ async fn signature_aggregator(
 ) -> Result<(), BridgeError> {
     while let Some((partial_sigs, queue_item)) = partial_sig_receiver.recv().await {
         let final_sig = crate::musig2::aggregate_partial_signatures(
-            verifiers_public_keys.clone(),
+            &verifiers_public_keys,
             None,
             queue_item.agg_nonce,
-            partial_sigs,
+            &partial_sigs,
             Message::from_digest(queue_item.sighash.as_raw_hash().to_byte_array()),
         )?;
 

--- a/core/tests/musig2.rs
+++ b/core/tests/musig2.rs
@@ -18,7 +18,7 @@ use clementine_core::{
     utils,
 };
 use clementine_core::{database::Database, utils::initialize_logger};
-use secp256k1::musig::{MusigAggNonce, MusigPartialSignature, MusigPubNonce};
+use secp256k1::musig::{MusigAggNonce, MusigPartialSignature};
 use std::{env, thread};
 
 mod common;
@@ -55,8 +55,9 @@ fn get_nonces(verifiers_secret_public_keys: Vec<Keypair>) -> (Vec<MuSigNoncePair
     let agg_nonce = aggregate_nonces(
         nonce_pairs
             .iter()
-            .map(|(_, musig_pub_nonces)| *musig_pub_nonces)
-            .collect::<Vec<MusigPubNonce>>(),
+            .map(|(_, musig_pub_nonces)| musig_pub_nonces)
+            .collect::<Vec<_>>()
+            .as_slice(),
     );
 
     (nonce_pairs, agg_nonce)
@@ -129,10 +130,10 @@ async fn key_spend() {
         .collect();
 
     let final_signature = aggregate_partial_signatures(
-        verifier_public_keys.clone(),
+        &verifier_public_keys,
         Some(Musig2Mode::OnlyKeySpend),
         agg_nonce,
-        partial_sigs,
+        &partial_sigs,
         message,
     )
     .unwrap();
@@ -227,10 +228,10 @@ async fn key_spend_with_script() {
         .collect();
 
     let final_signature = aggregate_partial_signatures(
-        verifier_public_keys.clone(),
+        &verifier_public_keys,
         Some(Musig2Mode::KeySpendWithScript(merkle_root)),
         agg_nonce,
-        partial_sigs,
+        &partial_sigs,
         message,
     )
     .unwrap();
@@ -331,10 +332,10 @@ async fn script_spend() {
         })
         .collect();
     let final_signature = aggregate_partial_signatures(
-        verifier_public_keys.clone(),
+        &verifier_public_keys,
         None,
         agg_nonce,
-        partial_sigs,
+        &partial_sigs,
         message,
     )
     .unwrap();


### PR DESCRIPTION
# Description

Changed into &[] types for Vec taking functions:

- aggregate_partial_signatures
- create_assert_end_tx_handler
- aggregate_nonces

## Linked Issues

- Work on #432 (not complete)

Requires merge of #447 before review
