### PR TITLE
style: minor cleanup

### DIFF
--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -1,28 +1,14 @@
 use bitcoin::{Amount, BlockHash};
-// use clementine_circuits::constants::CLAIM_MERKLE_TREE_DEPTH;
 use crypto_bigint::U256;
 
 /// For connector tree utxos, we should wait some time for any verifier to burn the branch if preimage is revealed
 pub const CONNECTOR_TREE_OPERATOR_TAKES_AFTER: u16 = 1;
 
-/// Depth of the utxo tree from the source connector utxo, it is probably equal to claim merkle tree depth
-// pub const CONNECTOR_TREE_DEPTH: usize = CLAIM_MERKLE_TREE_DEPTH;
-
 /// Dust value for mempool acceptance
 pub const DUST_VALUE: Amount = Amount::from_sat(1000);
 
-/// Minimum relay fee for mempool acceptance
-// pub const MIN_RELAY_FEE: Amount = Amount::from_sat(289);
-
 /// This is temporary. to be able to set PERIOD_END_BLOCK_HEIGHTS
 pub const PERIOD_BLOCK_COUNT: u32 = 50; // 10 mins for 1 block, 6 months = 6*30*24*6 = 25920
-
-/// For deposits, every user makes a timelock to take the money back if deposit deos not happen,
-/// one reason is to not spam the bridge operator
-// pub const USER_TAKES_AFTER: u32 = 200;
-
-/// For deposits, bridge operator does not accept the tx if it is not confirmed
-// pub const CONFIRMATION_BLOCK_COUNT: u32 = 1;
 
 /// K_DEEP is the give time to verifier to make a proper challenge
 pub const K_DEEP: u32 = 3;
@@ -31,5 +17,3 @@ pub const K_DEEP: u32 = 3;
 pub const MAX_BITVM_CHALLENGE_RESPONSE_BLOCKS: u32 = 5;
 
 pub type VerifierChallenge = (BlockHash, U256, u8);
-
-// pub const TEST_MODE: bool = true;

--- a/core/src/database/wrapper.rs
+++ b/core/src/database/wrapper.rs
@@ -37,7 +37,7 @@ impl sqlx::Type<sqlx::Postgres> for OutPointDB {
     }
 }
 
-impl<'q> Encode<'q, Postgres> for OutPointDB {
+impl Encode<'_, Postgres> for OutPointDB {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> sqlx::encode::IsNull {
         let s = self.0.to_string();
 
@@ -59,7 +59,7 @@ impl sqlx::Type<sqlx::Postgres> for AddressDB {
     }
 }
 
-impl<'q> Encode<'q, Postgres> for AddressDB {
+impl Encode<'_, Postgres> for AddressDB {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> sqlx::encode::IsNull {
         let s = self.0.clone().assume_checked().to_string();
         <&str as Encode<Postgres>>::encode_by_ref(&s.as_str(), buf)
@@ -79,7 +79,7 @@ impl sqlx::Type<sqlx::Postgres> for EVMAddressDB {
     }
 }
 
-impl<'q> Encode<'q, Postgres> for EVMAddressDB {
+impl Encode<'_, Postgres> for EVMAddressDB {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> sqlx::encode::IsNull {
         let s = hex::encode(self.0 .0);
         <&str as Encode<Postgres>>::encode_by_ref(&s.as_str(), buf)
@@ -101,7 +101,7 @@ impl sqlx::Type<sqlx::Postgres> for TxidDB {
     }
 }
 
-impl<'q> Encode<'q, Postgres> for TxidDB {
+impl Encode<'_, Postgres> for TxidDB {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> sqlx::encode::IsNull {
         let s = bitcoin::consensus::encode::serialize_hex(&self.0);
         <&str as Encode<Postgres>>::encode_by_ref(&s.as_str(), buf)
@@ -122,7 +122,7 @@ impl sqlx::Type<sqlx::Postgres> for TxOutDB {
     }
 }
 
-impl<'q> Encode<'q, Postgres> for TxOutDB {
+impl Encode<'_, Postgres> for TxOutDB {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> sqlx::encode::IsNull {
         let s = bitcoin::consensus::encode::serialize_hex(&self.0);
         <&str as Encode<Postgres>>::encode_by_ref(&s.as_str(), buf)
@@ -143,7 +143,7 @@ impl sqlx::Type<sqlx::Postgres> for SignatureDB {
     }
 }
 
-impl<'q> Encode<'q, Postgres> for SignatureDB {
+impl Encode<'_, Postgres> for SignatureDB {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> sqlx::encode::IsNull {
         let s: String = secp256k1::schnorr::Signature::to_string(&self.0);
         <&str as Encode<Postgres>>::encode_by_ref(&s.as_str(), buf)

--- a/core/src/mock/common.rs
+++ b/core/src/mock/common.rs
@@ -19,17 +19,14 @@ pub fn get_test_config(configuration_file: &str) -> Result<BridgeConfig, BridgeE
     };
 
     // Read specified configuration file from `tests/data` directory.
-    let mut config = match BridgeConfig::try_parse_file(
+    let mut config = BridgeConfig::try_parse_file(
         format!(
             "{}/tests/data/{}",
             env!("CARGO_MANIFEST_DIR"),
             configuration_file
         )
         .into(),
-    ) {
-        Ok(c) => c,
-        Err(e) => return Err(e),
-    };
+    )?;
 
     // Overwrite user's environment to test's hard coded data if environment
     // file is specified.


### PR DESCRIPTION
- address `clippy` warnings
- remove commented code (constants)