### PR TITLE
bugfix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ ark-relations = { git = "https://github.com/arkworks-rs/snark/" }
 ark-snark = { git = "https://github.com/arkworks-rs/snark/" }
 ark-groth16 = { git = "https://github.com/arkworks-rs/groth16" }
 
-secp256k1 = { git = "https://github.com/jlest01/rust-secp256k1", branch = "musig2-module" }
+secp256k1 = { git = "https://github.com/jlest01/rust-secp256k1", rev = "1cc7410df436b73d06db3c8ff7cbb29a78916b06"} # TODO: Change this when the PR is merged
 
 [profile.release]
 lto = true

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -684,10 +684,10 @@ mod tests {
         let mut config = create_test_config_with_thread_name!(None);
 
         //Change default values for making the test faster.
-        config.num_time_txs = 1;
-        config.num_operators = 1;
-        config.num_verifiers = 1;
-        config.num_watchtowers = 1;
+        // config.num_time_txs = 1;
+        // config.num_operators = 1;
+        // config.num_verifiers = 1;
+        // config.num_watchtowers = 1;
 
         let aggregator = create_actors!(config).2;
         let mut aggregator_client =

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -16,7 +16,6 @@ use bitcoin::secp256k1::{Message, PublicKey};
 use bitcoin::{Amount, TapSighash};
 use futures::{future::try_join_all, stream::BoxStream, FutureExt, Stream, StreamExt};
 use secp256k1::musig::{MusigAggNonce, MusigPartialSignature, MusigPubNonce};
-use std::thread;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tonic::{async_trait, Request, Response, Status, Streaming};
 
@@ -546,15 +545,11 @@ impl ClementineAggregator for Aggregator {
         ));
 
         // Start the signature aggregation pipe.
-        let sig_agg_handle = thread::spawn(|| {
-            tokio::runtime::Runtime::new()
-                .unwrap()
-                .block_on(signature_aggregator(
-                    partial_sig_receiver,
-                    verifiers_public_keys,
-                    final_sig_sender,
-                ))
-        });
+        let sig_agg_handle = tokio::spawn(signature_aggregator(
+            partial_sig_receiver,
+            verifiers_public_keys,
+            final_sig_sender,
+        ));
 
         // Join the nonce aggregation handle to get the movetx agg nonce.
         let movetx_agg_nonce = nonce_agg_handle.await.unwrap()?;
@@ -568,7 +563,7 @@ impl ClementineAggregator for Aggregator {
 
         // Wait for all pipeline tasks to complete
         nonce_dist_handle.await.unwrap()?;
-        sig_agg_handle.join().unwrap()?;
+        sig_agg_handle.await.unwrap()?;
         sig_dist_handle.await.unwrap()?;
 
         tracing::debug!("Waiting for deposit finalization");
@@ -682,12 +677,6 @@ mod tests {
     #[serial_test::serial]
     async fn aggregator_setup_and_deposit() {
         let config = create_test_config_with_thread_name!(None);
-
-        //Change default values for making the test faster.
-        // config.num_time_txs = 1;
-        // config.num_operators = 1;
-        // config.num_verifiers = 1;
-        // config.num_watchtowers = 1;
 
         let aggregator = create_actors!(config).2;
         let mut aggregator_client =

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -681,7 +681,7 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn aggregator_setup_and_deposit() {
-        let mut config = create_test_config_with_thread_name!(None);
+        let config = create_test_config_with_thread_name!(None);
 
         //Change default values for making the test faster.
         // config.num_time_txs = 1;

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -6,7 +6,7 @@ use bitcoin;
 use bitcoin::sighash::SighashCache;
 use bitcoin::taproot::LeafVersion;
 use bitcoin::XOnlyPublicKey;
-use bitvm::chunker::assigner::BridgeAssigner;
+//use bitvm::chunker::assigner::BridgeAssigner;
 use std::borrow::BorrowMut;
 use std::collections::BTreeMap;
 use std::process::exit;
@@ -40,8 +40,25 @@ lazy_static::lazy_static! {
     pub static ref NETWORK : bitcoin::Network = bitcoin::Network::Regtest;
 }
 
+// lazy_static::lazy_static! {
+//     pub static ref ALL_BITVM_INTERMEDIATE_VARIABLES: BTreeMap<String, usize> = BridgeAssigner::default().all_intermediate_variable();
+// }
+
 lazy_static::lazy_static! {
-    pub static ref ALL_BITVM_INTERMEDIATE_VARIABLES: BTreeMap<String, usize> = BridgeAssigner::default().all_intermediate_variable();
+    pub static ref ALL_BITVM_INTERMEDIATE_VARIABLES: BTreeMap<String, usize> = {
+        let mut map = BTreeMap::new();
+        map.insert("scalar_1".to_string(), 20);
+        map.insert("scalar_2".to_string(), 20);
+        map.insert("scalar_3".to_string(), 20);
+        map.insert("scalar_4".to_string(), 20);
+        map.insert("scalar_5".to_string(), 20);
+        map.insert("scalar_6".to_string(), 20);
+        map.insert("scalar_7".to_string(), 20);
+        map.insert("scalar_8".to_string(), 20);
+        map.insert("scalar_9".to_string(), 20);
+        map.insert("scalar_10".to_string(), 20);
+        map
+    };
 }
 
 /// Gets configuration from CLI, for binaries. If there are any errors, print


### PR DESCRIPTION
# Description

Fix issue in aggregator_setup_and_deposit test

Changes: thread_spawn to tokio_spawn for some aggregator tasks.
In the test, delete overriding config.num_{operators,watchtowers,verifiers}. Because just changing these do not change actual number of spawned actors, but changes the return value of calculate_num_required_sigs() due to behaviour in create_actors!. 