### PR TITLE
Implement key&script spend test on the same UTXO.

### DIFF
--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -12,7 +12,7 @@ use crate::{
             clementine_watchtower_client::ClementineWatchtowerClient,
         },
     },
-    utils::handle_taproot_witness_new,
+    utils::set_p2tr_script_spend_witness,
     EVMAddress,
 };
 use bitcoin::{
@@ -356,7 +356,7 @@ impl Aggregator {
             self.config.network,
         );
         let move_tx_witness_elements = vec![move_tx_sig.serialize().to_vec()];
-        handle_taproot_witness_new(&mut move_tx_handler, &move_tx_witness_elements, 0, Some(0))?;
+        set_p2tr_script_spend_witness(&mut move_tx_handler, &move_tx_witness_elements, 0, 0)?;
 
         let txid = move_tx_handler.txid;
         Ok((move_tx_handler.tx.raw_hex(), txid))

--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -194,7 +194,7 @@ pub fn nonce_pair(
 }
 
 pub fn partial_sign(
-    pks: Vec<PublicKey>,
+    pks: impl AsRef<[PublicKey]>,
     // Aggregated tweak, if there is any. This is useful for
     // Taproot key-spends, since we might have script-spend conditions.
     tweak: Option<Musig2Mode>,

--- a/core/src/test_utils.rs
+++ b/core/src/test_utils.rs
@@ -48,7 +48,7 @@ macro_rules! create_test_config_with_thread_name {
             + &suffix;
 
         // Use maximum log level for tests.
-        initialize_logger(5).unwrap();
+        initialize_logger(Some(::tracing::level_filters::LevelFilter::DEBUG)).unwrap();
 
         let mut config = BridgeConfig::default();
 
@@ -106,7 +106,12 @@ macro_rules! create_test_config_with_thread_name {
 macro_rules! initialize_database {
     ($config:expr) => {{
         let url = Database::get_postgresql_url(&$config);
-        let conn = sqlx::PgPool::connect(url.as_str()).await.unwrap();
+        let conn = sqlx::PgPool::connect(url.as_str())
+            .await
+            .expect(&format!(
+                "Failed to connect to database, please make sure a test Postgres DB is running at {}",
+                url
+            ));
 
         sqlx::query(&format!("DROP DATABASE IF EXISTS {}", &$config.db_name))
             .execute(&conn)

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -8,7 +8,7 @@ use clementine_core::actor::Actor;
 use clementine_core::builder::transaction::TxHandler;
 use clementine_core::builder::{self};
 use clementine_core::extended_rpc::ExtendedRpc;
-use clementine_core::utils::{handle_taproot_witness_new, SECP};
+use clementine_core::utils::{set_p2tr_script_spend_witness, SECP};
 use clementine_core::{config::BridgeConfig, database::Database, utils::initialize_logger};
 use std::{env, thread};
 
@@ -83,7 +83,7 @@ async fn create_address_and_transaction_then_sign_transaction() {
     let sig = signer
         .sign_taproot_script_spend_tx_new_tweaked(&mut tx_details, 0, 0)
         .unwrap();
-    handle_taproot_witness_new(&mut tx_details, &[sig.as_ref()], 0, Some(0)).unwrap();
+    set_p2tr_script_spend_witness(&mut tx_details, &[sig.as_ref()], 0, 0).unwrap();
     rpc.mine_blocks(1).await.unwrap();
 
     // New transaction should be OK to send.


### PR DESCRIPTION

# Description

Verifies that a single P2TR with both key and script spend paths are actually able to be spent using the non-tweaked Musig2 aggregation **and** tweaked

Other changes:
- change default levelfilter to DEBUG (trace is way too aggressive in most cases)
- Use LevelFilter in internal API initialize_logger (did not change external-facing config signature)
- Added nice error message when a database connection can't be established in tests
- Refactored handle_taproot_witness_new to set_p2tr_script_spend_witness:
   - made it simpler, and removed incorrect Option. I believe the Option was used to make this function multi-purpose for both spend types, but this is a bad pattern as there is very little checking of the witness content in this case, and it's easy to misuse the function.
- Added set_p2tr_key_spend_witness, does a similar thing to above but for key spends and with type checks (by taking a valid taproot::Signature)


Describe what this pull request does, here.

## Linked Issues

- Closes #427 

## Testing

This is a testing change with one new musig2 test.
