### PR TITLE
Convert NofN key spends to checksig script spends

### DIFF
--- a/core/src/builder/address.rs
+++ b/core/src/builder/address.rs
@@ -147,11 +147,11 @@ pub fn generate_deposit_address(
 /// - [`Address`]: Checksig taproot Bitcoin address
 /// - [`TaprootSpendInfo`]: Checksig address's taproot spending information
 pub fn create_checksig_address(
-    nofn_xonly_pk: XOnlyPublicKey,
+    xonly_pk: XOnlyPublicKey,
     network: bitcoin::Network,
 ) -> (Address, TaprootSpendInfo) {
-    let nofn_script = builder::script::generate_checksig_script(nofn_xonly_pk);
-    create_taproot_address(&[nofn_script], None, network)
+    let script = builder::script::generate_checksig_script(xonly_pk);
+    create_taproot_address(&[script], None, network)
 }
 
 pub fn derive_challenge_address_from_xonlypk_and_wpk(

--- a/core/src/builder/address.rs
+++ b/core/src/builder/address.rs
@@ -130,7 +130,7 @@ pub fn generate_deposit_address(
     let recovery_extracted_xonly_pk =
         XOnlyPublicKey::from_slice(&recovery_script_pubkey.as_bytes()[2..34]).unwrap();
 
-    let script_timelock = builder::script::generate_relative_timelock_script(
+    let script_timelock = builder::script::generate_checksig_relative_timelock_script(
         recovery_extracted_xonly_pk,
         user_takes_after,
     );
@@ -138,20 +138,20 @@ pub fn generate_deposit_address(
     create_taproot_address(&[deposit_script, script_timelock], None, network)
 }
 
-/// Shorthand function for creating a MuSig2 taproot address: No scripts and
-/// `nofn_xonly_pk` as the internal key.
+/// Shorthand function for creating a checksig taproot address: A single checksig script with the given xonly PK and no internal key.
 ///
 /// # Returns
 ///
 /// See [`create_taproot_address`].
 ///
-/// - [`Address`]: MuSig2 taproot Bitcoin address
-/// - [`TaprootSpendInfo`]: MuSig2 address's taproot spending information
-pub fn create_musig2_address(
+/// - [`Address`]: Checksig taproot Bitcoin address
+/// - [`TaprootSpendInfo`]: Checksig address's taproot spending information
+pub fn create_checksig_address(
     nofn_xonly_pk: XOnlyPublicKey,
     network: bitcoin::Network,
 ) -> (Address, TaprootSpendInfo) {
-    create_taproot_address(&[], Some(nofn_xonly_pk), network)
+    let nofn_script = builder::script::generate_checksig_script(nofn_xonly_pk);
+    create_taproot_address(&[nofn_script], None, network)
 }
 
 pub fn derive_challenge_address_from_xonlypk_and_wpk(

--- a/core/src/builder/script.rs
+++ b/core/src/builder/script.rs
@@ -133,8 +133,7 @@ pub fn actor_with_preimage_script(
 
 /// Generates a signature verification script.
 ///
-/// This script is a simple P2PKH script that pays to the signature generated from the
-/// given xonly pk.
+/// This is a simple P2PK script that pays to the given xonly pk.
 ///
 /// # Parameters
 ///

--- a/core/src/builder/script.rs
+++ b/core/src/builder/script.rs
@@ -67,6 +67,8 @@ pub fn create_deposit_script(
         .into_script()
 }
 
+/// Generates a relative timelock script with a given [`XOnlyPublicKey`] that CHECKSIG checks the signature against.
+///
 /// ATTENTION: If you want to spend a UTXO using timelock script, the
 /// condition is that (`# in the script`) ≤ (`# in the sequence of the tx`)
 /// ≤ (`# of blocks mined after UTXO appears on the chain`). However, this is not mandatory.
@@ -76,23 +78,37 @@ pub fn create_deposit_script(
 /// - [BIP-0068](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki)
 /// - [BIP-0112](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki)
 ///
-/// `actor_taproot_xonly_pk` is the tweaked XonlyPublicKey, which appears in the script_pubkey
-/// of the address. The tweaked signature will be given accordingly.
-pub fn generate_relative_timelock_script(
-    actor_taproot_xonly_pk: XOnlyPublicKey,
+/// # Parameters
+///
+/// - `xonly_pk`: The XonlyPublicKey that CHECKSIG checks the signature against.
+/// - `block_count`: The number of blocks after which the funds can be spent.
+///
+/// # Returns
+///
+/// - [`ScriptBuf`]: The relative timelock script with signature verification
+pub fn generate_checksig_relative_timelock_script(
+    xonly_pk: XOnlyPublicKey,
     block_count: u16,
 ) -> ScriptBuf {
     Builder::new()
         .push_int(i64::from(block_count))
         .push_opcode(OP_CSV)
         .push_opcode(OP_DROP)
-        .push_x_only_key(&actor_taproot_xonly_pk)
+        .push_x_only_key(&xonly_pk)
         .push_opcode(OP_CHECKSIG)
         .into_script()
 }
 
 /// Generates a relative timelock script without a key. This means after the specified block count, the funds can be spent by anyone.
-pub fn generate_relative_timelock_script_no_key(block_count: i64) -> ScriptBuf {
+///
+/// # Parameters
+///
+/// - `block_count`: The number of blocks after which the funds can be spent.
+///
+/// # Returns
+///
+/// - [`ScriptBuf`]: The relative timelock script without a key
+pub fn generate_relative_timelock_script(block_count: i64) -> ScriptBuf {
     Builder::new()
         .push_int(block_count)
         .push_opcode(OP_CSV)
@@ -116,9 +132,20 @@ pub fn actor_with_preimage_script(
 }
 
 /// Generates a signature verification script.
-pub fn checksig_script(actor_taproot_xonly_pk: XOnlyPublicKey) -> ScriptBuf {
+///
+/// This script is a simple P2PKH script that pays to the signature generated from the
+/// given xonly pk.
+///
+/// # Parameters
+///
+/// - `xonly_pk`: The x-only public key of the actor.
+///
+/// # Returns
+///
+/// - [`ScriptBuf`]: The script that unlocks with the given `xonly_pk`'s signature
+pub fn generate_checksig_script(xonly_pk: XOnlyPublicKey) -> ScriptBuf {
     Builder::new()
-        .push_x_only_key(&actor_taproot_xonly_pk)
+        .push_x_only_key(&xonly_pk)
         .push_opcode(OP_CHECKSIG)
         .into_script()
 }

--- a/core/src/builder/transaction/challenge.rs
+++ b/core/src/builder/transaction/challenge.rs
@@ -135,7 +135,7 @@ pub fn create_watchtower_challenge_txhandler(
     );
 
     let nofn_halfweek =
-        builder::script::generate_relative_timelock_script(nofn_xonly_pk, 7 * 24 * 6 / 2); // 0.5 week
+        builder::script::generate_checksig_relative_timelock_script(nofn_xonly_pk, 7 * 24 * 6 / 2); // 0.5 week
     let operator_with_preimage =
         builder::script::actor_with_preimage_script(operator_xonly_pk, operator_unlock_hash);
     let (op_or_nofn_halfweek, op_or_nofn_halfweek_spend) = builder::address::create_taproot_address(
@@ -185,7 +185,7 @@ pub fn create_watchtower_challenge_txhandler_simplified(
     );
 
     let nofn_halfweek =
-        builder::script::generate_relative_timelock_script(nofn_xonly_pk, 7 * 24 * 6 / 2); // 0.5 week
+        builder::script::generate_checksig_relative_timelock_script(nofn_xonly_pk, 7 * 24 * 6 / 2); // 0.5 week
     let operator_with_preimage =
         builder::script::actor_with_preimage_script(operator_xonly_pk, operator_unlock_hash);
     let (op_or_nofn_halfweek, op_or_nofn_halfweek_spend) = builder::address::create_taproot_address(

--- a/core/src/builder/transaction/operator_assert.rs
+++ b/core/src/builder/transaction/operator_assert.rs
@@ -145,11 +145,9 @@ pub fn create_assert_end_txhandler(
     });
 
     let disprove_taproot_spend_info = TaprootBuilder::new()
-        .add_hidden_node(1, TapNodeHash::from_slice(root_hash).unwrap())
+        .add_hidden_node(0, TapNodeHash::from_slice(root_hash).unwrap())
         .unwrap()
-        .add_leaf(1, builder::script::generate_checksig_script(nofn_xonly_pk))
-        .unwrap()
-        .finalize(&SECP, nofn_xonly_pk) // TODO: how would we put this in a script?
+        .finalize(&SECP, nofn_xonly_pk) // TODO: we should convert this to script spend but we only have partial access to the taptree
         .unwrap();
 
     let disprove_address = Address::p2tr(

--- a/core/src/builder/transaction/operator_collateral.rs
+++ b/core/src/builder/transaction/operator_collateral.rs
@@ -48,13 +48,14 @@ pub fn create_sequential_collateral_txhandler(
         }]
         .into(),
     );
-    let max_withdrawal_time_locked_script = builder::script::generate_relative_timelock_script(
-        operator_xonly_pk,
-        max_withdrawal_time_block_count,
-    );
+    let max_withdrawal_time_locked_script =
+        builder::script::generate_checksig_relative_timelock_script(
+            operator_xonly_pk,
+            max_withdrawal_time_block_count,
+        );
 
     let timeout_block_count_locked_script =
-        builder::script::generate_relative_timelock_script_no_key(timeout_block_count);
+        builder::script::generate_relative_timelock_script(timeout_block_count);
 
     let (op_address, op_spend) = create_taproot_address(&[], Some(operator_xonly_pk), network);
     let (reimburse_gen_connector, reimburse_gen_spend) =


### PR DESCRIPTION
# Description

This PR moves the keyspend to the script path to reduce work done by signers/aggregators with tweaking.

## Linked Issues

- Closes #461 

## Testing

None, we should add spending tests.

