### PR TITLE
RPC module de business logicification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.12"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
  "shlex",
 ]
@@ -4576,9 +4576,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
 ]

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -269,6 +269,11 @@ pub enum BridgeError {
 
     #[error("{0} input channel for {1} ended prematurely")]
     ChannelEndedPrematurely(&'static str, &'static str),
+
+    // TODO: Couldn't put `from[SendError<T>]` because of generics, find a way
+    /// 0: Data name, 1: Error message
+    #[error("Error while sending {0} data: {1}")]
+    SendError(&'static str, String),
 }
 
 impl From<BridgeError> for ErrorObject<'static> {

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -263,6 +263,12 @@ pub enum BridgeError {
     MultipleWinternitzScripts,
     #[error("Encountered multiple preimage reveal scripts when attempting to commit to only one.")]
     MultiplePreimageRevealScripts,
+
+    #[error("Sighash stream ended prematurely")]
+    SighashStreamEndedPrematurely,
+
+    #[error("{0} input channel for {1} ended prematurely")]
+    ChannelEndedPrematurely(&'static str, &'static str),
 }
 
 impl From<BridgeError> for ErrorObject<'static> {

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -198,7 +198,7 @@ async fn signature_distributor(
         for tx in &deposit_finalize_sender {
             tx.send(final_params.clone())
                 .await
-                .map_err(|_| output_stream_ended_prematurely())?;
+                .map_err(output_stream_ended_prematurely)?;
         }
     }
 
@@ -211,7 +211,7 @@ async fn signature_distributor(
             )),
         })
         .await
-        .map_err(|_| output_stream_ended_prematurely())?
+        .map_err(output_stream_ended_prematurely)?
     }
 
     Ok(())

--- a/core/src/rpc/error.rs
+++ b/core/src/rpc/error.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use tokio::sync::mpsc::error::SendError;
 use tonic::Status;
 
 pub(crate) fn _expected_msg_got_error(msg: Status) -> Status {
@@ -13,8 +14,8 @@ pub(crate) fn input_ended_prematurely() -> Status {
     Status::invalid_argument("Input stream ended prematurely")
 }
 
-pub(crate) fn output_stream_ended_prematurely() -> Status {
-    Status::internal("Output stream ended prematurely".to_string())
+pub(crate) fn output_stream_ended_prematurely<T>(e: SendError<T>) -> Status {
+    Status::internal(format!("Output stream ended prematurely: {}", e))
 }
 
 pub(crate) fn invalid_argument<'a, T: std::error::Error + Send + Sync + 'static + Display>(

--- a/core/src/rpc/error.rs
+++ b/core/src/rpc/error.rs
@@ -13,7 +13,7 @@ pub(crate) fn input_ended_prematurely() -> Status {
     Status::invalid_argument("Input stream ended prematurely")
 }
 
-pub(crate) fn sighash_stream_ended_prematurely() -> Status {
+pub(crate) fn _sighash_stream_ended_prematurely() -> Status {
     Status::internal("Sighash stream ended prematurely")
 }
 
@@ -21,7 +21,7 @@ pub(crate) fn output_stream_ended_prematurely() -> Status {
     Status::internal("Output stream ended prematurely".to_string())
 }
 
-pub(crate) fn sighash_stream_failed(msg: Status) -> Status {
+pub(crate) fn _sighash_stream_failed(msg: Status) -> Status {
     Status::internal(format!("Sighash stream failed: {msg}"))
 }
 

--- a/core/src/rpc/error.rs
+++ b/core/src/rpc/error.rs
@@ -13,16 +13,8 @@ pub(crate) fn input_ended_prematurely() -> Status {
     Status::invalid_argument("Input stream ended prematurely")
 }
 
-pub(crate) fn _sighash_stream_ended_prematurely() -> Status {
-    Status::internal("Sighash stream ended prematurely")
-}
-
 pub(crate) fn output_stream_ended_prematurely() -> Status {
     Status::internal("Output stream ended prematurely".to_string())
-}
-
-pub(crate) fn _sighash_stream_failed(msg: Status) -> Status {
-    Status::internal(format!("Sighash stream failed: {msg}"))
 }
 
 pub(crate) fn invalid_argument<'a, T: std::error::Error + Send + Sync + 'static + Display>(

--- a/core/src/rpc/operator.rs
+++ b/core/src/rpc/operator.rs
@@ -32,20 +32,20 @@ impl ClementineOperator for Operator {
             let operator_config: OperatorParams = operator.clone().into();
             tx.send(Ok(operator_config))
                 .await
-                .map_err(|_| output_stream_ended_prematurely())?;
+                .map_err(output_stream_ended_prematurely)?;
 
             while let Some(winternitz_public_key) = wpk_receiver.recv().await {
                 let operator_winternitz_pubkey: OperatorParams = winternitz_public_key.into();
                 tx.send(Ok(operator_winternitz_pubkey))
                     .await
-                    .map_err(|_| output_stream_ended_prematurely())?;
+                    .map_err(output_stream_ended_prematurely)?;
             }
 
             while let Some(hash) = hash_receiver.recv().await {
                 let hash: OperatorParams = hash.into();
                 tx.send(Ok(hash))
                     .await
-                    .map_err(|_| output_stream_ended_prematurely())?;
+                    .map_err(output_stream_ended_prematurely)?;
             }
 
             Ok::<(), Status>(())

--- a/core/src/rpc/parser/verifier.rs
+++ b/core/src/rpc/parser/verifier.rs
@@ -215,7 +215,7 @@ pub async fn parse_next_deposit_finalize_param_schnorr_sig(
             schnorr::Signature::from_slice(&final_sig)
                 .map_err(invalid_argument("FinalSig", "Invalid signature length"))?
         }
-        _ => return Err(Status::internal("Expected FinalSig")),
+        _ => return Err(Status::internal("Expected FinalSig 1")),
     };
 
     Ok(Some(final_sig))
@@ -231,7 +231,7 @@ pub async fn parse_deposit_finalize_param_agg_nonce(
             Ok(MusigAggNonce::from_slice(&aggnonce)
                 .map_err(invalid_argument("MusigAggNonce", "failed to parse"))?)
         }
-        _ => Err(Status::internal("Expected FinalSig")),
+        _ => Err(Status::internal("Expected FinalSig 2")),
     }
 }
 

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -219,6 +219,8 @@ impl ClementineVerifier for Verifier {
                 )
                 .await?;
 
+            let mut nonce_idx = 0;
+            let num_required_sigs = calculate_num_required_nofn_sigs(&verifier.config);
             while let Some(partial_sig) = partial_sig_receiver.recv().await {
                 tx.send(Ok(PartialSig {
                     partial_sig: partial_sig.serialize().to_vec(),

--- a/core/src/rpc/watchtower.rs
+++ b/core/src/rpc/watchtower.rs
@@ -15,33 +15,29 @@ impl ClementineWatchtower for Watchtower {
         &self,
         _request: Request<Empty>,
     ) -> Result<Response<Self::GetParamsStream>, Status> {
-        let watchtower = self.clone();
-        let watchtower_winternitz_public_keys =
-            watchtower.get_watchtower_winternitz_public_keys().await?;
+        let (watchtower_id, mut winternitz_public_keys, xonly_pk) = self.get_params().await?;
 
-        let (tx, rx) = mpsc::channel(watchtower_winternitz_public_keys.len() + 2);
+        let (tx, rx) = mpsc::channel(winternitz_public_keys.max_capacity() + 2);
         let out_stream: Self::GetParamsStream = ReceiverStream::new(rx);
+
+        tracing::info!(
+            "Watchtower gives watchtower xonly public key {:?} for index {}",
+            self.actor.xonly_public_key,
+            self.config.index
+        );
 
         tokio::spawn(async move {
             tx.send(Ok(WatchtowerParams {
-                response: Some(watchtower_params::Response::WatchtowerId(
-                    watchtower.config.index,
-                )),
+                response: Some(watchtower_params::Response::WatchtowerId(watchtower_id)),
             }))
             .await?;
 
-            for wpk in watchtower_winternitz_public_keys {
+            while let Some(wpk) = winternitz_public_keys.recv().await {
                 let wpk: WatchtowerParams = wpk.into();
                 tx.send(Ok(wpk)).await?;
             }
 
-            tracing::info!(
-                "Watchtower gives watchtower xonly public key {:?} for index {}",
-                watchtower.actor.xonly_public_key,
-                watchtower.config.index
-            );
-
-            let xonly_pk: WatchtowerParams = watchtower.actor.xonly_public_key.into();
+            let xonly_pk: WatchtowerParams = xonly_pk.into();
             tx.send(Ok(xonly_pk)).await?;
 
             Ok::<(), SendError<_>>(())

--- a/core/src/rpc/watchtower.rs
+++ b/core/src/rpc/watchtower.rs
@@ -15,9 +15,9 @@ impl ClementineWatchtower for Watchtower {
         &self,
         _request: Request<Empty>,
     ) -> Result<Response<Self::GetParamsStream>, Status> {
-        let (watchtower_id, mut winternitz_public_keys, xonly_pk) = self.get_params().await?;
+        let (watchtower_id, winternitz_public_keys, xonly_pk) = self.get_params().await?;
 
-        let (tx, rx) = mpsc::channel(winternitz_public_keys.max_capacity() + 2);
+        let (tx, rx) = mpsc::channel(winternitz_public_keys.len() + 2);
         let out_stream: Self::GetParamsStream = ReceiverStream::new(rx);
 
         tracing::info!(
@@ -32,7 +32,7 @@ impl ClementineWatchtower for Watchtower {
             }))
             .await?;
 
-            while let Some(wpk) = winternitz_public_keys.recv().await {
+            for wpk in winternitz_public_keys {
                 let wpk: WatchtowerParams = wpk.into();
                 tx.send(Ok(wpk)).await?;
             }

--- a/core/src/watchtower.rs
+++ b/core/src/watchtower.rs
@@ -163,7 +163,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_params() {
+    async fn watchtower_get_params() {
         let config = create_test_config_with_thread_name!(None);
         let watchtower = Watchtower::new(config.clone()).await.unwrap();
 


### PR DESCRIPTION
# Description

This PR moves out business logic code from RPC module.

- Adds another transportation layer (tokio mpsc channels) between actor modules and rpc module (only for streams) in order to achieve this
- Maintains async nature of the streams
- Only required changes to the actual code apart from moving the code
- Tests are untouched to ensure previous working state is preserved

## Linked Issues

- Related #469  
- Closes #515 