### PR TITLE
Save signatures with more information to db

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -299,6 +299,7 @@ mod tests {
     use crate::builder::transaction::output::UnspentTxOut;
     use crate::builder::transaction::TxHandlerBuilder;
     use crate::config::BridgeConfig;
+    use crate::rpc::clementine::NormalSignatureKind;
     use crate::utils::{initialize_logger, SECP};
     use crate::{
         actor::WinternitzDerivationPath, builder::transaction::TxHandler,
@@ -324,6 +325,7 @@ mod tests {
         let (op_addr, op_spend) =
             create_taproot_address(&[], Some(actor.xonly_public_key), Network::Regtest);
         let builder = TxHandlerBuilder::new().add_input(
+            NormalSignatureKind::AlreadyDisproved1,
             SpendableTxIn::new(
                 OutPoint::default(),
                 TxOut {
@@ -333,6 +335,7 @@ mod tests {
                 vec![],
                 Some(op_spend),
             ),
+            crate::builder::script::SpendPath::Unknown,
             Sequence::ENABLE_RBF_NO_LOCKTIME,
         );
         builder

--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -219,7 +219,7 @@ impl Aggregator {
         agg_nonce: &MusigAggNonce,
         partial_sigs: Vec<MusigPartialSignature>,
     ) -> Result<schnorr::Signature, BridgeError> {
-        let mut tx = builder::transaction::create_move_to_vault_txhandler(
+        let tx = builder::transaction::create_move_to_vault_txhandler(
             deposit_outpoint,
             evm_address,
             recovery_taproot_address,

--- a/core/src/builder/script.rs
+++ b/core/src/builder/script.rs
@@ -19,6 +19,13 @@ use bitvm::signatures::winternitz::{Parameters, PublicKey};
 use std::any::Any;
 use std::fmt::Debug;
 
+#[derive(Debug, Clone)]
+pub enum SpendPath {
+    ScriptSpend(usize),
+    KeySpend,
+    Unknown,
+}
+
 pub trait SpendableScript: Send + Sync + 'static + std::any::Any {
     fn as_any(&self) -> &dyn Any;
 

--- a/core/src/builder/sighash.rs
+++ b/core/src/builder/sighash.rs
@@ -13,6 +13,9 @@ use async_stream::try_stream;
 use bitcoin::{address::NetworkUnchecked, Address, Amount, OutPoint};
 use bitcoin::{TapSighash, Txid, XOnlyPublicKey};
 use futures_core::stream::Stream;
+use crate::rpc::clementine::signature::SignatureId;
+
+use super::transaction::TxHandler;
 
 /// Returns the number of required signatures for N-of-N signing session.
 pub fn calculate_num_required_nofn_sigs(config: &BridgeConfig) -> usize {
@@ -27,6 +30,18 @@ pub fn calculate_num_required_nofn_sigs(config: &BridgeConfig) -> usize {
 pub fn calculate_num_required_operator_sigs(config: &BridgeConfig) -> usize {
     config.num_sequential_collateral_txs * config.num_kickoffs_per_sequential_collateral_tx * 3
 }
+
+pub struct SignatureInfo {
+    pub operator_idx: usize,
+    pub sequential_collateral_idx: usize,
+    pub kickoff_utxo_idx: usize,
+    pub signature_id: SignatureId,
+}
+
+pub fn calculate_pubkey_sighash_get_signature_info(txhandler: &TxHandler, input_idx: usize) {
+    
+}
+
 
 /// Refer to bridge design diagram to see which NofN signatures are needed (the ones marked with blue arrows).
 /// These sighashes are needed in order to create the message to be signed later for MuSig2 of NofN.
@@ -55,7 +70,7 @@ pub fn create_nofn_sighash_stream(
     max_withdrawal_time_block_count: u16,
     bridge_amount_sats: Amount,
     network: bitcoin::Network,
-) -> impl Stream<Item = Result<TapSighash, BridgeError>> {
+) -> impl Stream<Item = Result<(TapSighash, SignatureInfo), BridgeError>> {
     use bitcoin::TapSighashType::All as SighashAll;
     try_stream! {
         // Create move_tx handler. This is unique for each deposit tx.

--- a/core/src/builder/sighash.rs
+++ b/core/src/builder/sighash.rs
@@ -218,6 +218,7 @@ pub fn create_nofn_sighash_stream(
                         let mut operator_challenge_nack_txhandler =
                             builder::transaction::create_operator_challenge_nack_txhandler(
                                 &watchtower_challenge_txhandler,
+                                watchtower_idx,
                                 &kickoff_txhandler
                             )?;
 

--- a/core/src/builder/transaction/input.rs
+++ b/core/src/builder/transaction/input.rs
@@ -1,6 +1,6 @@
 use crate::builder::script::SpendableScript;
 use crate::builder::{address::create_taproot_address, script::SpendPath};
-use crate::rpc::clementine::signature::SignatureId;
+use crate::rpc::clementine::tagged_signature::SignatureId;
 use bitcoin::{
     taproot::{LeafVersion, TaprootSpendInfo},
     Amount, OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Witness, WitnessProgram, XOnlyPublicKey,
@@ -195,6 +195,10 @@ impl SpentTxIn {
 
     pub fn get_witness(&self) -> &Option<Witness> {
         &self.witness
+    }
+
+    pub fn get_signature_id(&self) -> SignatureId {
+        self.input_id
     }
 
     pub fn set_witness(&mut self, witness: Witness) {

--- a/core/src/builder/transaction/input.rs
+++ b/core/src/builder/transaction/input.rs
@@ -1,5 +1,6 @@
-use crate::builder::address::create_taproot_address;
 use crate::builder::script::SpendableScript;
+use crate::builder::{address::create_taproot_address, script::SpendPath};
+use crate::rpc::clementine::signature::SignatureId;
 use bitcoin::{
     taproot::{LeafVersion, TaprootSpendInfo},
     Amount, OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Witness, WitnessProgram, XOnlyPublicKey,
@@ -153,6 +154,7 @@ impl SpendableTxIn {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct SpentTxIn {
     spendable: SpendableTxIn,
@@ -166,11 +168,15 @@ pub struct SpentTxIn {
     ///
     /// Has to be Some(_) when the transaction is signed.
     witness: Option<Witness>,
+    spend_path: SpendPath,
+    input_id: SignatureId,
 }
 
 impl SpentTxIn {
     pub fn from_spendable(
+        input_id: SignatureId,
         spendable: SpendableTxIn,
+        spend_path: SpendPath,
         sequence: Sequence,
         witness: Option<Witness>,
     ) -> SpentTxIn {
@@ -178,6 +184,8 @@ impl SpentTxIn {
             spendable,
             sequence,
             witness,
+            spend_path,
+            input_id,
         }
     }
 

--- a/core/src/builder/transaction/mod.rs
+++ b/core/src/builder/transaction/mod.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use super::script::SpendPath;
 use super::script::{CheckSig, DepositScript, TimelockScript};
 pub use crate::builder::transaction::challenge::*;
 use crate::builder::transaction::input::SpendableTxIn;
@@ -15,6 +16,7 @@ use crate::builder::transaction::output::UnspentTxOut;
 pub use crate::builder::transaction::txhandler::*;
 use crate::constants::ANCHOR_AMOUNT;
 use crate::errors::BridgeError;
+use crate::rpc::clementine::NormalSignatureKind;
 use crate::EVMAddress;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::opcodes::all::{OP_PUSHNUM_1, OP_RETURN};
@@ -97,6 +99,7 @@ pub fn create_move_to_vault_txhandler(
     ));
 
     let builder = TxHandlerBuilder::new().add_input(
+        NormalSignatureKind::NotStored,
         SpendableTxIn::from_scripts(
             deposit_outpoint,
             bridge_amount_sats,
@@ -104,6 +107,7 @@ pub fn create_move_to_vault_txhandler(
             None,
             network,
         ),
+        SpendPath::ScriptSpend(0),
         DEFAULT_SEQUENCE,
     );
 

--- a/core/src/builder/transaction/operator_reimburse.rs
+++ b/core/src/builder/transaction/operator_reimburse.rs
@@ -4,6 +4,7 @@ use crate::builder::transaction::output::UnspentTxOut;
 use crate::builder::transaction::txhandler::{TxHandler, TxHandlerBuilder};
 use crate::constants::{BLOCKS_PER_WEEK, MIN_TAPROOT_AMOUNT};
 use crate::errors::BridgeError;
+use crate::rpc::clementine::NormalSignatureKind;
 use crate::{builder, utils};
 use bitcoin::hashes::Hash;
 use bitcoin::script::PushBytesBuf;
@@ -23,7 +24,9 @@ pub fn create_kickoff_txhandler(
 ) -> Result<TxHandler, BridgeError> {
     let mut builder = TxHandlerBuilder::new();
     builder = builder.add_input(
+        NormalSignatureKind::NotStored,
         sequential_collateral_txhandler.get_spendable_output(2 + kickoff_idx)?,
+        builder::script::SpendPath::ScriptSpend(0),
         DEFAULT_SEQUENCE,
     );
 
@@ -94,10 +97,17 @@ pub fn create_start_happy_reimburse_txhandler(
 ) -> Result<TxHandler, BridgeError> {
     let mut builder = TxHandlerBuilder::new();
     builder = builder.add_input(
+        NormalSignatureKind::NotStored,
         kickoff_txhandler.get_spendable_output(1)?,
+        builder::script::SpendPath::ScriptSpend(1),
         Sequence::from_height(BLOCKS_PER_WEEK),
     );
-    builder = builder.add_input(kickoff_txhandler.get_spendable_output(3)?, DEFAULT_SEQUENCE);
+    builder = builder.add_input(
+        NormalSignatureKind::StartHappyReimburse2,
+        kickoff_txhandler.get_spendable_output(3)?,
+        builder::script::SpendPath::ScriptSpend(0),
+        DEFAULT_SEQUENCE,
+    );
 
     Ok(builder
         .add_output(UnspentTxOut::from_scripts(
@@ -123,13 +133,22 @@ pub fn create_happy_reimburse_txhandler(
 ) -> Result<TxHandler, BridgeError> {
     let mut builder = TxHandlerBuilder::new();
     builder = builder
-        .add_input(move_txhandler.get_spendable_output(0)?, DEFAULT_SEQUENCE)
         .add_input(
-            start_happy_reimburse_txhandler.get_spendable_output(0)?,
+            NormalSignatureKind::HappyReimburse1,
+            move_txhandler.get_spendable_output(0)?,
+            builder::script::SpendPath::ScriptSpend(0),
             DEFAULT_SEQUENCE,
         )
         .add_input(
+            NormalSignatureKind::NotStored,
+            start_happy_reimburse_txhandler.get_spendable_output(0)?,
+            builder::script::SpendPath::KeySpend,
+            DEFAULT_SEQUENCE,
+        )
+        .add_input(
+            NormalSignatureKind::NotStored,
             reimburse_generator_txhandler.get_spendable_output(1 + kickoff_idx)?,
+            builder::script::SpendPath::KeySpend,
             DEFAULT_SEQUENCE,
         );
 
@@ -154,13 +173,22 @@ pub fn create_reimburse_txhandler(
     operator_reimbursement_address: &bitcoin::Address,
 ) -> Result<TxHandler, BridgeError> {
     let builder = TxHandlerBuilder::new()
-        .add_input(move_txhandler.get_spendable_output(0)?, DEFAULT_SEQUENCE)
         .add_input(
-            disprove_timeout_txhandler.get_spendable_output(0)?,
+            NormalSignatureKind::Reimburse1,
+            move_txhandler.get_spendable_output(0)?,
+            builder::script::SpendPath::ScriptSpend(0),
             DEFAULT_SEQUENCE,
         )
         .add_input(
+            NormalSignatureKind::NotStored,
+            disprove_timeout_txhandler.get_spendable_output(0)?,
+            builder::script::SpendPath::KeySpend,
+            DEFAULT_SEQUENCE,
+        )
+        .add_input(
+            NormalSignatureKind::NotStored,
             reimburse_generator_txhandler.get_spendable_output(1 + kickoff_idx)?,
+            builder::script::SpendPath::KeySpend,
             DEFAULT_SEQUENCE,
         );
 

--- a/core/src/builder/transaction/txhandler.rs
+++ b/core/src/builder/transaction/txhandler.rs
@@ -1,6 +1,6 @@
 use crate::builder::script::SpendPath;
 use crate::errors::BridgeError;
-use crate::rpc::clementine::signature::SignatureId;
+use crate::rpc::clementine::tagged_signature::SignatureId;
 use bitcoin::sighash::SighashCache;
 use bitcoin::taproot::{self, LeafVersion};
 use bitcoin::transaction::Version;
@@ -51,6 +51,10 @@ impl<T: State> TxHandler<T> {
             txout.spendinfo().clone(),
         )) // TODO: Can we get rid of clones?
     }
+    pub fn get_signature_id(&self, idx: usize) -> Result<SignatureId, BridgeError> {
+        let txin = self.txins.get(idx).ok_or(BridgeError::TxInputNotFound)?;
+        Ok(txin.get_signature_id())
+    }
 }
 
 impl TxHandler<Unsigned> {
@@ -94,7 +98,7 @@ impl TxHandler<Unsigned> {
     }
 
     pub fn calculate_script_spend_sighash_indexed(
-        &mut self,
+        &self,
         txin_index: usize,
         spend_script_idx: usize,
         sighash_type: TapSighashType,
@@ -114,7 +118,7 @@ impl TxHandler<Unsigned> {
     }
 
     pub fn calculate_script_spend_sighash(
-        &mut self,
+        &self,
         txin_index: usize,
         spend_script: &Script,
         sighash_type: TapSighashType,

--- a/core/src/builder/transaction/txhandler.rs
+++ b/core/src/builder/transaction/txhandler.rs
@@ -1,6 +1,7 @@
 use crate::builder::script::SpendPath;
 use crate::errors::BridgeError;
 use crate::rpc::clementine::tagged_signature::SignatureId;
+use crate::rpc::clementine::NormalSignatureKind;
 use bitcoin::sighash::SighashCache;
 use bitcoin::taproot::{self, LeafVersion};
 use bitcoin::transaction::Version;
@@ -319,6 +320,23 @@ impl TxHandlerBuilder {
             spend_path,
             sequence,
             None,
+        ));
+
+        self
+    }
+
+    pub fn add_input_with_witness(
+        mut self,
+        spendable: SpendableTxIn,
+        sequence: Sequence,
+        witness: Witness,
+    ) -> Self {
+        self.txins.push(SpentTxIn::from_spendable(
+            NormalSignatureKind::NormalSignatureUnknown.into(),
+            spendable,
+            SpendPath::Unknown,
+            sequence,
+            Some(witness),
         ));
 
         self

--- a/core/src/builder/transaction/txhandler.rs
+++ b/core/src/builder/transaction/txhandler.rs
@@ -1,4 +1,6 @@
+use crate::builder::script::SpendPath;
 use crate::errors::BridgeError;
+use crate::rpc::clementine::signature::SignatureId;
 use bitcoin::sighash::SighashCache;
 use bitcoin::taproot::{self, LeafVersion};
 use bitcoin::transaction::Version;
@@ -300,24 +302,20 @@ impl TxHandlerBuilder {
         self
     }
 
-    pub fn add_input_with_witness(
+    pub fn add_input(
         mut self,
+        input_id: impl Into<SignatureId>,
         spendable: SpendableTxIn,
+        spend_path: SpendPath,
         sequence: Sequence,
-        witness: Witness,
     ) -> Self {
         self.txins.push(SpentTxIn::from_spendable(
+            input_id.into(),
             spendable,
+            spend_path,
             sequence,
-            Some(witness),
+            None,
         ));
-
-        self
-    }
-
-    pub fn add_input(mut self, spendable: SpendableTxIn, sequence: Sequence) -> Self {
-        self.txins
-            .push(SpentTxIn::from_spendable(spendable, sequence, None));
 
         self
     }

--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -226,6 +226,7 @@ mod tests {
     use super::{nonce_pair, MuSigNoncePair, Musig2Mode};
     use crate::builder::script::{CheckSig, OtherSpendable, SpendableScript};
     use crate::builder::transaction::DEFAULT_SEQUENCE;
+    use crate::rpc::clementine::NormalSignatureKind;
     use crate::{
         builder::{
             self,
@@ -527,12 +528,14 @@ mod tests {
         let mut builder = TxHandlerBuilder::new();
         builder = builder
             .add_input(
+                NormalSignatureKind::NotStored,
                 SpendableTxIn::new(
                     utxo,
                     prevout.clone(),
                     scripts.clone(),
                     Some(sending_address_spend_info.clone()),
                 ),
+                builder::script::SpendPath::Unknown,
                 DEFAULT_SEQUENCE,
             )
             .add_output(UnspentTxOut::from_partial(TxOut {
@@ -633,12 +636,14 @@ mod tests {
 
         let mut tx_details = TxHandlerBuilder::new()
             .add_input(
+                NormalSignatureKind::NotStored,
                 SpendableTxIn::new(
                     utxo,
                     prevout,
                     scripts,
                     Some(sending_address_spend_info.clone()),
                 ),
+                builder::script::SpendPath::Unknown,
                 DEFAULT_SEQUENCE,
             )
             .add_output(UnspentTxOut::from_partial(TxOut {

--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -634,7 +634,7 @@ mod tests {
             vout: 0,
         };
 
-        let mut tx_details = TxHandlerBuilder::new()
+        let tx_details = TxHandlerBuilder::new()
             .add_input(
                 NormalSignatureKind::NotStored,
                 SpendableTxIn::new(

--- a/core/src/rpc/clementine.proto
+++ b/core/src/rpc/clementine.proto
@@ -46,7 +46,9 @@ message WatchtowerSignatureId {
   int32 watchtower_idx = 2;
 }
 
-message Signature {
+// A tagged signature struct that identifies the transaction-input that the signature is for.
+// The id is left as NotStored for signatures that are created on the fly by the operator (they're also not stored).
+message TaggedSignature {
   oneof signature_id {
     NormalSignatureId normal_signature = 1;
     WatchtowerSignatureId watchtower_signature = 2;
@@ -54,7 +56,7 @@ message Signature {
   bytes signature = 3;
 }
 
-message DepositSignatures { repeated Signature signatures = 1; }
+message DepositSignatures { repeated TaggedSignature signatures = 1; }
 
 message ChallengeACKDigest {
   bytes hash = 1;

--- a/core/src/rpc/clementine.proto
+++ b/core/src/rpc/clementine.proto
@@ -8,6 +8,54 @@ message Outpoint {
   uint32 vout = 2;
 }
 
+enum NormalSignatureKind {
+  NormalSignatureUnknown = 0;
+  // Used for TxHandlers that verifiers don't care. These will have signatures created
+  // by the operator on the fly.
+  NotStored = 1;
+  KickoffTimeout1 = 2;
+  KickoffTimeout2 = 3;
+  Challenge = 4;
+  WatchtowerChallengeKickoff = 5;
+  StartHappyReimburse2 = 6;
+  HappyReimburse1 = 7;
+  AssertEndLast = 8;
+  DisproveTimeout1 = 9;
+  DisproveTimeout2 = 10;
+  AlreadyDisproved1 = 11;
+  AlreadyDisproved2 = 12;
+  Disprove2 = 13;
+  Reimburse1 = 14;
+}
+
+enum WatchtowerSignatureKind {
+  WatchtowerSignatureUnknown = 0;
+  // Used for TxHandlers that verifiers don't care. These will have signatures created
+  // by the operator on the fly.
+  WatchtowerNotStored = 1;
+  OperatorChallengeNack1 = 2;
+  OperatorChallengeNack2 = 3;
+}
+
+message NormalSignatureId {
+  NormalSignatureKind signature_kind = 1;
+}
+
+message WatchtowerSignatureId {
+  WatchtowerSignatureKind signature_kind = 1;
+  int32 watchtower_idx = 2;
+}
+
+message Signature {
+  oneof signature_id {
+    NormalSignatureId normal_signature = 1;
+    WatchtowerSignatureId watchtower_signature = 2;
+  }
+  bytes signature = 3;
+}
+
+message DepositSignatures { repeated Signature signatures = 1; }
+
 message ChallengeACKDigest {
   bytes hash = 1;
 }

--- a/core/src/rpc/clementine.rs
+++ b/core/src/rpc/clementine.rs
@@ -20,15 +20,17 @@ pub struct WatchtowerSignatureId {
     #[prost(int32, tag = "2")]
     pub watchtower_idx: i32,
 }
+/// A tagged signature struct that identifies the transaction-input that the signature is for.
+/// The id is left as NotStored for signatures that are created on the fly by the operator (they're also not stored).
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Signature {
+pub struct TaggedSignature {
     #[prost(bytes = "vec", tag = "3")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
-    #[prost(oneof = "signature::SignatureId", tags = "1, 2")]
-    pub signature_id: ::core::option::Option<signature::SignatureId>,
+    #[prost(oneof = "tagged_signature::SignatureId", tags = "1, 2")]
+    pub signature_id: ::core::option::Option<tagged_signature::SignatureId>,
 }
-/// Nested message and enum types in `Signature`.
-pub mod signature {
+/// Nested message and enum types in `TaggedSignature`.
+pub mod tagged_signature {
     #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
     pub enum SignatureId {
         #[prost(message, tag = "1")]
@@ -40,7 +42,7 @@ pub mod signature {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DepositSignatures {
     #[prost(message, repeated, tag = "1")]
-    pub signatures: ::prost::alloc::vec::Vec<Signature>,
+    pub signatures: ::prost::alloc::vec::Vec<TaggedSignature>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChallengeAckDigest {

--- a/core/src/rpc/clementine.rs
+++ b/core/src/rpc/clementine.rs
@@ -8,6 +8,40 @@ pub struct Outpoint {
     #[prost(uint32, tag = "2")]
     pub vout: u32,
 }
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct NormalSignatureId {
+    #[prost(enumeration = "NormalSignatureKind", tag = "1")]
+    pub signature_kind: i32,
+}
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct WatchtowerSignatureId {
+    #[prost(enumeration = "WatchtowerSignatureKind", tag = "1")]
+    pub signature_kind: i32,
+    #[prost(int32, tag = "2")]
+    pub watchtower_idx: i32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Signature {
+    #[prost(bytes = "vec", tag = "3")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
+    #[prost(oneof = "signature::SignatureId", tags = "1, 2")]
+    pub signature_id: ::core::option::Option<signature::SignatureId>,
+}
+/// Nested message and enum types in `Signature`.
+pub mod signature {
+    #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
+    pub enum SignatureId {
+        #[prost(message, tag = "1")]
+        NormalSignature(super::NormalSignatureId),
+        #[prost(message, tag = "2")]
+        WatchtowerSignature(super::WatchtowerSignatureId),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DepositSignatures {
+    #[prost(message, repeated, tag = "1")]
+    pub signatures: ::prost::alloc::vec::Vec<Signature>,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChallengeAckDigest {
     #[prost(bytes = "vec", tag = "1")]
@@ -223,6 +257,107 @@ pub mod watchtower_params {
 pub struct RawSignedMoveTx {
     #[prost(bytes = "vec", tag = "1")]
     pub raw_tx: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum NormalSignatureKind {
+    NormalSignatureUnknown = 0,
+    /// Used for TxHandlers that verifiers don't care. These will have signatures created
+    /// by the operator on the fly.
+    NotStored = 1,
+    KickoffTimeout1 = 2,
+    KickoffTimeout2 = 3,
+    Challenge = 4,
+    WatchtowerChallengeKickoff = 5,
+    StartHappyReimburse2 = 6,
+    HappyReimburse1 = 7,
+    AssertEndLast = 8,
+    DisproveTimeout1 = 9,
+    DisproveTimeout2 = 10,
+    AlreadyDisproved1 = 11,
+    AlreadyDisproved2 = 12,
+    Disprove2 = 13,
+    Reimburse1 = 14,
+}
+impl NormalSignatureKind {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::NormalSignatureUnknown => "NormalSignatureUnknown",
+            Self::NotStored => "NotStored",
+            Self::KickoffTimeout1 => "KickoffTimeout1",
+            Self::KickoffTimeout2 => "KickoffTimeout2",
+            Self::Challenge => "Challenge",
+            Self::WatchtowerChallengeKickoff => "WatchtowerChallengeKickoff",
+            Self::StartHappyReimburse2 => "StartHappyReimburse2",
+            Self::HappyReimburse1 => "HappyReimburse1",
+            Self::AssertEndLast => "AssertEndLast",
+            Self::DisproveTimeout1 => "DisproveTimeout1",
+            Self::DisproveTimeout2 => "DisproveTimeout2",
+            Self::AlreadyDisproved1 => "AlreadyDisproved1",
+            Self::AlreadyDisproved2 => "AlreadyDisproved2",
+            Self::Disprove2 => "Disprove2",
+            Self::Reimburse1 => "Reimburse1",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "NormalSignatureUnknown" => Some(Self::NormalSignatureUnknown),
+            "NotStored" => Some(Self::NotStored),
+            "KickoffTimeout1" => Some(Self::KickoffTimeout1),
+            "KickoffTimeout2" => Some(Self::KickoffTimeout2),
+            "Challenge" => Some(Self::Challenge),
+            "WatchtowerChallengeKickoff" => Some(Self::WatchtowerChallengeKickoff),
+            "StartHappyReimburse2" => Some(Self::StartHappyReimburse2),
+            "HappyReimburse1" => Some(Self::HappyReimburse1),
+            "AssertEndLast" => Some(Self::AssertEndLast),
+            "DisproveTimeout1" => Some(Self::DisproveTimeout1),
+            "DisproveTimeout2" => Some(Self::DisproveTimeout2),
+            "AlreadyDisproved1" => Some(Self::AlreadyDisproved1),
+            "AlreadyDisproved2" => Some(Self::AlreadyDisproved2),
+            "Disprove2" => Some(Self::Disprove2),
+            "Reimburse1" => Some(Self::Reimburse1),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum WatchtowerSignatureKind {
+    WatchtowerSignatureUnknown = 0,
+    /// Used for TxHandlers that verifiers don't care. These will have signatures created
+    /// by the operator on the fly.
+    WatchtowerNotStored = 1,
+    OperatorChallengeNack1 = 2,
+    OperatorChallengeNack2 = 3,
+}
+impl WatchtowerSignatureKind {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::WatchtowerSignatureUnknown => "WatchtowerSignatureUnknown",
+            Self::WatchtowerNotStored => "WatchtowerNotStored",
+            Self::OperatorChallengeNack1 => "OperatorChallengeNack1",
+            Self::OperatorChallengeNack2 => "OperatorChallengeNack2",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "WatchtowerSignatureUnknown" => Some(Self::WatchtowerSignatureUnknown),
+            "WatchtowerNotStored" => Some(Self::WatchtowerNotStored),
+            "OperatorChallengeNack1" => Some(Self::OperatorChallengeNack1),
+            "OperatorChallengeNack2" => Some(Self::OperatorChallengeNack2),
+            _ => None,
+        }
+    }
 }
 /// Generated client implementations.
 pub mod clementine_operator_client {

--- a/core/src/rpc/mod.rs
+++ b/core/src/rpc/mod.rs
@@ -1,4 +1,6 @@
 use crate::errors::BridgeError;
+use clementine::*;
+use signature::SignatureId;
 use std::future::Future;
 use tonic::transport::Uri;
 
@@ -12,6 +14,23 @@ pub mod operator;
 mod parser;
 pub mod verifier;
 pub mod watchtower;
+
+impl From<NormalSignatureKind> for SignatureId {
+    fn from(value: NormalSignatureKind) -> Self {
+        SignatureId::NormalSignature(NormalSignatureId {
+            signature_kind: value as i32,
+        })
+    }
+}
+
+impl From<(WatchtowerSignatureKind, i32)> for SignatureId {
+    fn from(value: (WatchtowerSignatureKind, i32)) -> Self {
+        SignatureId::WatchtowerSignature(WatchtowerSignatureId {
+            signature_kind: value.0 as i32,
+            watchtower_idx: value.1,
+        })
+    }
+}
 
 /// Returns gRPC clients.
 ///

--- a/core/src/rpc/mod.rs
+++ b/core/src/rpc/mod.rs
@@ -1,7 +1,7 @@
 use crate::errors::BridgeError;
 use clementine::*;
-use signature::SignatureId;
 use std::future::Future;
+use tagged_signature::SignatureId;
 use tonic::transport::Uri;
 
 #[allow(clippy::all)]

--- a/core/src/rpc/operator.rs
+++ b/core/src/rpc/operator.rs
@@ -86,7 +86,7 @@ impl ClementineOperator for Operator {
             ));
 
             while let Some(sighash) = sighash_stream.next().await {
-                let sighash = sighash?;
+                let sighash = sighash?.0;
 
                 // None because utxos that operators need to sign do not have scripts
                 let sig = operator.signer.sign_with_tweak(sighash, None)?;

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -4,14 +4,18 @@ use super::clementine::{
     VerifierParams, VerifierPublicKeys, WatchtowerParams,
 };
 use super::error::*;
+use crate::builder::sighash::SignatureInfo;
+use crate::config::BridgeConfig;
 use crate::fetch_next_optional_message_from_stream;
+use crate::rpc::clementine::TaggedSignature;
 use crate::utils::SECP;
 use crate::{
     builder::{
         self,
         address::{derive_challenge_address_from_xonlypk_and_wpk, taproot_builder_with_scripts},
         sighash::{
-            calculate_num_required_nofn_sigs, calculate_num_required_operator_sigs,
+            calculate_num_required_nofn_sigs, calculate_num_required_nofn_sigs_per_kickoff,
+            calculate_num_required_operator_sigs, calculate_num_required_operator_sigs_per_kickoff,
             create_nofn_sighash_stream, create_operator_sighash_stream,
         },
         transaction::create_move_to_vault_txhandler,
@@ -25,7 +29,7 @@ use crate::{
 };
 use bitcoin::{hashes::Hash, Amount, TapTweakHash, Txid};
 use bitcoin::{
-    secp256k1::{schnorr, Message, PublicKey},
+    secp256k1::{Message, PublicKey},
     ScriptBuf, XOnlyPublicKey,
 };
 use bitvm::signatures::{
@@ -473,7 +477,7 @@ impl ClementineVerifier for Verifier {
                     nonce,
                     agg_nonce,
                     verifier.signer.keypair,
-                    Message::from_digest(*sighash.as_byte_array()),
+                    Message::from_digest(*sighash.0.as_byte_array()),
                 )?;
 
                 tx.send(Ok(PartialSig {
@@ -559,7 +563,28 @@ impl ClementineVerifier for Verifier {
         ));
 
         let num_required_nofn_sigs = calculate_num_required_nofn_sigs(&self.config);
-        let mut verified_sigs = Vec::with_capacity(num_required_nofn_sigs);
+        let num_required_nofn_sigs_per_kickoff =
+            calculate_num_required_nofn_sigs_per_kickoff(&self.config);
+        let num_required_op_sigs = calculate_num_required_operator_sigs(&self.config);
+        let num_required_op_sigs_per_kickoff = calculate_num_required_operator_sigs_per_kickoff();
+        let &BridgeConfig {
+            num_operators,
+            num_sequential_collateral_txs,
+            num_kickoffs_per_sequential_collateral_tx,
+            ..
+        } = &self.config;
+        let mut verified_sigs = vec![
+            vec![
+                vec![
+                    Vec::<TaggedSignature>::with_capacity(
+                        num_required_nofn_sigs_per_kickoff + num_required_op_sigs_per_kickoff
+                    );
+                    num_kickoffs_per_sequential_collateral_tx
+                ];
+                num_sequential_collateral_txs
+            ];
+            num_operators
+        ];
 
         let mut nonce_idx: usize = 0;
 
@@ -575,7 +600,7 @@ impl ClementineVerifier for Verifier {
 
             tracing::debug!("Verifying Final Signature");
             utils::SECP
-                .verify_schnorr(&sig, &Message::from(sighash), &self.nofn_xonly_pk)
+                .verify_schnorr(&sig, &Message::from(sighash.0), &self.nofn_xonly_pk)
                 .map_err(|x| {
                     Status::internal(format!(
                         "Nofn Signature {} Verification Failed: {}.",
@@ -583,8 +608,18 @@ impl ClementineVerifier for Verifier {
                         x
                     ))
                 })?;
-
-            verified_sigs.push(sig);
+            let &SignatureInfo {
+                operator_idx,
+                sequential_collateral_idx,
+                kickoff_utxo_idx,
+                signature_id,
+            } = &sighash.1;
+            let tagged_sig = TaggedSignature {
+                signature: sig.serialize().to_vec(),
+                signature_id: Some(signature_id),
+            };
+            verified_sigs[operator_idx][sequential_collateral_idx][kickoff_utxo_idx]
+                .push(tagged_sig);
             tracing::debug!("Final Signature Verified");
 
             nonce_idx += 1;
@@ -601,7 +636,7 @@ impl ClementineVerifier for Verifier {
         }
 
         // Generate partial signature for move transaction
-        let mut move_txhandler = create_move_to_vault_txhandler(
+        let move_txhandler = create_move_to_vault_txhandler(
             deposit_outpoint,
             evm_address,
             &recovery_taproot_address,
@@ -634,12 +669,6 @@ impl ClementineVerifier for Verifier {
                 .ok_or_else(|| Status::internal("No move tx secnonce in session"))?
         };
 
-        let mut op_deposit_sigs: Vec<Vec<schnorr::Signature>> = verified_sigs
-            .chunks_exact(verified_sigs.len() / self.config.num_operators)
-            .map(|chunk| chunk.to_vec())
-            .collect();
-
-        let num_required_op_sigs = calculate_num_required_operator_sigs(&self.config);
         let num_required_total_op_sigs = num_required_op_sigs * self.config.num_operators;
         let mut total_op_sig_count = 0;
 
@@ -686,7 +715,11 @@ impl ClementineVerifier for Verifier {
                     .ok_or_else(sighash_stream_ended_prematurely)??;
 
                 utils::SECP
-                    .verify_schnorr(&operator_sig, &Message::from(sighash), &tweaked_op_xonly_pk)
+                    .verify_schnorr(
+                        &operator_sig,
+                        &Message::from(sighash.0),
+                        &tweaked_op_xonly_pk,
+                    )
                     .map_err(|x| {
                         Status::internal(format!(
                             "Operator {} Signature {}: verification failed: {}.",
@@ -696,7 +729,18 @@ impl ClementineVerifier for Verifier {
                         ))
                     })?;
 
-                op_deposit_sigs[operator_idx].push(operator_sig);
+                let &SignatureInfo {
+                    operator_idx,
+                    sequential_collateral_idx,
+                    kickoff_utxo_idx,
+                    signature_id,
+                } = &sighash.1;
+                let tagged_sig = TaggedSignature {
+                    signature: operator_sig.serialize().to_vec(),
+                    signature_id: Some(signature_id),
+                };
+                verified_sigs[operator_idx][sequential_collateral_idx][kickoff_utxo_idx]
+                    .push(tagged_sig);
 
                 op_sig_count += 1;
                 total_op_sig_count += 1;
@@ -726,10 +770,21 @@ impl ClementineVerifier for Verifier {
 
         // Deposit is not actually finalized here, its only finalized after the aggregator gets all the partial sigs and checks the aggregated sig
         // TODO: It can create problems if the deposit fails at the end by some verifier not sending movetx partial sig, but we still added sigs to db
-        for (i, window) in op_deposit_sigs.into_iter().enumerate() {
-            self.db
-                .set_deposit_signatures(None, deposit_outpoint, i as u32, window)
-                .await?;
+        for (operator_idx, operator_sigs) in verified_sigs.into_iter().enumerate() {
+            for (seq_idx, op_sequential_sigs) in operator_sigs.into_iter().enumerate() {
+                for (kickoff_idx, kickoff_sigs) in op_sequential_sigs.into_iter().enumerate() {
+                    self.db
+                        .set_deposit_signatures(
+                            None,
+                            deposit_outpoint,
+                            operator_idx,
+                            seq_idx,
+                            kickoff_idx,
+                            kickoff_sigs,
+                        )
+                        .await?;
+                }
+            }
         }
 
         Ok(Response::new(partial_sig))

--- a/core/tests/musig2.rs
+++ b/core/tests/musig2.rs
@@ -3,7 +3,7 @@ use bitcoin::secp256k1::{Message, PublicKey};
 use bitcoin::{hashes::Hash, script, Amount};
 use bitcoin::{taproot, Sequence, TxOut, XOnlyPublicKey};
 use bitcoincore_rpc::RpcApi;
-use clementine_core::builder::script::{CheckSig, OtherSpendable, SpendableScript};
+use clementine_core::builder::script::{CheckSig, OtherSpendable, SpendPath, SpendableScript};
 use clementine_core::builder::transaction::input::SpendableTxIn;
 use clementine_core::builder::transaction::output::UnspentTxOut;
 use clementine_core::builder::transaction::{TxHandlerBuilder, DEFAULT_SEQUENCE};
@@ -11,6 +11,7 @@ use clementine_core::errors::BridgeError;
 use clementine_core::musig2::{
     aggregate_nonces, aggregate_partial_signatures, AggregateFromPublicKeys, Musig2Mode,
 };
+use clementine_core::rpc::clementine::{NormalSignatureId, NormalSignatureKind};
 use clementine_core::utils::SECP;
 use clementine_core::{
     builder::{self},
@@ -99,7 +100,9 @@ async fn key_spend() {
 
     let mut tx_details = TxHandlerBuilder::new()
         .add_input(
+            NormalSignatureKind::NormalSignatureUnknown,
             SpendableTxIn::new(utxo, prevout, vec![], Some(from_address_spend_info.clone())),
+            SpendPath::Unknown,
             Sequence::default(),
         )
         .add_output(UnspentTxOut::new(
@@ -206,12 +209,14 @@ async fn key_spend_with_script() {
     let mut builder = TxHandlerBuilder::new();
     builder = builder
         .add_input(
+            NormalSignatureKind::NormalSignatureUnknown,
             SpendableTxIn::new(
                 utxo,
                 prevout.clone(),
                 scripts.clone(),
                 Some(from_address_spend_info.clone()),
             ),
+            SpendPath::Unknown,
             DEFAULT_SEQUENCE,
         )
         .add_output(UnspentTxOut::from_partial(TxOut {
@@ -319,12 +324,14 @@ async fn script_spend() {
     let prevout = rpc.get_txout_from_outpoint(&utxo).await.unwrap();
     let mut tx_details = TxHandlerBuilder::new()
         .add_input(
+            NormalSignatureKind::NormalSignatureUnknown,
             SpendableTxIn::new(
                 utxo,
                 prevout.clone(),
                 scripts,
                 Some(from_address_spend_info.clone()),
             ),
+            SpendPath::Unknown,
             DEFAULT_SEQUENCE,
         )
         .add_output(UnspentTxOut::from_partial(TxOut {
@@ -463,12 +470,14 @@ async fn key_and_script_spend() {
     // Test Transactions
     let mut test_txhandler_1 = TxHandlerBuilder::new()
         .add_input(
+            NormalSignatureKind::NormalSignatureUnknown,
             SpendableTxIn::new(
                 utxo_1,
                 prevout_1,
                 scripts.clone(),
                 Some(from_address_spend_info.clone()),
             ),
+            SpendPath::Unknown,
             DEFAULT_SEQUENCE,
         )
         .add_output(UnspentTxOut::from_partial(TxOut {
@@ -479,12 +488,14 @@ async fn key_and_script_spend() {
 
     let mut test_txhandler_2 = TxHandlerBuilder::new()
         .add_input(
+            NormalSignatureKind::NormalSignatureUnknown,
             SpendableTxIn::new(
                 utxo_2,
                 prevout_2,
                 scripts,
                 Some(from_address_spend_info.clone()),
             ),
+            SpendPath::Unknown,
             DEFAULT_SEQUENCE,
         )
         .add_output(UnspentTxOut::from_partial(TxOut {

--- a/core/tests/musig2.rs
+++ b/core/tests/musig2.rs
@@ -11,7 +11,7 @@ use clementine_core::errors::BridgeError;
 use clementine_core::musig2::{
     aggregate_nonces, aggregate_partial_signatures, AggregateFromPublicKeys, Musig2Mode,
 };
-use clementine_core::rpc::clementine::{NormalSignatureId, NormalSignatureKind};
+use clementine_core::rpc::clementine::NormalSignatureKind;
 use clementine_core::utils::SECP;
 use clementine_core::{
     builder::{self},

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -3,12 +3,13 @@ use bitcoin::secp256k1::Scalar;
 use bitcoin::{Address, Amount, TapTweakHash, TxOut};
 use bitcoincore_rpc::RpcApi;
 use clementine_core::actor::Actor;
-use clementine_core::builder::script::{CheckSig, SpendableScript};
+use clementine_core::builder::script::{CheckSig, SpendPath, SpendableScript};
 use clementine_core::builder::transaction::input::SpendableTxIn;
 use clementine_core::builder::transaction::output::UnspentTxOut;
 use clementine_core::builder::transaction::{TxHandlerBuilder, DEFAULT_SEQUENCE};
 use clementine_core::builder::{self};
 use clementine_core::extended_rpc::ExtendedRpc;
+use clementine_core::rpc::clementine::NormalSignatureKind;
 use clementine_core::utils::SECP;
 use clementine_core::{config::BridgeConfig, database::Database, utils::initialize_logger};
 use std::sync::Arc;
@@ -65,6 +66,7 @@ async fn create_address_and_transaction_then_sign_transaction() {
 
     let mut builder = TxHandlerBuilder::new();
     builder = builder.add_input(
+        NormalSignatureKind::NormalSignatureUnknown,
         SpendableTxIn::new(
             utxo,
             TxOut {
@@ -74,6 +76,7 @@ async fn create_address_and_transaction_then_sign_transaction() {
             scripts.clone(),
             Some(taproot_spend_info.clone()),
         ),
+        SpendPath::Unknown,
         DEFAULT_SEQUENCE,
     );
 

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -23,12 +23,6 @@ create table if not exists operator_sequential_collateral_txs (
     primary key (operator_idx, idx)
 );
 
--- Timeout tx signatures. Verifiers needs to store these data and use it when needed
-create table if not exists operator_timeout_tx_sigs (
-    operator_idx int primary key, -- Index of the operator
-    timeout_tx_sigs bytea not null -- Serialized Timeout tx signatures
-);
-
 -- Verifier table for deposit details
 /* This table holds the information related to a deposit. */
 create table if not exists deposit_infos (
@@ -159,12 +153,19 @@ create table if not exists operator_winternitz_public_keys (
     primary key (operator_id)
 );
 
+create table if not exists deposits (
+    deposit_id serial primary key,
+    deposit_outpoint text unique not null check (deposit_outpoint ~ '^[a-fA-F0-9]{64}:(0|[1-9][0-9]{0,9})$')
+);
+
 -- Deposit signatures
 create table if not exists deposit_signatures (
-    deposit_outpoint text not null check (deposit_outpoint ~ '^[a-fA-F0-9]{64}:(0|[1-9][0-9]{0,9})$'),
+    deposit_id int not null,
     operator_idx int not null,
+    sequential_collateral_idx int not null,
+    kickoff_idx int not null,
     signatures bytea not null,
-    primary key (deposit_outpoint, operator_idx)
+    primary key (deposit_id, operator_idx, sequential_collateral_idx, kickoff_idx)
 );
 
 -- Verifier table for BitVM setup data


### PR DESCRIPTION
# Description
-While creating TxHandler add information about spend path of input (keypath or script path idx), tag every input with an enum so that we can easily understand which saved nofn signature corresponds to which utxo. 
-Save signatures with their tag to db, each row in signatures db is denoted by deposit_outpoint (converted to a unique int), operator_idx, sequential_collateral_idx and kickoff_idx.

## Linked Issues

- Closes #503
