### PR TITLE
Tx creator

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -425,7 +425,7 @@ mod tests {
     use crate::builder::script::{CheckSig, SpendPath, SpendableScript};
     use crate::builder::transaction::input::SpendableTxIn;
     use crate::builder::transaction::output::UnspentTxOut;
-    use crate::builder::transaction::{TxHandler, TxHandlerBuilder};
+    use crate::builder::transaction::{TransactionType, TxHandler, TxHandlerBuilder};
     use crate::config::BridgeConfig;
     use crate::rpc::clementine::NormalSignatureKind;
     use crate::utils::{initialize_logger, SECP};
@@ -462,7 +462,7 @@ mod tests {
             value: Amount::from_sat(1000),
             script_pubkey: tap_addr.script_pubkey(),
         };
-        let builder = TxHandlerBuilder::new().add_input(
+        let builder = TxHandlerBuilder::new(TransactionType::Dummy).add_input(
             NormalSignatureKind::AlreadyDisproved1,
             SpendableTxIn::new(
                 OutPoint::default(),
@@ -519,7 +519,7 @@ mod tests {
             Some(spend_info),
         );
 
-        let builder = TxHandlerBuilder::new().add_input(
+        let builder = TxHandlerBuilder::new(TransactionType::Dummy).add_input(
             NormalSignatureKind::AlreadyDisproved1,
             spendable_input,
             SpendPath::ScriptSpend(0),

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -422,7 +422,7 @@ mod tests {
     use crate::builder::address::create_taproot_address;
 
     use super::*;
-    use crate::builder::script::{CheckSig, ScriptKind, SpendPath, SpendableScript};
+    use crate::builder::script::{CheckSig, SpendPath, SpendableScript};
     use crate::builder::transaction::input::SpendableTxIn;
     use crate::builder::transaction::output::UnspentTxOut;
     use crate::builder::transaction::{TxHandler, TxHandlerBuilder};
@@ -434,11 +434,11 @@ mod tests {
         initialize_database,
     };
     use bitcoin::secp256k1::{schnorr, Message, SecretKey};
-    use bitcoin::sighash::SighashCache;
-    use bitcoin::sighash::{Prevouts, TapSighashType};
+
+    use bitcoin::sighash::TapSighashType;
     use bitcoin::transaction::Transaction;
-    use bitcoin::Sequence;
-    use bitcoin::{Amount, Network, OutPoint, ScriptBuf};
+
+    use bitcoin::{Amount, Network, OutPoint};
     use bitvm::{
         execute_script,
         signatures::winternitz::{
@@ -447,7 +447,7 @@ mod tests {
         treepp::script,
     };
     use rand::thread_rng;
-    use secp256k1::{rand, SECP256K1};
+    use secp256k1::rand;
     use std::env;
     use std::str::FromStr;
     use std::sync::Arc;
@@ -583,7 +583,7 @@ mod tests {
     fn test_actor_script_spend_sig_valid() {
         let sk = SecretKey::new(&mut thread_rng());
         let actor = Actor::new(sk, None, Network::Regtest);
-        let (prevutxo, mut txhandler) = create_script_spend_tx_handler(&actor);
+        let (_, mut txhandler) = create_script_spend_tx_handler(&actor);
 
         // Actor performs a partial sign for script spend.
         // Using an empty signature slice since our dummy CheckSig uses actor signature.
@@ -604,7 +604,7 @@ mod tests {
 
         // Compute the sighash expected for a pubkey spend (similar to key spend).
         let sighash = txhandler
-            .calculate_script_spend_sighash_indexed(0, 0, TapSighashType::All)
+            .calculate_script_spend_sighash_indexed(0, 0, TapSighashType::Default)
             .expect("Sighash computed");
 
         let message = Message::from_digest(*sighash.as_byte_array());
@@ -656,7 +656,7 @@ mod tests {
 
         // This transaction is matching with prevouts. Therefore signing will
         // be successful.
-        let mut tx_handler = create_key_spend_tx_handler(&actor).1;
+        let tx_handler = create_key_spend_tx_handler(&actor).1;
         let sighash = tx_handler
             .calculate_pubkey_spend_sighash(0, Some(bitcoin::TapSighashType::Default))
             .expect("calculating pubkey spend sighash");

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -236,7 +236,7 @@ impl Actor {
     }
 
     //
-    pub fn partial_sign_winternitz_or_preimagereveal(
+    pub fn partial_sign_commit(
         &self,
         txhandler: &mut TxHandler,
         signatures: &[TaggedSignature],

--- a/core/src/builder/address.rs
+++ b/core/src/builder/address.rs
@@ -3,6 +3,8 @@
 //! Address builder provides useful functions for building typical Bitcoin
 //! addresses.
 
+use super::script::{CheckSig, DepositScript, SpendableScript, TimelockScript};
+use crate::constants::{WATCHTOWER_CHALLENGE_MESSAGE_LENGTH, WINTERNITZ_LOG_D};
 use crate::errors::BridgeError;
 use crate::utils::SECP;
 use crate::{utils, EVMAddress};
@@ -15,8 +17,6 @@ use bitcoin::{
 };
 use bitcoin::{Amount, Network};
 use bitvm::signatures::winternitz;
-
-use super::script::{CheckSig, DepositScript, SpendableScript, TimelockScript};
 
 pub fn taproot_builder_with_scripts(scripts: &[ScriptBuf]) -> TaprootBuilder {
     let builder = TaprootBuilder::new();
@@ -169,7 +169,8 @@ pub fn derive_challenge_address_from_xonlypk_and_wpk(
 ) -> Address {
     let verifier =
         winternitz::Winternitz::<winternitz::ListpickVerifier, winternitz::TabledConverter>::new();
-    let wots_params = winternitz::Parameters::new(240, 4);
+    let wots_params =
+        winternitz::Parameters::new(WATCHTOWER_CHALLENGE_MESSAGE_LENGTH, WINTERNITZ_LOG_D);
     let mut script_builder = verifier.checksig_verify(&wots_params, winternitz_pk);
     script_builder = script_builder.push_x_only_key(xonly_pk);
     script_builder = script_builder.push_opcode(OP_CHECKSIG); // TODO: Add checksig in the beginning

--- a/core/src/builder/script.rs
+++ b/core/src/builder/script.rs
@@ -63,7 +63,7 @@ impl OtherSpendable {
         &self.0
     }
 
-    fn generate_witness(&self, witness: Witness) -> Witness {
+    fn generate_script_inputs(&self, witness: Witness) -> Witness {
         witness
     }
 
@@ -89,7 +89,7 @@ impl SpendableScript for CheckSig {
 }
 
 impl CheckSig {
-    pub fn generate_witness(&self, signature: &schnorr::Signature) -> Witness {
+    pub fn generate_script_inputs(&self, signature: &schnorr::Signature) -> Witness {
         Witness::from_slice(&[signature.serialize()])
     }
 
@@ -123,7 +123,7 @@ impl SpendableScript for WinternitzCommit {
 }
 
 impl WinternitzCommit {
-    pub fn generate_witness(
+    pub fn generate_script_inputs(
         &self,
         commit_data: &Vec<u8>,
         secret_key: &SecretKey,
@@ -180,7 +180,7 @@ impl SpendableScript for TimelockScript {
 }
 
 impl TimelockScript {
-    pub fn generate_witness(&self, signature: &Option<schnorr::Signature>) -> Witness {
+    pub fn generate_script_inputs(&self, signature: &Option<schnorr::Signature>) -> Witness {
         match signature {
             Some(sig) => Witness::from_slice(&[sig.serialize()]),
             None => Witness::default(),
@@ -212,7 +212,7 @@ impl SpendableScript for PreimageRevealScript {
 }
 
 impl PreimageRevealScript {
-    pub fn generate_witness(&self, preimage: &[u8], signature: &schnorr::Signature) -> Witness {
+    pub fn generate_script_inputs(&self, preimage: &[u8], signature: &schnorr::Signature) -> Witness {
         Witness::from_slice(&[preimage, &signature.serialize()])
     }
 
@@ -246,7 +246,7 @@ impl SpendableScript for DepositScript {
 }
 
 impl DepositScript {
-    pub fn generate_witness(&self, signature: &schnorr::Signature) -> Witness {
+    pub fn generate_script_inputs(&self, signature: &schnorr::Signature) -> Witness {
         Witness::from_slice(&[signature.serialize()])
     }
 

--- a/core/src/builder/script.rs
+++ b/core/src/builder/script.rs
@@ -32,7 +32,7 @@ pub enum SpendPath {
 /// generate a witness, the trait object can be used to generate the script_buf.
 ///
 /// We store [`Arc<dyn SpendableScript>`]s inside a [`super::transaction::TxHandler`] input, and we cast them into a [`ScriptKind`] when signing.
-/// 
+///
 /// When creating a new Script, make sure you add it to the [`ScriptKind`] enum and add a test for it below.
 /// Otherwise, it will not be spendable.
 pub trait SpendableScript: Send + Sync + 'static + std::any::Any {

--- a/core/src/builder/sighash.rs
+++ b/core/src/builder/sighash.rs
@@ -109,8 +109,8 @@ pub fn create_nofn_sighash_stream(
     db: Database,
     config: BridgeConfig,
     deposit_outpoint: OutPoint,
-    _evm_address: EVMAddress,
-    _recovery_taproot_address: Address<NetworkUnchecked>,
+    evm_address: EVMAddress,
+    recovery_taproot_address: Address<NetworkUnchecked>,
     nofn_xonly_pk: XOnlyPublicKey,
     _user_takes_after: u16,
     collateral_funding_amount: Amount,
@@ -124,8 +124,8 @@ pub fn create_nofn_sighash_stream(
         // Create move_tx handler. This is unique for each deposit tx.
         let move_txhandler = builder::transaction::create_move_to_vault_txhandler(
             deposit_outpoint,
-            _evm_address,
-            &_recovery_taproot_address,
+            evm_address,
+            &recovery_taproot_address,
             nofn_xonly_pk,
             _user_takes_after,
             bridge_amount_sats,

--- a/core/src/builder/sighash.rs
+++ b/core/src/builder/sighash.rs
@@ -119,7 +119,7 @@ pub fn create_nofn_sighash_stream(
     bridge_amount_sats: Amount,
     network: bitcoin::Network,
 ) -> impl Stream<Item = Result<(TapSighash, SignatureInfo), BridgeError>> {
-    use bitcoin::TapSighashType::All as SighashAll;
+    use bitcoin::TapSighashType::Default as SighashAll;
     try_stream! {
         // Create move_tx handler. This is unique for each deposit tx.
         let move_txhandler = builder::transaction::create_move_to_vault_txhandler(

--- a/core/src/builder/transaction/creator.rs
+++ b/core/src/builder/transaction/creator.rs
@@ -1,0 +1,504 @@
+use crate::actor::{Actor, WinternitzDerivationPath};
+use crate::builder::script::WinternitzCommit;
+use crate::builder::transaction::{TransactionType, TxHandler};
+use crate::config::BridgeConfig;
+use crate::constants::{
+    WATCHTOWER_CHALLENGE_MESSAGE_LENGTH, WINTERNITZ_LOG_D,
+};
+use crate::database::Database;
+use crate::errors::BridgeError;
+use crate::{builder, utils, EVMAddress};
+use bitcoin::address::NetworkUnchecked;
+use bitcoin::{Address, Amount, OutPoint, XOnlyPublicKey};
+use bitvm::signatures::winternitz;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub async fn create_txhandlers(
+    db: Database,
+    config: BridgeConfig,
+    deposit_outpoint: OutPoint,
+    evm_address: EVMAddress,
+    recovery_taproot_address: Address<NetworkUnchecked>,
+    nofn_xonly_pk: XOnlyPublicKey,
+    _user_takes_after: u16,
+    collateral_funding_amount: Amount,
+    timeout_block_count: i64,
+    max_withdrawal_time_block_count: u16,
+    bridge_amount_sats: Amount,
+    transaction_type: TransactionType,
+    operator_idx: usize,
+    sequential_collateral_tx_idx: usize,
+    kickoff_idx: usize,
+    network: bitcoin::Network,
+) -> Result<HashMap<TransactionType, TxHandler>, BridgeError> {
+    let mut txhandlers = HashMap::new();
+    // Create move_tx handler. This is unique for each deposit tx.
+    let move_txhandler = builder::transaction::create_move_to_vault_txhandler(
+        deposit_outpoint,
+        evm_address,
+        &recovery_taproot_address,
+        nofn_xonly_pk,
+        _user_takes_after,
+        bridge_amount_sats,
+        network,
+    )?;
+    txhandlers.insert(move_txhandler.get_transaction_type(), move_txhandler);
+    // Get operator details (for each operator, (X-Only Public Key, Address, Collateral Funding Txid))
+    let (operator_xonly_pk, operator_reimburse_address, collateral_funding_txid) =
+        db.get_operator(None, operator_idx as i32).await?;
+
+    // create nth sequential collateral tx and reimburse generator tx for the operator
+    let (sequential_collateral_txhandler, reimburse_generator_txhandler) =
+        builder::transaction::create_seq_collat_reimburse_gen_nth_txhandler(
+            operator_xonly_pk,
+            collateral_funding_txid,
+            collateral_funding_amount,
+            timeout_block_count,
+            config.num_kickoffs_per_sequential_collateral_tx,
+            max_withdrawal_time_block_count,
+            network,
+            sequential_collateral_tx_idx,
+        )?;
+    txhandlers.insert(
+        sequential_collateral_txhandler.get_transaction_type(),
+        sequential_collateral_txhandler,
+    );
+    txhandlers.insert(
+        reimburse_generator_txhandler.get_transaction_type(),
+        reimburse_generator_txhandler,
+    );
+
+    let kickoff_txhandler = builder::transaction::create_kickoff_txhandler(
+        txhandlers
+            .get(&TransactionType::SequentialCollateral)
+            .ok_or(BridgeError::TxHandlerNotFound)?,
+        kickoff_idx,
+        nofn_xonly_pk,
+        operator_xonly_pk,
+        *txhandlers
+            .get(&TransactionType::MoveToVault)
+            .ok_or(BridgeError::TxHandlerNotFound)?
+            .get_txid(),
+        operator_idx,
+        network,
+    )?;
+    txhandlers.insert(kickoff_txhandler.get_transaction_type(), kickoff_txhandler);
+
+    // Creates the kickoff_timeout_tx handler.
+    let kickoff_timeout_txhandler = builder::transaction::create_kickoff_timeout_txhandler(
+        txhandlers
+            .get(&TransactionType::Kickoff)
+            .ok_or(BridgeError::TxHandlerNotFound)?,
+        txhandlers
+            .get(&TransactionType::SequentialCollateral)
+            .ok_or(BridgeError::TxHandlerNotFound)?,
+    )?;
+    txhandlers.insert(
+        kickoff_timeout_txhandler.get_transaction_type(),
+        kickoff_timeout_txhandler,
+    );
+
+    // Creates the challenge_tx handler.
+    let challenge_tx = builder::transaction::create_challenge_txhandler(
+        txhandlers
+            .get(&TransactionType::Kickoff)
+            .ok_or(BridgeError::TxHandlerNotFound)?,
+        &operator_reimburse_address,
+    )?;
+    txhandlers.insert(challenge_tx.get_transaction_type(), challenge_tx);
+
+    // Generate Happy reimburse txs conditionally
+    if matches!(
+        transaction_type,
+        TransactionType::StartHappyReimburse
+            | TransactionType::Reimburse
+            | TransactionType::All
+            | TransactionType::AllNeededForDeposit
+    ) {
+        // Creates the start_happy_reimburse_tx handler.
+        let start_happy_reimburse_txhandler =
+            builder::transaction::create_start_happy_reimburse_txhandler(
+                txhandlers
+                    .get(&TransactionType::Kickoff)
+                    .ok_or(BridgeError::TxHandlerNotFound)?,
+                operator_xonly_pk,
+                network,
+            )?;
+        txhandlers.insert(
+            start_happy_reimburse_txhandler.get_transaction_type(),
+            start_happy_reimburse_txhandler,
+        );
+
+        // Creates the happy_reimburse_tx handler.
+        let happy_reimburse_txhandler = builder::transaction::create_happy_reimburse_txhandler(
+            txhandlers
+                .get(&TransactionType::MoveToVault)
+                .ok_or(BridgeError::TxHandlerNotFound)?,
+            txhandlers
+                .get(&TransactionType::StartHappyReimburse)
+                .ok_or(BridgeError::TxHandlerNotFound)?,
+            txhandlers
+                .get(&TransactionType::ReimburseGenerator)
+                .ok_or(BridgeError::TxHandlerNotFound)?,
+            kickoff_idx,
+            &operator_reimburse_address,
+        )?;
+        txhandlers.insert(
+            happy_reimburse_txhandler.get_transaction_type(),
+            happy_reimburse_txhandler,
+        );
+        if !matches!(
+            transaction_type,
+            TransactionType::All | TransactionType::AllNeededForDeposit
+        ) {
+            // We do not need other txhandlers, exit early
+            return Ok(txhandlers);
+        }
+    }
+
+    // Generate watchtower challenges (addresses from db) if all txs are needed
+    if matches!(
+        transaction_type,
+        TransactionType::AllNeededForDeposit
+            | TransactionType::All
+            | TransactionType::WatchtowerChallengeKickoff
+            | TransactionType::WatchtowerChallenge(_)
+            | TransactionType::OperatorChallengeNACK(_)
+            | TransactionType::OperatorChallengeACK(_)
+    ) {
+        let needed_watchtower_idx: i32 =
+            if let TransactionType::WatchtowerChallenge(idx) = transaction_type {
+                idx as i32
+            } else {
+                -1
+            };
+
+        // Get all the watchtower challenge addresses for this operator. We have all of them here (for all the kickoff_utxos).
+        // TODO: Make this only return for a specific kickoff
+        let watchtower_all_challenge_addresses = (0..config.num_watchtowers)
+            .map(|i| db.get_watchtower_challenge_addresses(None, i as u32, operator_idx as u32))
+            .collect::<Vec<_>>();
+        let watchtower_all_challenge_addresses =
+            futures::future::try_join_all(watchtower_all_challenge_addresses).await?;
+
+        // Collect the challenge Winternitz pubkeys for this specific kickoff_utxo.
+        let watchtower_challenge_addresses = (0..config.num_watchtowers)
+            .map(|i| {
+                watchtower_all_challenge_addresses[i][sequential_collateral_tx_idx
+                    * config.num_kickoffs_per_sequential_collateral_tx
+                    + kickoff_idx]
+                    .clone()
+            })
+            .collect::<Vec<_>>();
+
+        let watchtower_challenge_kickoff_txhandler =
+            builder::transaction::create_watchtower_challenge_kickoff_txhandler_from_db(
+                txhandlers
+                    .get(&TransactionType::Kickoff)
+                    .ok_or(BridgeError::TxHandlerNotFound)?,
+                config.num_watchtowers as u32,
+                &watchtower_challenge_addresses,
+            )?;
+        txhandlers.insert(
+            watchtower_challenge_kickoff_txhandler.get_transaction_type(),
+            watchtower_challenge_kickoff_txhandler,
+        );
+
+        let public_hashes = db
+            .get_operators_challenge_ack_hashes(
+                None,
+                operator_idx as i32,
+                sequential_collateral_tx_idx as i32,
+                kickoff_idx as i32,
+            )
+            .await?
+            .ok_or(BridgeError::WatchtowerPublicHashesNotFound(
+                operator_idx as i32,
+                sequential_collateral_tx_idx as i32,
+                kickoff_idx as i32,
+            ))?;
+        // Each watchtower will sign their Groth16 proof of the header chain circuit. Then, the operator will either
+        // - acknowledge the challenge by sending the operator_challenge_ACK_tx, which will prevent the burning of the kickoff_tx.output[2],
+        // - or do nothing, which will cause one to send the operator_challenge_NACK_tx, which will burn the kickoff_tx.output[2]
+        // using watchtower_challenge_tx.output[0].
+        for (watchtower_idx, public_hash) in public_hashes.iter().enumerate() {
+            let watchtower_challenge_txhandler = if watchtower_idx as i32 != needed_watchtower_idx {
+                // create it with db if we don't need actual winternitz script
+                builder::transaction::create_watchtower_challenge_txhandler_from_db(
+                    txhandlers
+                        .get(&TransactionType::WatchtowerChallengeKickoff)
+                        .ok_or(BridgeError::TxHandlerNotFound)?,
+                    watchtower_idx,
+                    public_hash,
+                    nofn_xonly_pk,
+                    operator_xonly_pk,
+                    network,
+                )?
+            } else {
+                // generate with actual scripts if we want to specifically create a watchtower challenge tx
+                let path = WinternitzDerivationPath {
+                    message_length: WATCHTOWER_CHALLENGE_MESSAGE_LENGTH,
+                    log_d: WINTERNITZ_LOG_D,
+                    tx_type: crate::actor::TxType::WatchtowerChallenge,
+                    index: None,
+                    operator_idx: Some(operator_idx as u32),
+                    watchtower_idx: None,
+                    sequential_collateral_tx_idx: Some(sequential_collateral_tx_idx as u32),
+                    kickoff_idx: Some(kickoff_idx as u32),
+                    intermediate_step_name: None,
+                };
+                let actor = Actor::new(
+                    config.secret_key,
+                    config.winternitz_secret_key,
+                    config.network,
+                );
+                let public_key = actor.derive_winternitz_pk(path)?;
+                let winternitz_params = winternitz::Parameters::new(
+                    WATCHTOWER_CHALLENGE_MESSAGE_LENGTH,
+                    WINTERNITZ_LOG_D,
+                );
+
+                builder::transaction::create_watchtower_challenge_txhandler_from_script(
+                    txhandlers
+                        .get(&TransactionType::WatchtowerChallengeKickoff)
+                        .ok_or(BridgeError::TxHandlerNotFound)?,
+                    watchtower_idx,
+                    public_hash,
+                    Arc::new(WinternitzCommit::new(
+                        public_key,
+                        winternitz_params,
+                        actor.xonly_public_key,
+                    )),
+                    nofn_xonly_pk,
+                    operator_xonly_pk,
+                    network,
+                )?
+            };
+            txhandlers.insert(
+                watchtower_challenge_txhandler.get_transaction_type(),
+                watchtower_challenge_txhandler,
+            );
+            // Creates the operator_challenge_NACK_tx handler.
+            let operator_challenge_nack_txhandler =
+                builder::transaction::create_operator_challenge_nack_txhandler(
+                    txhandlers
+                        .get(&TransactionType::WatchtowerChallenge(watchtower_idx))
+                        .ok_or(BridgeError::TxHandlerNotFound)?,
+                    watchtower_idx,
+                    txhandlers
+                        .get(&TransactionType::Kickoff)
+                        .ok_or(BridgeError::TxHandlerNotFound)?,
+                )?;
+            txhandlers.insert(
+                operator_challenge_nack_txhandler.get_transaction_type(),
+                operator_challenge_nack_txhandler,
+            );
+
+            let operator_challenge_ack_txhandler =
+                builder::transaction::create_operator_challenge_ack_txhandler(
+                    txhandlers
+                        .get(&TransactionType::WatchtowerChallenge(watchtower_idx))
+                        .ok_or(BridgeError::TxHandlerNotFound)?,
+                    watchtower_idx,
+                )?;
+            txhandlers.insert(
+                operator_challenge_ack_txhandler.get_transaction_type(),
+                operator_challenge_ack_txhandler,
+            );
+        }
+        if !matches!(
+            transaction_type,
+            TransactionType::All | TransactionType::AllNeededForDeposit
+        ) {
+            // We do not need other txhandlers, exit early
+            return Ok(txhandlers);
+        }
+    }
+    if matches!(
+        transaction_type,
+        TransactionType::AssertBegin | TransactionType::AssertEnd | TransactionType::MiniAssert(_)
+    ) {
+        // if we specifically want to generate assert txs, we need to generate correct Winternitz scripts
+        let actor = Actor::new(
+            config.secret_key,
+            config.winternitz_secret_key,
+            config.network,
+        );
+        let mut assert_scripts = Vec::with_capacity(utils::ALL_BITVM_INTERMEDIATE_VARIABLES.len());
+        for (intermediate_step, intermediate_step_size) in
+            utils::ALL_BITVM_INTERMEDIATE_VARIABLES.iter()
+        {
+            let params = winternitz::Parameters::new(*intermediate_step_size as u32 * 2, 4);
+            let path = WinternitzDerivationPath {
+                message_length: *intermediate_step_size as u32 * 2,
+                log_d: 4,
+                tx_type: crate::actor::TxType::BitVM,
+                index: Some(operator_idx as u32), // same as in operator get_params, idk why its not operator_idx
+                operator_idx: None,
+                watchtower_idx: None,
+                sequential_collateral_tx_idx: Some(sequential_collateral_tx_idx as u32),
+                kickoff_idx: Some(kickoff_idx as u32),
+                intermediate_step_name: Some(intermediate_step),
+            };
+            let pk = actor.derive_winternitz_pk(path)?;
+            assert_scripts.push(Arc::new(WinternitzCommit::new(
+                pk,
+                params,
+                operator_xonly_pk,
+            )));
+        }
+        // Creates the assert_begin_tx handler.
+        let assert_begin_txhandler =
+            builder::transaction::create_assert_begin_txhandler_from_scripts(
+                txhandlers
+                    .get(&TransactionType::Kickoff)
+                    .ok_or(BridgeError::TxHandlerNotFound)?,
+                &assert_scripts,
+                network,
+            )?;
+
+        txhandlers.insert(
+            assert_begin_txhandler.get_transaction_type(),
+            assert_begin_txhandler,
+        );
+
+        let root_hash = db.get_bitvm_root_hash(
+            None,
+            operator_idx as i32,
+            sequential_collateral_tx_idx as i32,
+            kickoff_idx as i32,
+        ).await?.ok_or(BridgeError::BitvmSetupNotFound(
+            operator_idx as i32,
+            sequential_collateral_tx_idx as i32,
+            kickoff_idx as i32,
+        ))?;
+
+        // Creates the assert_end_tx handler.
+        let mini_asserts_and_assert_end_txhandlers =
+            builder::transaction::create_mini_asserts_and_assert_end_from_scripts(
+                txhandlers
+                    .get(&TransactionType::Kickoff)
+                    .ok_or(BridgeError::TxHandlerNotFound)?,
+                txhandlers
+                    .get(&TransactionType::AssertBegin)
+                    .ok_or(BridgeError::TxHandlerNotFound)?,
+                &assert_scripts,
+                &root_hash,
+                nofn_xonly_pk,
+                network,
+            )?;
+        for txhandler in mini_asserts_and_assert_end_txhandlers {
+            txhandlers.insert(txhandler.get_transaction_type(), txhandler);
+        }
+    } else {
+        // Get the bitvm setup for this operator, sequential collateral tx, and kickoff idx.
+        let (assert_tx_addrs, root_hash, _public_input_wots) = db
+            .get_bitvm_setup(
+                None,
+                operator_idx as i32,
+                sequential_collateral_tx_idx as i32,
+                kickoff_idx as i32,
+            )
+            .await?
+            .ok_or(BridgeError::BitvmSetupNotFound(
+                operator_idx as i32,
+                sequential_collateral_tx_idx as i32,
+                kickoff_idx as i32,
+            ))?;
+
+        // Creates the assert_begin_tx handler.
+        let assert_begin_txhandler = builder::transaction::create_assert_begin_txhandler(
+            txhandlers
+                .get(&TransactionType::Kickoff)
+                .ok_or(BridgeError::TxHandlerNotFound)?,
+            &assert_tx_addrs,
+            network,
+        )?;
+
+        txhandlers.insert(
+            assert_begin_txhandler.get_transaction_type(),
+            assert_begin_txhandler,
+        );
+
+        // Creates the assert_end_tx handler.
+        let assert_end_txhandler = builder::transaction::create_assert_end_txhandler(
+            txhandlers
+                .get(&TransactionType::Kickoff)
+                .ok_or(BridgeError::TxHandlerNotFound)?,
+            txhandlers
+                .get(&TransactionType::AssertBegin)
+                .ok_or(BridgeError::TxHandlerNotFound)?,
+            &assert_tx_addrs,
+            &root_hash,
+            nofn_xonly_pk,
+            network,
+        )?;
+
+        txhandlers.insert(
+            assert_end_txhandler.get_transaction_type(),
+            assert_end_txhandler,
+        );
+    }
+
+    // Creates the disprove_timeout_tx handler.
+    let disprove_timeout_txhandler = builder::transaction::create_disprove_timeout_txhandler(
+        txhandlers
+            .get(&TransactionType::AssertEnd)
+            .ok_or(BridgeError::TxHandlerNotFound)?,
+        operator_xonly_pk,
+        network,
+    )?;
+
+    txhandlers.insert(
+        disprove_timeout_txhandler.get_transaction_type(),
+        disprove_timeout_txhandler,
+    );
+
+    // Creates the already_disproved_tx handler.
+    let already_disproved_txhandler = builder::transaction::create_already_disproved_txhandler(
+        txhandlers
+            .get(&TransactionType::AssertEnd)
+            .ok_or(BridgeError::TxHandlerNotFound)?,
+        txhandlers
+            .get(&TransactionType::SequentialCollateral)
+            .ok_or(BridgeError::TxHandlerNotFound)?,
+    )?;
+
+    txhandlers.insert(
+        already_disproved_txhandler.get_transaction_type(),
+        already_disproved_txhandler,
+    );
+
+    // Creates the reimburse_tx handler.
+    let reimburse_txhandler = builder::transaction::create_reimburse_txhandler(
+        txhandlers
+            .get(&TransactionType::MoveToVault)
+            .ok_or(BridgeError::TxHandlerNotFound)?,
+        txhandlers
+            .get(&TransactionType::DisproveTimeout)
+            .ok_or(BridgeError::TxHandlerNotFound)?,
+        txhandlers
+            .get(&TransactionType::ReimburseGenerator)
+            .ok_or(BridgeError::TxHandlerNotFound)?,
+        kickoff_idx,
+        &operator_reimburse_address,
+    )?;
+
+    txhandlers.insert(
+        reimburse_txhandler.get_transaction_type(),
+        reimburse_txhandler,
+    );
+
+    // TODO: Disprove TX is not included rn (We need actual disprove script we will use for Disprove TX)
+
+    Ok(txhandlers)
+}
+
+#[cfg(test)]
+mod tests {
+
+    async fn test_deposit_then_sign() {
+
+    }
+}

--- a/core/src/builder/transaction/input.rs
+++ b/core/src/builder/transaction/input.rs
@@ -193,6 +193,10 @@ impl SpentTxIn {
         &self.spendable
     }
 
+    pub fn get_spend_path(&self) -> SpendPath {
+        self.spend_path
+    }
+
     pub fn get_witness(&self) -> &Option<Witness> {
         &self.witness
     }

--- a/core/src/builder/transaction/mod.rs
+++ b/core/src/builder/transaction/mod.rs
@@ -25,6 +25,7 @@ use bitcoin::{Address, Amount, OutPoint, ScriptBuf, TxOut, XOnlyPublicKey};
 pub use txhandler::Unsigned;
 
 mod challenge;
+mod creator;
 pub mod input;
 mod operator_assert;
 mod operator_collateral;

--- a/core/src/builder/transaction/mod.rs
+++ b/core/src/builder/transaction/mod.rs
@@ -32,6 +32,36 @@ mod operator_reimburse;
 pub mod output;
 mod txhandler;
 
+/// Types of all transactions that can be created. Some transactions have an (usize) to as they are created
+/// multiple times per kickoff.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum TransactionType {
+    SequentialCollateral,
+    ReimburseGenerator,
+    Kickoff,
+    MoveToVault,
+    Payout,
+    Challenge,
+    KickoffTimeout,
+    KickoffUTXOTimeout,
+    WatchtowerChallengeKickoff,
+    StartHappyReimburse,
+    HappyReimburse,
+    WatchtowerChallenge(usize),
+    OperatorChallengeNACK(usize),
+    OperatorChallengeACK(usize),
+    AssertBegin,
+    MiniAssert(usize),
+    AssertEnd,
+    Disprove,
+    DisproveTimeout,
+    AlreadyDisproved,
+    Reimburse,
+    AllNeededForDeposit, // this will include all tx's that is needed for a deposit
+    All, // this will also include tx's not needed for a deposit, for example OperatorChallengeACK
+    Dummy, // for tests
+}
+
 /// Creates a P2WSH output that anyone can spend. TODO: We will not need this in the future.
 pub fn anyone_can_spend_txout() -> TxOut {
     let script = Builder::new().push_opcode(OP_PUSHNUM_1).into_script();
@@ -98,7 +128,7 @@ pub fn create_move_to_vault_txhandler(
         user_takes_after,
     ));
 
-    let builder = TxHandlerBuilder::new().add_input(
+    let builder = TxHandlerBuilder::new(TransactionType::MoveToVault).add_input(
         NormalSignatureKind::NotStored,
         SpendableTxIn::from_scripts(
             deposit_outpoint,

--- a/core/src/builder/transaction/operator_reimburse.rs
+++ b/core/src/builder/transaction/operator_reimburse.rs
@@ -1,4 +1,5 @@
 use super::txhandler::DEFAULT_SEQUENCE;
+use super::TransactionType;
 use crate::builder::script::{CheckSig, TimelockScript};
 use crate::builder::transaction::output::UnspentTxOut;
 use crate::builder::transaction::txhandler::{TxHandler, TxHandlerBuilder};
@@ -22,7 +23,7 @@ pub fn create_kickoff_txhandler(
     operator_idx: usize,
     network: Network,
 ) -> Result<TxHandler, BridgeError> {
-    let mut builder = TxHandlerBuilder::new();
+    let mut builder = TxHandlerBuilder::new(TransactionType::Kickoff);
     builder = builder.add_input(
         NormalSignatureKind::NotStored,
         sequential_collateral_txhandler.get_spendable_output(2 + kickoff_idx)?,
@@ -95,7 +96,7 @@ pub fn create_start_happy_reimburse_txhandler(
     operator_xonly_pk: XOnlyPublicKey,
     network: bitcoin::Network,
 ) -> Result<TxHandler, BridgeError> {
-    let mut builder = TxHandlerBuilder::new();
+    let mut builder = TxHandlerBuilder::new(TransactionType::StartHappyReimburse);
     builder = builder.add_input(
         NormalSignatureKind::NotStored,
         kickoff_txhandler.get_spendable_output(1)?,
@@ -131,7 +132,7 @@ pub fn create_happy_reimburse_txhandler(
     kickoff_idx: usize,
     operator_reimbursement_address: &bitcoin::Address,
 ) -> Result<TxHandler, BridgeError> {
-    let mut builder = TxHandlerBuilder::new();
+    let mut builder = TxHandlerBuilder::new(TransactionType::HappyReimburse);
     builder = builder
         .add_input(
             NormalSignatureKind::HappyReimburse1,
@@ -172,7 +173,7 @@ pub fn create_reimburse_txhandler(
     kickoff_idx: usize,
     operator_reimbursement_address: &bitcoin::Address,
 ) -> Result<TxHandler, BridgeError> {
-    let builder = TxHandlerBuilder::new()
+    let builder = TxHandlerBuilder::new(TransactionType::Reimburse)
         .add_input(
             NormalSignatureKind::Reimburse1,
             move_txhandler.get_spendable_output(0)?,

--- a/core/src/builder/transaction/txhandler.rs
+++ b/core/src/builder/transaction/txhandler.rs
@@ -113,6 +113,7 @@ impl TxHandler<Unsigned> {
             }
 
             if let Some(witness) = signer(idx, &self.txins[idx], calc_sighash)? {
+                self.cached_tx.input[idx].witness = witness.clone();
                 self.txins[idx].set_witness(witness);
             }
         }
@@ -269,43 +270,6 @@ impl TxHandler<Unsigned> {
         Ok(())
     }
 
-    // Candidate refactoring
-    // pub fn set_p2tr_script_spend_witness_find<T: AsRef<[u8]>>(
-    //     &mut self,
-    //     txin_index: usize,
-    //     script_finder: impl Fn(&&Scripts) -> bool,
-    //     script_spender: impl FnOnce(&Scripts) -> Witness,
-    // ) -> Result<(), BridgeError> {
-    //     let txin = self
-    //         .txins
-    //         .get_mut(txin_index)
-    //         ?;
-
-    //     if txin.get_witness().is_some() {
-    //         return Err(BridgeError::WitnessAlreadySet);
-    //     }
-
-    //     let script = txin
-    //         .get_witness()
-    //         .get_scripts()
-    //         .iter()
-    //         .find(script_finder)
-    //         .ok_or(BridgeError::TaprootScriptError)?;
-
-    //     let spend_control_block = txin
-    //         .get_spendable()
-    //         .get_spend_info()
-    //         .control_block(&((*script).to_script_buf(), LeafVersion::TapScript))
-    //         .ok_or(BridgeError::ControlBlockError)?;
-
-    //     let witness = script_spender(script);
-
-    //     txin.set_witness(witness);
-
-    //     self.cached_tx.input[txin_index].witness = txin.get_witness().as_ref().unwrap().clone();
-    //     Ok(())
-    // }
-
     pub fn set_p2tr_key_spend_witness(
         &mut self,
         signature: &taproot::Signature,
@@ -421,23 +385,4 @@ impl TxHandlerBuilder {
     pub fn finalize_signed(self) -> Result<TxHandler<Signed>, BridgeError> {
         self.finalize().promote()
     }
-
-    // pub fn spend<U: SpendableScript, T: FnOnce(U) -> Witness>(
-    //     &mut self,
-    //     txin_index: usize,
-    //     script_index: usize,
-    //     witness_fn: T,
-    // ) -> Result<(), BridgeError> {
-    //     let spendable = self
-    //         .prev_scripts
-    //         .get(txin_index)
-    //         .ok_or(BridgeError::NoScriptsForTxIn(txin_index))?
-    //         .get(script_index)
-    //         .ok_or(BridgeError::NoScriptAtIndex(script_index))?
-    //         .downcast::<U>()
-    //         .map_err(|_| BridgeError::ScriptTypeMismatch)?;
-    //     let witness = witness_fn(spendable);
-    //     self.tx.input_mut(txin_index).witness = witness;
-    //     Ok(())
-    // }
 }

--- a/core/src/builder/transaction/txhandler.rs
+++ b/core/src/builder/transaction/txhandler.rs
@@ -75,12 +75,12 @@ impl TxHandler<Unsigned> {
         move || -> Result<TapSighash, BridgeError> {
             match self.txins[idx].get_spend_path() {
                 SpendPath::KeySpend => {
-                    self.calculate_pubkey_spend_sighash(idx, Some(TapSighashType::All))
+                    self.calculate_pubkey_spend_sighash(idx, Some(TapSighashType::Default))
                 }
                 SpendPath::ScriptSpend(script_idx) => self.calculate_script_spend_sighash_indexed(
                     idx,
                     script_idx,
-                    TapSighashType::All,
+                    TapSighashType::Default,
                 ),
                 SpendPath::Unknown => Err(BridgeError::SpendPathNotSpecified),
             }
@@ -167,7 +167,7 @@ impl TxHandler<Unsigned> {
             .to_script_buf();
 
         // TODO: remove copy here
-        self.calculate_script_spend_sighash(txin_index, &script.clone(), sighash_type)
+        self.calculate_script_spend_sighash(txin_index, &script, sighash_type)
     }
 
     pub fn calculate_script_spend_sighash(

--- a/core/src/builder/transaction/txhandler.rs
+++ b/core/src/builder/transaction/txhandler.rs
@@ -72,14 +72,19 @@ impl TxHandler<Unsigned> {
         &mut self,
         mut signer: impl FnMut(usize, &SpentTxIn) -> Result<Option<Witness>, BridgeError>,
     ) -> Result<(), BridgeError> {
-        for (idx, txin) in self.txins.iter_mut().enumerate() {
-            if txin.get_witness().is_some() {
+        for (idx) in 0..self.txins.len() {
+            let test_closure = || {
+                println!("{self:?}");
+            };
+            if self.txins[idx].get_witness().is_some() {
                 continue;
             }
 
-            if let Some(witness) = signer(idx, &txin)? {
-                txin.set_witness(witness);
+            if let Some(witness) = signer(idx, &self.txins[idx])? {
+                test_closure();
+                self.txins[idx].set_witness(witness);
             }
+
         }
         Ok(())
     }

--- a/core/src/builder/transaction/txhandler.rs
+++ b/core/src/builder/transaction/txhandler.rs
@@ -68,6 +68,22 @@ impl TxHandler<Unsigned> {
         &self.cached_txid
     }
 
+    pub fn sign_txins(
+        &mut self,
+        mut signer: impl FnMut(usize, &SpentTxIn) -> Result<Option<Witness>, BridgeError>,
+    ) -> Result<(), BridgeError> {
+        for (idx, txin) in self.txins.iter_mut().enumerate() {
+            if txin.get_witness().is_some() {
+                continue;
+            }
+
+            if let Some(witness) = signer(idx, &txin)? {
+                txin.set_witness(witness);
+            }
+        }
+        Ok(())
+    }
+
     pub fn calculate_pubkey_spend_sighash(
         &self,
         txin_index: usize,

--- a/core/src/builder/transaction/txhandler.rs
+++ b/core/src/builder/transaction/txhandler.rs
@@ -57,6 +57,10 @@ impl<T: State> TxHandler<T> {
         let txin = self.txins.get(idx).ok_or(BridgeError::TxInputNotFound)?;
         Ok(txin.get_signature_id())
     }
+
+    pub fn get_transaction_type(&self) -> TransactionType {
+        self.transaction_type
+    }
 }
 
 impl TxHandler<Unsigned> {

--- a/core/src/builder/transaction/txhandler.rs
+++ b/core/src/builder/transaction/txhandler.rs
@@ -84,7 +84,6 @@ impl TxHandler<Unsigned> {
                 test_closure();
                 self.txins[idx].set_witness(witness);
             }
-
         }
         Ok(())
     }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -10,6 +10,7 @@
 //! Configuration options can be read from a TOML file. File contents are
 //! described in `BridgeConfig` struct.
 
+use crate::constants::BLOCKS_PER_WEEK;
 use crate::errors::BridgeError;
 use bitcoin::secp256k1::{PublicKey, SecretKey};
 use bitcoin::{address::NetworkUnchecked, Amount};
@@ -95,6 +96,12 @@ pub struct BridgeConfig {
     pub header_chain_proof_path: Option<PathBuf>,
     /// Additional secret key that will be used for creating Winternitz one time signature.
     pub winternitz_secret_key: Option<SecretKey>,
+    /// Collateral funding amount for operators.
+    pub collateral_funding_amount: Amount,
+    /// Timeout block count for each kickoff UTXO
+    pub timeout_block_count: i64,
+    /// Max withdrawal(also called reimburse) time block count
+    pub max_withdrawal_time_block_count: u16,
 }
 
 impl BridgeConfig {
@@ -229,7 +236,7 @@ impl Default for BridgeConfig {
             db_password: "clementine".to_string(),
             db_name: "clementine".to_string(),
 
-            bridge_amount_sats: Amount::from_sat(100_000_000),
+            bridge_amount_sats: Amount::from_sat(1_000_000_000),
 
             confirmation_threshold: 1,
 
@@ -313,6 +320,9 @@ impl Default for BridgeConfig {
             verifier_endpoints: None,
             operator_endpoints: None,
             watchtower_endpoints: None,
+            collateral_funding_amount: Amount::from_sat(200_000_000),
+            timeout_block_count: 6,
+            max_withdrawal_time_block_count: BLOCKS_PER_WEEK * 4,
         }
     }
 }

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -20,3 +20,7 @@ pub const ANCHOR_AMOUNT: Amount = Amount::from_sat(240); // TODO: This will chan
 pub const OPERATOR_CHALLENGE_AMOUNT: Amount = Amount::from_sat(200_000_000);
 
 pub const BLOCKS_PER_WEEK: u16 = 6 * 24 * 7;
+
+pub const WATCHTOWER_CHALLENGE_MESSAGE_LENGTH: u32 = 480;
+
+pub const WINTERNITZ_LOG_D: u32 = 4;

--- a/core/src/database/operator.rs
+++ b/core/src/database/operator.rs
@@ -1148,6 +1148,18 @@ mod tests {
         assert_eq!(result.1, root_hash);
         assert_eq!(result.2, public_input_wots);
 
+        let hash = database
+            .get_bitvm_root_hash(
+                None,
+                operator_idx,
+                sequential_collateral_tx_idx,
+                kickoff_idx,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(hash, root_hash);
+
         // Test non-existent entry
         let non_existent = database
             .get_bitvm_setup(None, 999, sequential_collateral_tx_idx, kickoff_idx)

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -230,7 +230,9 @@ pub enum BridgeError {
     #[error("Spend Path in SpentTxIn in TxHandler not specified")]
     SpendPathNotSpecified,
     #[error("Actor does not own the key needed in P2TR keypath")]
-    NonOwnedKeyPath,
+    NotOwnKeyPath,
+    #[error("public key of Checksig in script is not owned by Actor")]
+    NotOwnedScriptPath,
     #[error("Couldn't find needed signature from database")]
     SignatureNotFound,
 

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -257,6 +257,9 @@ pub enum BridgeError {
 
     #[error("Not enough operators")]
     NotEnoughOperators,
+
+    #[error("Encountered multiple winternitz scripts when attempting to commit to only one.")]
+    MultipleWinternitzScripts,
 }
 
 impl From<BridgeError> for ErrorObject<'static> {

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -252,6 +252,8 @@ pub enum BridgeError {
 
     #[error("InvalidAssertTxAddrs")]
     InvalidAssertTxAddrs,
+    #[error("Not enough assert tx scripts given")]
+    InvalidAssertTxScripts,
     #[error("Invalid response from Citrea: {0}")]
     InvalidCitreaResponse(String),
 

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -227,6 +227,12 @@ pub enum BridgeError {
     NoScriptsForTxIn(usize),
     #[error("No script in TxHandler for the index {0}")]
     NoScriptAtIndex(usize),
+    #[error("Spend Path in SpentTxIn in TxHandler not specified")]
+    SpendPathNotSpecified,
+    #[error("Actor does not own the key needed in P2TR keypath")]
+    NonOwnedKeyPath,
+    #[error("Couldn't find needed signature from database")]
+    SignatureNotFound,
 
     #[error("BitvmSetupNotFound for operator {0}, sequential_collateral_tx {1}, kickoff {2}")]
     BitvmSetupNotFound(i32, i32, i32),

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -235,6 +235,8 @@ pub enum BridgeError {
     NotOwnedScriptPath,
     #[error("Couldn't find needed signature from database")]
     SignatureNotFound,
+    #[error("Couldn't find needed txhandler during creation")]
+    TxHandlerNotFound,
 
     #[error("BitvmSetupNotFound for operator {0}, sequential_collateral_tx {1}, kickoff {2}")]
     BitvmSetupNotFound(i32, i32, i32),

--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -225,7 +225,7 @@ pub fn partial_sign(
 mod tests {
     use super::{nonce_pair, MuSigNoncePair, Musig2Mode};
     use crate::builder::script::{CheckSig, OtherSpendable, SpendableScript};
-    use crate::builder::transaction::DEFAULT_SEQUENCE;
+    use crate::builder::transaction::{TransactionType, DEFAULT_SEQUENCE};
     use crate::rpc::clementine::NormalSignatureKind;
     use crate::{
         builder::{
@@ -524,8 +524,7 @@ mod tests {
             txid: Txid::from_byte_array([0u8; 32]),
             vout: 0,
         };
-
-        let mut builder = TxHandlerBuilder::new();
+        let mut builder = TxHandlerBuilder::new(TransactionType::Dummy);
         builder = builder
             .add_input(
                 NormalSignatureKind::NotStored,
@@ -634,7 +633,7 @@ mod tests {
             vout: 0,
         };
 
-        let tx_details = TxHandlerBuilder::new()
+        let tx_details = TxHandlerBuilder::new(TransactionType::Dummy)
             .add_input(
                 NormalSignatureKind::NotStored,
                 SpendableTxIn::new(

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -25,7 +25,7 @@ use crate::{
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::schnorr::Signature;
 use bitcoin::secp256k1::{Message, PublicKey};
-use bitcoin::{Amount, TapSighash};
+use bitcoin::TapSighash;
 use futures::TryFutureExt;
 use futures::{future::try_join_all, stream::BoxStream, FutureExt, Stream, StreamExt};
 use secp256k1::musig::{MusigAggNonce, MusigPartialSignature, MusigPubNonce};
@@ -526,7 +526,7 @@ impl ClementineAggregator for Aggregator {
     ) -> Result<Response<RawSignedMoveTx>, Status> {
         let deposit_params = request.into_inner();
 
-        let (deposit_outpoint, evm_address, recovery_taproot_address, user_takes_after) =
+        let (deposit_outpoint, evm_address, recovery_taproot_address, _user_takes_after) =
             parser::parse_deposit_params(deposit_params.clone())?;
 
         // Generate nonce streams for all verifiers.
@@ -605,12 +605,6 @@ impl ClementineAggregator for Aggregator {
             evm_address,
             recovery_taproot_address,
             self.nofn_xonly_pk,
-            user_takes_after,
-            Amount::from_sat(200_000_000), // TODO: Fix this.
-            6,
-            100,
-            self.config.bridge_amount_sats,
-            self.config.network,
         ));
 
         // Create channels for pipeline communication

--- a/core/src/rpc/operator.rs
+++ b/core/src/rpc/operator.rs
@@ -7,7 +7,7 @@ use super::error::*;
 use crate::builder::sighash::create_operator_sighash_stream;
 use crate::rpc::parser;
 use crate::{errors::BridgeError, operator::Operator};
-use bitcoin::{Amount, OutPoint};
+use bitcoin::OutPoint;
 use futures::StreamExt;
 use std::pin::pin;
 use tokio::sync::mpsc;
@@ -63,7 +63,7 @@ impl ClementineOperator for Operator {
         let (tx, rx) = mpsc::channel(1280);
         let deposit_sign_session = request.into_inner();
 
-        let (deposit_outpoint, evm_address, recovery_taproot_address, user_takes_after) =
+        let (deposit_outpoint, evm_address, recovery_taproot_address, _user_takes_after) =
             parser::parse_deposit_params(deposit_sign_session.try_into()?)?;
 
         tokio::spawn(async move {
@@ -77,12 +77,6 @@ impl ClementineOperator for Operator {
                 evm_address,
                 recovery_taproot_address,
                 operator.nofn_xonly_pk,
-                user_takes_after,
-                Amount::from_sat(200_000_000), // TODO: Fix this.
-                6,
-                100,
-                operator.config.bridge_amount_sats,
-                operator.config.network,
             ));
 
             while let Some(sighash) = sighash_stream.next().await {

--- a/core/src/watchtower.rs
+++ b/core/src/watchtower.rs
@@ -1,3 +1,4 @@
+use crate::constants::{WATCHTOWER_CHALLENGE_MESSAGE_LENGTH, WINTERNITZ_LOG_D};
 use crate::{
     actor::{Actor, WinternitzDerivationPath},
     builder::address::derive_challenge_address_from_xonlypk_and_wpk,
@@ -57,8 +58,8 @@ impl Watchtower {
             for sequential_collateral_tx in 0..self.config.num_sequential_collateral_txs as u32 {
                 for kickoff_idx in 0..self.config.num_kickoffs_per_sequential_collateral_tx as u32 {
                     let path = WinternitzDerivationPath {
-                        message_length: 480,
-                        log_d: 4,
+                        message_length: WATCHTOWER_CHALLENGE_MESSAGE_LENGTH,
+                        log_d: WINTERNITZ_LOG_D,
                         tx_type: crate::actor::TxType::WatchtowerChallenge,
                         index: None,
                         operator_idx: Some(operator),

--- a/core/tests/data/test_config.toml
+++ b/core/tests/data/test_config.toml
@@ -3,6 +3,10 @@ host = "127.0.0.1"
 port = 17000
 index = 0
 
+collateral_funding_amount = 200000000
+timeout_block_count = 6
+max_withdrawal_time_block_count = 4032
+
 # Secret key of the current actor (operator or verifier)
 secret_key = "3333333333333333333333333333333333333333333333333333333333333333"
 
@@ -58,7 +62,7 @@ db_user = "clementine"
 db_password = "clementine"
 db_name = "clementine"
 
-bridge_amount_sats = 100000000
+bridge_amount_sats = 10000000000
 
 confirmation_threshold = 1
 

--- a/core/tests/musig2.rs
+++ b/core/tests/musig2.rs
@@ -6,7 +6,7 @@ use bitcoincore_rpc::RpcApi;
 use clementine_core::builder::script::{CheckSig, OtherSpendable, SpendPath, SpendableScript};
 use clementine_core::builder::transaction::input::SpendableTxIn;
 use clementine_core::builder::transaction::output::UnspentTxOut;
-use clementine_core::builder::transaction::{TxHandlerBuilder, DEFAULT_SEQUENCE};
+use clementine_core::builder::transaction::{TransactionType, TxHandlerBuilder, DEFAULT_SEQUENCE};
 use clementine_core::errors::BridgeError;
 use clementine_core::musig2::{
     aggregate_nonces, aggregate_partial_signatures, AggregateFromPublicKeys, Musig2Mode,
@@ -98,7 +98,7 @@ async fn key_spend() {
         .unwrap();
     let prevout = rpc.get_txout_from_outpoint(&utxo).await.unwrap();
 
-    let mut tx_details = TxHandlerBuilder::new()
+    let mut tx_details = TxHandlerBuilder::new(TransactionType::Dummy)
         .add_input(
             NormalSignatureKind::NormalSignatureUnknown,
             SpendableTxIn::new(utxo, prevout, vec![], Some(from_address_spend_info.clone())),
@@ -206,7 +206,7 @@ async fn key_spend_with_script() {
         .await
         .unwrap();
     let prevout = rpc.get_txout_from_outpoint(&utxo).await.unwrap();
-    let mut builder = TxHandlerBuilder::new();
+    let mut builder = TxHandlerBuilder::new(TransactionType::Dummy);
     builder = builder
         .add_input(
             NormalSignatureKind::NormalSignatureUnknown,
@@ -322,7 +322,7 @@ async fn script_spend() {
         .await
         .unwrap();
     let prevout = rpc.get_txout_from_outpoint(&utxo).await.unwrap();
-    let mut tx_details = TxHandlerBuilder::new()
+    let mut tx_details = TxHandlerBuilder::new(TransactionType::Dummy)
         .add_input(
             NormalSignatureKind::NormalSignatureUnknown,
             SpendableTxIn::new(
@@ -468,7 +468,7 @@ async fn key_and_script_spend() {
     );
 
     // Test Transactions
-    let mut test_txhandler_1 = TxHandlerBuilder::new()
+    let mut test_txhandler_1 = TxHandlerBuilder::new(TransactionType::Dummy)
         .add_input(
             NormalSignatureKind::NormalSignatureUnknown,
             SpendableTxIn::new(
@@ -486,7 +486,7 @@ async fn key_and_script_spend() {
         }))
         .finalize();
 
-    let mut test_txhandler_2 = TxHandlerBuilder::new()
+    let mut test_txhandler_2 = TxHandlerBuilder::new(TransactionType::Dummy)
         .add_input(
             NormalSignatureKind::NormalSignatureUnknown,
             SpendableTxIn::new(

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -1,6 +1,4 @@
-use bitcoin::hashes::{Hash, HashEngine};
-use bitcoin::secp256k1::Scalar;
-use bitcoin::{Address, Amount, TapTweakHash, TxOut};
+use bitcoin::{Amount, TxOut};
 use bitcoincore_rpc::RpcApi;
 use clementine_core::actor::Actor;
 use clementine_core::builder::script::{CheckSig, SpendPath, SpendableScript};
@@ -30,23 +28,11 @@ async fn create_address_and_transaction_then_sign_transaction() {
     .unwrap();
 
     let (xonly_pk, _) = config.secret_key.public_key(&SECP).x_only_public_key();
-    let address = Address::p2tr(&SECP, xonly_pk, None, config.network);
-    let script = address.script_pubkey();
-    let tweaked_pk_script: [u8; 32] = script.as_bytes()[2..].try_into().unwrap();
-
-    // Calculate tweaked public key.
-    let mut hasher = TapTweakHash::engine();
-    hasher.input(&xonly_pk.serialize());
-    xonly_pk
-        .add_tweak(
-            &SECP,
-            &Scalar::from_be_bytes(TapTweakHash::from_engine(hasher).to_byte_array()).unwrap(),
-        )
-        .unwrap();
 
     // Prepare script and address.
     let script = Arc::new(CheckSig::new(
-        bitcoin::XOnlyPublicKey::from_slice(&tweaked_pk_script).unwrap(),
+        // bitcoin::XOnlyPublicKey::from_slice(&tweaked_pk_script).unwrap(),
+        xonly_pk,
     ));
     let scripts: Vec<Arc<dyn SpendableScript>> = vec![script.clone()];
     let (taproot_address, taproot_spend_info) = builder::address::create_taproot_address(
@@ -66,7 +52,7 @@ async fn create_address_and_transaction_then_sign_transaction() {
 
     let mut builder = TxHandlerBuilder::new();
     builder = builder.add_input(
-        NormalSignatureKind::NormalSignatureUnknown,
+        NormalSignatureKind::NotStored,
         SpendableTxIn::new(
             utxo,
             TxOut {
@@ -76,7 +62,7 @@ async fn create_address_and_transaction_then_sign_transaction() {
             scripts.clone(),
             Some(taproot_spend_info.clone()),
         ),
-        SpendPath::Unknown,
+        SpendPath::ScriptSpend(0),
         DEFAULT_SEQUENCE,
     );
 
@@ -97,6 +83,7 @@ async fn create_address_and_transaction_then_sign_transaction() {
         config.winternitz_secret_key,
         config.network,
     );
+
     signer
         .partial_sign(&mut tx_handler, &[])
         .expect("failed to sign transaction");

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -4,7 +4,7 @@ use clementine_core::actor::Actor;
 use clementine_core::builder::script::{CheckSig, SpendPath, SpendableScript};
 use clementine_core::builder::transaction::input::SpendableTxIn;
 use clementine_core::builder::transaction::output::UnspentTxOut;
-use clementine_core::builder::transaction::{TxHandlerBuilder, DEFAULT_SEQUENCE};
+use clementine_core::builder::transaction::{TransactionType, TxHandlerBuilder, DEFAULT_SEQUENCE};
 use clementine_core::builder::{self};
 use clementine_core::extended_rpc::ExtendedRpc;
 use clementine_core::rpc::clementine::NormalSignatureKind;
@@ -50,7 +50,7 @@ async fn create_address_and_transaction_then_sign_transaction() {
         .await
         .unwrap();
 
-    let mut builder = TxHandlerBuilder::new();
+    let mut builder = TxHandlerBuilder::new(TransactionType::Dummy);
     builder = builder.add_input(
         NormalSignatureKind::NotStored,
         SpendableTxIn::new(

--- a/core/tests/taproot.rs
+++ b/core/tests/taproot.rs
@@ -97,12 +97,10 @@ async fn create_address_and_transaction_then_sign_transaction() {
         config.winternitz_secret_key,
         config.network,
     );
-    let sig = signer
-        .sign_taproot_script_spend_tx_new_tweaked(&mut tx_handler, 0, 0)
-        .unwrap();
-    tx_handler
-        .set_p2tr_script_spend_witness(&[sig.as_ref()], 0, 0)
-        .unwrap();
+    signer
+        .partial_sign(&mut tx_handler, &[])
+        .expect("failed to sign transaction");
+
     rpc.mine_blocks(1).await.unwrap();
 
     // New transaction should be OK to send.


### PR DESCRIPTION
# Description

Adds a function that returns a HashMap that has a new enum TransactionType as key and corresponding TxHandlers as value.
Function needs deposit info and operator_idx, sequential_collateral_idx and kickoff_idx as parameters.
The function returns the requested TxHandler and all ancestors of it in the HashMap (sometimes it has some descendants of it too).

After getting the TxHandler signing can be done with:
actor.partial_sign(&mut txhandler, &saved_deposit_sigs)
actor.partial_sign_commit(&mut txhandler, &saved_deposit_sigs, &commit_data) (for Winternitz commits and preimage reveals)

after signing txhandler.cached_tx contains bitcoin::Transaction with correct witnesses inside
