### PR TITLE
[Test] Use Unix sockets for reliability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,6 +1010,7 @@ dependencies = [
  "hex",
  "http 1.2.0",
  "hyper 1.6.0",
+ "hyper-util",
  "jsonrpsee",
  "lazy_static",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,8 @@ dependencies = [
  "futures-util",
  "header-chain",
  "hex",
+ "http 1.2.0",
+ "hyper 1.6.0",
  "jsonrpsee",
  "lazy_static",
  "prost",
@@ -1025,6 +1027,7 @@ dependencies = [
  "toml",
  "tonic",
  "tonic-build",
+ "tower 0.4.13",
  "tracing",
  "tracing-subscriber 0.3.19",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ toml = "0.8.19"
 sqlx = { version = "0.7.4", default-features = false }
 serial_test = "3.2.0"
 tempfile = "3.16.0"
+eyre = { version = "0.6.12" }
 
 # bitcoin
 bitcoin = { version = "0.32.5", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ futures = "0.3.31"
 async-stream = "0.3.6"
 futures-util = "0.3.31"
 futures-core = "0.3.31"
+http = "^1"
+hyper = "^1"
+tower = "^0.4"
+hyper-util = { version = "0.1" }
 
 # Circuits
 sha2 = { version = "=0.10.8", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,6 +41,7 @@ eyre = { workspace = true }
 http = "^1"
 hyper = "^1"
 tower = "^0.4"
+hyper-util = { version = "0.1" }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,10 +38,10 @@ futures-core = { workspace = true }
 bitvm = { workspace = true }
 tempfile = { workspace = true }
 eyre = { workspace = true }
-http = "^1"
-hyper = "^1"
-tower = "^0.4"
-hyper-util = { version = "0.1" }
+http = { workspace = true }
+hyper = { workspace = true }
+tower = { workspace = true }
+hyper-util = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,7 +37,10 @@ futures-util = { workspace = true }
 futures-core = { workspace = true }
 bitvm = { workspace = true }
 tempfile = { workspace = true }
-eyre = "0.6.12"
+eyre = { workspace = true }
+http = "^1"
+hyper = "^1"
+tower = "^0.4"
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -59,10 +59,10 @@ impl Aggregator {
                 .verifier_endpoints
                 .clone()
                 .ok_or(BridgeError::ConfigError(
-                    "Couldn't find operator endpoints in config file!".to_string(),
+                    "Couldn't find verifier endpoints in config file!".to_string(),
                 ))?;
         let verifier_clients =
-            rpc::get_clients(verifier_endpoints, ClementineVerifierClient::connect).await?;
+            rpc::get_clients(verifier_endpoints, ClementineVerifierClient::new).await?;
 
         let operator_endpoints =
             config
@@ -72,7 +72,7 @@ impl Aggregator {
                     "Couldn't find operator endpoints in config file!".to_string(),
                 ))?;
         let operator_clients =
-            rpc::get_clients(operator_endpoints, ClementineOperatorClient::connect).await?;
+            rpc::get_clients(operator_endpoints, ClementineOperatorClient::new).await?;
 
         let watchtower_endpoints =
             config
@@ -83,7 +83,7 @@ impl Aggregator {
                 ))?;
 
         let watchtower_clients =
-            rpc::get_clients(watchtower_endpoints, ClementineWatchtowerClient::connect).await?;
+            rpc::get_clients(watchtower_endpoints, ClementineWatchtowerClient::new).await?;
 
         let signer = Actor::new(config.secret_key, None, config.protocol_paramset().network);
         let rpc = ExtendedRpc::connect(

--- a/core/src/rpc/mod.rs
+++ b/core/src/rpc/mod.rs
@@ -1,8 +1,9 @@
 use crate::errors::BridgeError;
 use clementine::*;
-use std::future::Future;
+use hyper_util::rt::TokioIo;
+use std::path::PathBuf;
 use tagged_signature::SignatureId;
-use tonic::transport::Uri;
+use tonic::transport::{Channel, Uri};
 
 #[allow(clippy::all)]
 #[rustfmt::skip]
@@ -36,26 +37,61 @@ impl From<(NumberedSignatureKind, i32)> for SignatureId {
 ///
 /// # Parameters
 ///
-/// - `endpoints`: URIs for clients
+/// - `endpoints`: URIs for clients (can be http/https URLs or unix:// paths)
 /// - `connect`: Function that will be used to initiate gRPC connection
 ///
 /// # Returns
 ///
 /// - [`CLIENT`]: [`tonic`] gRPC client.
-pub async fn get_clients<CLIENT, F, Fut>(
+pub async fn get_clients<CLIENT, F>(
     endpoints: Vec<String>,
     connect: F,
 ) -> Result<Vec<CLIENT>, BridgeError>
 where
-    F: FnOnce(Uri) -> Fut + Copy,
-    Fut: Future<Output = Result<CLIENT, tonic::transport::Error>>,
+    F: FnOnce(Channel) -> CLIENT + Copy,
 {
-    futures::future::try_join_all(endpoints.iter().map(|endpoint| async move {
-        let uri = Uri::try_from(endpoint).map_err(|e| {
-            BridgeError::ConfigError(format!("Endpoint {} is malformed: {}", endpoint, e))
-        })?;
+    futures::future::try_join_all(
+        endpoints
+            .into_iter()
+            .map(|endpoint| async move {
+                let channel = if endpoint.starts_with("unix://") {
+                    // Handle Unix socket
+                    let path = endpoint.trim_start_matches("unix://").to_string();
+                    Channel::from_static("lttp://[::]:50051")
+                        .connect_with_connector(tower::service_fn(move |_| {
+                            let path = PathBuf::from(path.clone());
+                            async move {
+                                let unix_stream = tokio::net::UnixStream::connect(path).await?;
+                                Ok::<_, std::io::Error>(TokioIo::new(unix_stream))
+                            }
+                        }))
+                        .await
+                        .map_err(|e| {
+                            BridgeError::ConfigError(format!(
+                                "Failed to connect to Unix socket {}: {}",
+                                endpoint, e
+                            ))
+                        })?
+                } else {
+                    // Handle TCP/HTTP connection
+                    let uri = Uri::try_from(endpoint.clone()).map_err(|e| {
+                        BridgeError::ConfigError(format!(
+                            "Endpoint {} is malformed: {}",
+                            endpoint, e
+                        ))
+                    })?;
 
-        Ok(connect(uri).await?)
-    }))
+                    Channel::builder(uri).connect().await.map_err(|e| {
+                        BridgeError::ConfigError(format!(
+                            "Failed to connect to endpoint {}: {}",
+                            endpoint, e
+                        ))
+                    })?
+                };
+
+                Ok(connect(channel))
+            })
+            .collect::<Vec<_>>(),
+    )
     .await
 }

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -13,6 +13,7 @@ use errors::BridgeError;
 use operator::Operator;
 use std::thread;
 use tokio::sync::oneshot;
+use tonic::server::NamedService;
 
 pub type ServerFuture = dyn futures::Future<Output = Result<(), tonic::transport::Error>>;
 
@@ -22,9 +23,116 @@ fn is_test_env() -> bool {
     thread::current().name().unwrap_or_default() != "main"
 }
 
+/// Represents a network address that can be either TCP or Unix socket
+#[derive(Debug, Clone)]
+pub enum ServerAddr {
+    Tcp(std::net::SocketAddr),
+    Unix(std::path::PathBuf),
+}
+
+impl From<std::net::SocketAddr> for ServerAddr {
+    fn from(addr: std::net::SocketAddr) -> Self {
+        ServerAddr::Tcp(addr)
+    }
+}
+
+impl From<std::path::PathBuf> for ServerAddr {
+    fn from(path: std::path::PathBuf) -> Self {
+        ServerAddr::Unix(path)
+    }
+}
+
+/// Generic function to create a gRPC server with the given service
+pub async fn create_grpc_server<S>(
+    addr: ServerAddr,
+    service: S,
+    server_name: &str,
+) -> Result<(ServerAddr, oneshot::Sender<()>), BridgeError>
+where
+    S: tower::Service<
+            http::Request<tonic::body::BoxBody>,
+            Response = http::Response<tonic::body::BoxBody>,
+            Error = std::convert::Infallible,
+        > + Clone
+        + Send
+        + NamedService
+        + 'static,
+    S::Future: Send + 'static,
+{
+    // Create channels for server readiness and shutdown
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let server_builder = tonic::transport::Server::builder().add_service(service);
+
+    match addr {
+        ServerAddr::Tcp(socket_addr) => {
+            tracing::info!(
+                "Starting {} gRPC server with TCP address: {}",
+                server_name,
+                socket_addr
+            );
+            let server_name_str = server_name.to_string();
+
+            let handle = server_builder.serve_with_shutdown(socket_addr, async move {
+                let _ = ready_tx.send(());
+                shutdown_rx.await.ok();
+                tracing::info!("{} gRPC server shutting down", server_name_str);
+            });
+
+            let server_name_str = server_name.to_string();
+
+            tokio::spawn(async move {
+                if let Err(e) = handle.await {
+                    tracing::error!("{} gRPC server error: {:?}", server_name_str, e);
+                }
+            });
+        }
+        ServerAddr::Unix(ref socket_path) => {
+            tracing::info!(
+                "Starting {} gRPC server with Unix socket: {:?}",
+                server_name,
+                socket_path
+            );
+
+            // Remove socket file if it already exists
+            if socket_path.exists() {
+                std::fs::remove_file(socket_path).map_err(BridgeError::ServerError)?;
+            }
+
+            // Create Unix socket listener
+            let uds =
+                tokio::net::UnixListener::bind(socket_path).map_err(BridgeError::ServerError)?;
+            let incoming = tokio_stream::wrappers::UnixListenerStream::new(uds);
+
+            let server_name_str = server_name.to_string();
+
+            let handle = server_builder.serve_with_incoming_shutdown(incoming, async move {
+                let _ = ready_tx.send(());
+                shutdown_rx.await.ok();
+                tracing::info!("{} gRPC server shutting down", server_name_str);
+            });
+
+            let server_name_str = server_name.to_string();
+
+            tokio::spawn(async move {
+                if let Err(e) = handle.await {
+                    tracing::error!("{} gRPC server error: {:?}", server_name_str, e);
+                }
+            });
+        }
+    }
+
+    // Wait for server to be ready
+    let _ = ready_rx.await;
+    tracing::info!("{} gRPC server started", server_name);
+
+    Ok((addr, shutdown_tx))
+}
+
 pub async fn create_verifier_grpc_server(
     config: BridgeConfig,
-) -> Result<(std::net::SocketAddr,), BridgeError> {
+) -> Result<(std::net::SocketAddr, oneshot::Sender<()>), BridgeError> {
     let _rpc = ExtendedRpc::connect(
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
@@ -32,39 +140,21 @@ pub async fn create_verifier_grpc_server(
     )
     .await?;
 
-    let addr = format!("{}:{}", config.host, config.port).parse()?;
-    tracing::info!("Starting verifier gRPC server with address: {}", addr);
+    let addr: std::net::SocketAddr = format!("{}:{}", config.host, config.port).parse()?;
     let verifier = Verifier::new(config).await?;
     let svc = ClementineVerifierServer::new(verifier);
 
-    // Create a channel to signal when the server is ready
-    let (tx, rx) = oneshot::channel();
+    let (server_addr, shutdown_tx) = create_grpc_server(addr.into(), svc, "Verifier").await?;
 
-    let handle = tonic::transport::Server::builder()
-        .add_service(svc)
-        .serve_with_shutdown(addr, async {
-            // Signal that the server is bound and ready
-            let _ = tx.send(());
-            // Wait for shutdown signal (optional - you can add shutdown handling here)
-            std::future::pending::<()>().await;
-        });
-
-    tokio::spawn(async move {
-        if let Err(e) = handle.await {
-            tracing::error!("gRPC server error: {:?}", e);
-        }
-    });
-
-    // Wait for server to be ready
-    let _ = rx.await;
-
-    tracing::info!("Verifier gRPC server started with address: {}", addr);
-    Ok((addr,))
+    match server_addr {
+        ServerAddr::Tcp(socket_addr) => Ok((socket_addr, shutdown_tx)),
+        _ => Err(BridgeError::ConfigError("Expected TCP address".into())),
+    }
 }
 
 pub async fn create_operator_grpc_server(
     config: BridgeConfig,
-) -> Result<(std::net::SocketAddr,), BridgeError> {
+) -> Result<(std::net::SocketAddr, oneshot::Sender<()>), BridgeError> {
     let _rpc = ExtendedRpc::connect(
         config.bitcoin_rpc_url.clone(),
         config.bitcoin_rpc_user.clone(),
@@ -77,85 +167,126 @@ pub async fn create_operator_grpc_server(
         config.host,
         config.port
     );
-    let addr = format!("{}:{}", config.host, config.port).parse()?;
-    tracing::info!("Starting operator gRPC server with address: {}", addr);
+    let addr: std::net::SocketAddr = format!("{}:{}", config.host, config.port).parse()?;
     let operator = Operator::new(config).await?;
     tracing::info!("Operator gRPC server created");
     let svc = ClementineOperatorServer::new(operator);
 
-    let (tx, rx) = oneshot::channel();
+    let (server_addr, shutdown_tx) = create_grpc_server(addr.into(), svc, "Operator").await?;
 
-    let handle = tonic::transport::Server::builder()
-        .add_service(svc)
-        .serve_with_shutdown(addr, async {
-            let _ = tx.send(());
-            std::future::pending::<()>().await;
-        });
-
-    tokio::spawn(async move {
-        if let Err(e) = handle.await {
-            tracing::error!("gRPC server error: {:?}", e);
-        }
-    });
-
-    let _ = rx.await;
-
-    tracing::info!("operator gRPC server started with address: {}", addr);
-    Ok((addr,))
+    match server_addr {
+        ServerAddr::Tcp(socket_addr) => Ok((socket_addr, shutdown_tx)),
+        _ => Err(BridgeError::ConfigError("Expected TCP address".into())),
+    }
 }
 
 pub async fn create_aggregator_grpc_server(
     config: BridgeConfig,
-) -> Result<(std::net::SocketAddr,), BridgeError> {
-    let addr = format!("{}:{}", config.host, config.port).parse()?;
+) -> Result<(std::net::SocketAddr, oneshot::Sender<()>), BridgeError> {
+    let addr: std::net::SocketAddr = format!("{}:{}", config.host, config.port).parse()?;
     let aggregator = Aggregator::new(config).await?;
     let svc = ClementineAggregatorServer::new(aggregator);
 
-    let (tx, rx) = oneshot::channel();
+    let (server_addr, shutdown_tx) = create_grpc_server(addr.into(), svc, "Aggregator").await?;
 
-    let handle = tonic::transport::Server::builder()
-        .add_service(svc)
-        .serve_with_shutdown(addr, async {
-            let _ = tx.send(());
-            std::future::pending::<()>().await;
-        });
-
-    tokio::spawn(async move {
-        if let Err(e) = handle.await {
-            tracing::error!("gRPC server error: {:?}", e);
-        }
-    });
-
-    let _ = rx.await;
-
-    tracing::info!("Aggregator gRPC server started with address: {}", addr);
-    Ok((addr,))
+    match server_addr {
+        ServerAddr::Tcp(socket_addr) => Ok((socket_addr, shutdown_tx)),
+        _ => Err(BridgeError::ConfigError("Expected TCP address".into())),
+    }
 }
 
 pub async fn create_watchtower_grpc_server(
     config: BridgeConfig,
-) -> Result<(std::net::SocketAddr,), BridgeError> {
-    let addr = format!("{}:{}", config.host, config.port).parse()?;
+) -> Result<(std::net::SocketAddr, oneshot::Sender<()>), BridgeError> {
+    let addr: std::net::SocketAddr = format!("{}:{}", config.host, config.port).parse()?;
     let watchtower = Watchtower::new(config).await?;
     let svc = ClementineWatchtowerServer::new(watchtower);
 
-    let (tx, rx) = oneshot::channel();
+    let (server_addr, shutdown_tx) = create_grpc_server(addr.into(), svc, "Watchtower").await?;
 
-    let handle = tonic::transport::Server::builder()
-        .add_service(svc)
-        .serve_with_shutdown(addr, async {
-            let _ = tx.send(());
-            std::future::pending::<()>().await;
-        });
-
-    tokio::spawn(async move {
-        if let Err(e) = handle.await {
-            tracing::error!("gRPC server error: {:?}", e);
-        }
-    });
-
-    let _ = rx.await;
-
-    tracing::info!("Watchtower gRPC server started with address: {}", addr);
-    Ok((addr,))
+    match server_addr {
+        ServerAddr::Tcp(socket_addr) => Ok((socket_addr, shutdown_tx)),
+        _ => Err(BridgeError::ConfigError("Expected TCP address".into())),
+    }
 }
+
+// Functions for creating servers with Unix sockets (useful for tests)
+pub async fn create_verifier_unix_server(
+    config: BridgeConfig,
+    socket_path: std::path::PathBuf,
+) -> Result<(std::path::PathBuf, oneshot::Sender<()>), BridgeError> {
+    let _rpc = ExtendedRpc::connect(
+        config.bitcoin_rpc_url.clone(),
+        config.bitcoin_rpc_user.clone(),
+        config.bitcoin_rpc_password.clone(),
+    )
+    .await?;
+
+    let verifier = Verifier::new(config).await?;
+    let svc = ClementineVerifierServer::new(verifier);
+
+    let (server_addr, shutdown_tx) =
+        create_grpc_server(socket_path.into(), svc, "Verifier").await?;
+
+    match server_addr {
+        ServerAddr::Unix(path) => Ok((path, shutdown_tx)),
+        _ => Err(BridgeError::ConfigError("Expected Unix socket path".into())),
+    }
+}
+
+pub async fn create_operator_unix_server(
+    config: BridgeConfig,
+    socket_path: std::path::PathBuf,
+) -> Result<(std::path::PathBuf, oneshot::Sender<()>), BridgeError> {
+    let _rpc = ExtendedRpc::connect(
+        config.bitcoin_rpc_url.clone(),
+        config.bitcoin_rpc_user.clone(),
+        config.bitcoin_rpc_password.clone(),
+    )
+    .await?;
+
+    let operator = Operator::new(config).await?;
+    let svc = ClementineOperatorServer::new(operator);
+
+    let (server_addr, shutdown_tx) =
+        create_grpc_server(socket_path.into(), svc, "Operator").await?;
+
+    match server_addr {
+        ServerAddr::Unix(path) => Ok((path, shutdown_tx)),
+        _ => Err(BridgeError::ConfigError("Expected Unix socket path".into())),
+    }
+}
+
+pub async fn create_aggregator_unix_server(
+    config: BridgeConfig,
+    socket_path: std::path::PathBuf,
+) -> Result<(std::path::PathBuf, oneshot::Sender<()>), BridgeError> {
+    let aggregator = Aggregator::new(config).await?;
+    let svc = ClementineAggregatorServer::new(aggregator);
+
+    let (server_addr, shutdown_tx) =
+        create_grpc_server(socket_path.into(), svc, "Aggregator").await?;
+
+    match server_addr {
+        ServerAddr::Unix(path) => Ok((path, shutdown_tx)),
+        _ => Err(BridgeError::ConfigError("Expected Unix socket path".into())),
+    }
+}
+
+pub async fn create_watchtower_unix_server(
+    config: BridgeConfig,
+    socket_path: std::path::PathBuf,
+) -> Result<(std::path::PathBuf, oneshot::Sender<()>), BridgeError> {
+    let watchtower = Watchtower::new(config).await?;
+    let svc = ClementineWatchtowerServer::new(watchtower);
+
+    let (server_addr, shutdown_tx) =
+        create_grpc_server(socket_path.into(), svc, "Watchtower").await?;
+
+    match server_addr {
+        ServerAddr::Unix(path) => Ok((path, shutdown_tx)),
+        _ => Err(BridgeError::ConfigError("Expected Unix socket path".into())),
+    }
+}
+
+// Similar Unix socket functions can be added for other server types as needed

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -27,6 +27,7 @@ fn is_test_env() -> bool {
 #[derive(Debug, Clone)]
 pub enum ServerAddr {
     Tcp(std::net::SocketAddr),
+    #[cfg(unix)]
     Unix(std::path::PathBuf),
 }
 
@@ -36,6 +37,7 @@ impl From<std::net::SocketAddr> for ServerAddr {
     }
 }
 
+#[cfg(unix)]
 impl From<std::path::PathBuf> for ServerAddr {
     fn from(path: std::path::PathBuf) -> Self {
         ServerAddr::Unix(path)
@@ -88,6 +90,7 @@ where
                 }
             });
         }
+        #[cfg(unix)]
         ServerAddr::Unix(ref socket_path) => {
             tracing::info!(
                 "Starting {} gRPC server with Unix socket: {:?}",
@@ -211,6 +214,7 @@ pub async fn create_watchtower_grpc_server(
 }
 
 // Functions for creating servers with Unix sockets (useful for tests)
+#[cfg(unix)]
 pub async fn create_verifier_unix_server(
     config: BridgeConfig,
     socket_path: std::path::PathBuf,
@@ -234,6 +238,17 @@ pub async fn create_verifier_unix_server(
     }
 }
 
+#[cfg(not(unix))]
+pub async fn create_verifier_unix_server(
+    _config: BridgeConfig,
+    _socket_path: std::path::PathBuf,
+) -> Result<(std::path::PathBuf, oneshot::Sender<()>), BridgeError> {
+    Err(BridgeError::ConfigError(
+        "Unix sockets are not supported on this platform".into(),
+    ))
+}
+
+#[cfg(unix)]
 pub async fn create_operator_unix_server(
     config: BridgeConfig,
     socket_path: std::path::PathBuf,
@@ -257,6 +272,17 @@ pub async fn create_operator_unix_server(
     }
 }
 
+#[cfg(not(unix))]
+pub async fn create_operator_unix_server(
+    _config: BridgeConfig,
+    _socket_path: std::path::PathBuf,
+) -> Result<(std::path::PathBuf, oneshot::Sender<()>), BridgeError> {
+    Err(BridgeError::ConfigError(
+        "Unix sockets are not supported on this platform".into(),
+    ))
+}
+
+#[cfg(unix)]
 pub async fn create_aggregator_unix_server(
     config: BridgeConfig,
     socket_path: std::path::PathBuf,
@@ -273,6 +299,17 @@ pub async fn create_aggregator_unix_server(
     }
 }
 
+#[cfg(not(unix))]
+pub async fn create_aggregator_unix_server(
+    _config: BridgeConfig,
+    _socket_path: std::path::PathBuf,
+) -> Result<(std::path::PathBuf, oneshot::Sender<()>), BridgeError> {
+    Err(BridgeError::ConfigError(
+        "Unix sockets are not supported on this platform".into(),
+    ))
+}
+
+#[cfg(unix)]
 pub async fn create_watchtower_unix_server(
     config: BridgeConfig,
     socket_path: std::path::PathBuf,
@@ -289,4 +326,12 @@ pub async fn create_watchtower_unix_server(
     }
 }
 
-// Similar Unix socket functions can be added for other server types as needed
+#[cfg(not(unix))]
+pub async fn create_watchtower_unix_server(
+    _config: BridgeConfig,
+    _socket_path: std::path::PathBuf,
+) -> Result<(std::path::PathBuf, oneshot::Sender<()>), BridgeError> {
+    Err(BridgeError::ConfigError(
+        "Unix sockets are not supported on this platform".into(),
+    ))
+}

--- a/core/src/test/common/test_utils.rs
+++ b/core/src/test/common/test_utils.rs
@@ -5,7 +5,9 @@
 use std::net::TcpListener;
 use std::str::FromStr;
 
+use bitcoin::consensus::serde::With;
 use bitcoin::secp256k1::schnorr;
+use tokio::sync::oneshot;
 use tonic::transport::Channel;
 
 use crate::builder::script::SpendPath;
@@ -16,7 +18,12 @@ use crate::rpc::clementine::clementine_operator_client::ClementineOperatorClient
 use crate::rpc::clementine::clementine_verifier_client::ClementineVerifierClient;
 use crate::rpc::clementine::clementine_watchtower_client::ClementineWatchtowerClient;
 use crate::rpc::clementine::NormalSignatureKind;
+use crate::servers::{
+    create_aggregator_unix_server, create_operator_unix_server, create_verifier_unix_server,
+    create_watchtower_unix_server,
+};
 use crate::utils::initialize_logger;
+use crate::verifier::Verifier;
 use crate::{
     actor::Actor,
     builder,
@@ -300,14 +307,26 @@ pub async fn initialize_database(config: &BridgeConfig) {
         .expect("Failed to run schema script");
 }
 
+pub struct ActorsCleanup(
+    Vec<oneshot::Sender<()>>,
+    tempfile::TempDir,
+    WithProcessCleanup,
+);
+
+impl ActorsCleanup {
+    pub fn rpc(&self) -> &ExtendedRpc {
+        self.2.rpc()
+    }
+}
+
 /// Starts operators, verifiers, aggregator and watchtower servers.
 ///
-/// Depends on create_regtest_rpc and get_available_port! for dynamic port allocation.
+/// Uses Unix sockets with temporary files for communication between services.
 ///
 /// # Returns
 ///
-/// Returns a tuple of vectors of clients, handles, and addresses for the
-/// verifiers, operators, aggregator and watchtowers.
+/// Returns a tuple of vectors of clients, handles, and socket paths for the
+/// verifiers, operators, aggregator and watchtowers, along with shutdown channels.
 pub async fn create_actors(
     config: &BridgeConfig,
 ) -> (
@@ -315,7 +334,7 @@ pub async fn create_actors(
     Vec<ClementineOperatorClient<Channel>>,
     ClementineAggregatorClient<Channel>,
     Vec<ClementineWatchtowerClient<Channel>>,
-    WithProcessCleanup,
+    ActorsCleanup,
 ) {
     let regtest = create_regtest_rpc(&mut config.clone()).await;
     let rpc = regtest.rpc();
@@ -334,66 +353,89 @@ pub async fn create_actors(
             .unwrap_or_else(|| {
                 panic!("All secret keys of the watchtowers are required for testing");
             });
+
+    // Collect all shutdown channels
+    let mut shutdown_channels = Vec::new();
+
+    // Create temporary directory for Unix sockets
+    let socket_dir = tempfile::tempdir().expect("Failed to create temporary directory for sockets");
+
     let verifier_futures = all_verifiers_secret_keys
         .iter()
         .enumerate()
         .map(|(i, sk)| {
-            let port = get_available_port();
-            // println!("Port: {}", port);
+            let socket_path = socket_dir.path().join(format!("verifier_{}.sock", i));
             let i = i.to_string();
             let mut config_with_new_db = config.clone();
             async move {
                 config_with_new_db.db_name += &i;
                 initialize_database(&config_with_new_db).await;
 
-                let verifier = create_verifier_grpc_server(BridgeConfig {
-                    secret_key: *sk,
-                    port,
-                    ..config_with_new_db.clone()
-                })
+                let (socket_path, shutdown_tx) = create_verifier_unix_server(
+                    BridgeConfig {
+                        secret_key: *sk,
+                        ..config_with_new_db.clone()
+                    },
+                    socket_path,
+                )
                 .await?;
-                Ok::<((std::net::SocketAddr,), BridgeConfig), BridgeError>((
-                    verifier,
+
+                Ok::<((std::path::PathBuf, oneshot::Sender<()>), BridgeConfig), BridgeError>((
+                    (socket_path, shutdown_tx),
                     config_with_new_db,
                 ))
             }
         })
         .collect::<Vec<_>>();
+
     let verifier_results = futures::future::try_join_all(verifier_futures)
         .await
         .expect("Failed to join verifier futures");
-    let verifier_endpoints = verifier_results.iter().map(|(v, _)| *v).collect::<Vec<_>>();
-    let verifier_configs = verifier_results
-        .iter()
-        .map(|(_, c)| c.clone())
-        .collect::<Vec<_>>();
+
+    let (verifier_tmp, verifier_configs) =
+        verifier_results.into_iter().unzip::<_, _, Vec<_>, Vec<_>>();
+    let (verifier_paths, verifier_shutdown_channels) =
+        verifier_tmp.into_iter().unzip::<_, _, Vec<_>, Vec<_>>();
+
+    shutdown_channels.extend(verifier_shutdown_channels);
 
     let all_operators_secret_keys = config.all_operators_secret_keys.clone().unwrap_or_else(|| {
         panic!("All secret keys of the operators are required for testing");
     });
 
-    // Create futures for operator gRPC servers
+    // Create futures for operator Unix socket servers
     let operator_futures = all_operators_secret_keys
         .iter()
         .enumerate()
         .map(|(i, sk)| {
-            let port = get_available_port();
+            let socket_path = socket_dir.path().join(format!("operator_{}.sock", i));
             let verifier_config = verifier_configs[i].clone();
             async move {
-                let socket_addr = create_operator_grpc_server(BridgeConfig {
-                    secret_key: *sk,
-                    port,
-                    ..verifier_config
-                })
+                let (socket_path, shutdown_tx) = create_operator_unix_server(
+                    BridgeConfig {
+                        secret_key: *sk,
+                        ..verifier_config
+                    },
+                    socket_path,
+                )
                 .await?;
-                Ok::<(std::net::SocketAddr,), BridgeError>(socket_addr)
+
+                Ok::<(std::path::PathBuf, oneshot::Sender<()>), BridgeError>((
+                    socket_path,
+                    shutdown_tx,
+                ))
             }
         })
         .collect::<Vec<_>>();
 
-    let operator_endpoints = futures::future::try_join_all(operator_futures)
+    let operator_results = futures::future::try_join_all(operator_futures)
         .await
         .expect("Failed to join operator futures");
+
+    let (operator_paths, operator_shutdown_channels) =
+        operator_results.into_iter().unzip::<_, _, Vec<_>, Vec<_>>();
+
+    shutdown_channels.extend(operator_shutdown_channels);
 
     let verifier_configs = verifier_configs.clone();
 
@@ -401,75 +443,95 @@ pub async fn create_actors(
         .iter()
         .enumerate()
         .map(|(i, sk)| {
-            let port = get_available_port();
-            println!("Watchtower {i} start port: {port}");
-            create_watchtower_grpc_server(BridgeConfig {
-                index: i as u32,
-                secret_key: *sk,
-                port,
-                ..verifier_configs[i].clone()
-            })
+            let socket_path = socket_dir.path().join(format!("watchtower_{}.sock", i));
+            create_watchtower_unix_server(
+                BridgeConfig {
+                    index: i as u32,
+                    secret_key: *sk,
+                    ..verifier_configs[i].clone()
+                },
+                socket_path,
+            )
         })
         .collect::<Vec<_>>();
 
-    let watchtower_endpoints = futures::future::try_join_all(watchtower_futures)
+    let watchtower_results = futures::future::try_join_all(watchtower_futures)
         .await
         .expect("Failed to join watchtower futures");
 
-    let port = get_available_port();
-    println!("Aggregator port: {}", port);
-    // + all_operators_secret_keys.len() as u16;
-    let aggregator = create_aggregator_grpc_server(BridgeConfig {
-        port,
-        verifier_endpoints: Some(
-            verifier_endpoints
-                .iter()
-                .map(|(socket_addr,)| format!("http://{}", socket_addr))
-                .collect(),
-        ),
-        operator_endpoints: Some(
-            operator_endpoints
-                .iter()
-                .map(|(socket_addr,)| format!("http://{}", socket_addr))
-                .collect(),
-        ),
-        watchtower_endpoints: Some(
-            watchtower_endpoints
-                .iter()
-                .map(|(socket_addr,)| format!("http://{}", socket_addr))
-                .collect(),
-        ),
-        ..verifier_configs[0].clone()
-    })
+    let (watchtower_paths, watchtower_shutdown_channels) = watchtower_results
+        .into_iter()
+        .unzip::<_, _, Vec<_>, Vec<_>>();
+
+    shutdown_channels.extend(watchtower_shutdown_channels);
+
+    let aggregator_socket_path = socket_dir.path().join("aggregator.sock");
+
+    let (aggregator_path, aggregator_shutdown_tx) = create_aggregator_unix_server(
+        BridgeConfig {
+            verifier_endpoints: Some(
+                verifier_paths
+                    .iter()
+                    .map(|path| format!("unix://{}", path.display()))
+                    .collect(),
+            ),
+            operator_endpoints: Some(
+                operator_paths
+                    .iter()
+                    .map(|path| format!("unix://{}", path.display()))
+                    .collect(),
+            ),
+            watchtower_endpoints: Some(
+                watchtower_paths
+                    .iter()
+                    .map(|path| format!("unix://{}", path.display()))
+                    .collect(),
+            ),
+            ..verifier_configs[0].clone()
+        },
+        aggregator_socket_path,
+    )
     .await
     .expect("Failed to create aggregator");
 
-    let verifiers =
-        futures_util::future::join_all(verifier_endpoints.iter().map(|verifier| async move {
-            ClementineVerifierClient::connect(format!("http://{}", verifier.0))
-                .await
-                .expect("Failed to connect to verifier")
-        }))
-        .await;
-    let operators =
-        futures_util::future::join_all(operator_endpoints.iter().map(|operator| async move {
-            ClementineOperatorClient::connect(format!("http://{}", operator.0))
-                .await
-                .expect("Failed to connect to operator")
-        }))
-        .await;
-    let aggregator = ClementineAggregatorClient::connect(format!("http://{}", aggregator.0))
-        .await
-        .expect("Failed to connect to aggregator");
+    // Add aggregator shutdown channel
+    shutdown_channels.push(aggregator_shutdown_tx);
+
+    // Connect to the Unix socket servers
+    let verifiers = futures_util::future::join_all(verifier_paths.iter().map(|path| async move {
+        ClementineVerifierClient::connect(format!("unix://{}", path.display()))
+            .await
+            .expect("Failed to connect to verifier")
+    }))
+    .await;
+
+    let operators = futures_util::future::join_all(operator_paths.iter().map(|path| async move {
+        ClementineOperatorClient::connect(format!("unix://{}", path.display()))
+            .await
+            .expect("Failed to connect to operator")
+    }))
+    .await;
+
+    let aggregator =
+        ClementineAggregatorClient::connect(format!("unix://{}", aggregator_path.display()))
+            .await
+            .expect("Failed to connect to aggregator");
+
     let watchtowers =
-        futures_util::future::join_all(watchtower_endpoints.iter().map(|watchtower| async move {
-            ClementineWatchtowerClient::connect(format!("http://{}", watchtower.0))
+        futures_util::future::join_all(watchtower_paths.iter().map(|path| async move {
+            ClementineWatchtowerClient::connect(format!("unix://{}", path.display()))
                 .await
                 .expect("Failed to connect to watchtower")
         }))
         .await;
 
-    (verifiers, operators, aggregator, watchtowers, regtest)
+    (
+        verifiers,
+        operators,
+        aggregator,
+        watchtowers,
+        ActorsCleanup(shutdown_channels, socket_dir, regtest),
+    )
 }
 
 /// Gets the the deposit address for the user.

--- a/core/tests/data/test_config.toml
+++ b/core/tests/data/test_config.toml
@@ -62,7 +62,6 @@ db_user = "clementine"
 db_password = "clementine"
 db_name = "clementine"
 
-bridge_amount_sats = 1000000000
 
 confirmation_threshold = 1
 


### PR DESCRIPTION
# Description

Some tests are flaky due to the many ports we allocate for each test with actors. TCP has an overhead and is quite a lot slower when bound by bandwidth. More importantly, due to the increasingly parallelized tests, we have flaky tests due to port collisions when allocating ports.

This PR migrates the random TCP port allocation to random Unix socket allocation by generalizing connection primitives and refactoring test utils

## Linked Issues

- Closes #548 

## Testing

The tests must execute without flakiness

## Docs

Docs have been updated for test utils.
