### PR TITLE
feat(states): Add state machine persistence and serialization support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3692,6 +3692,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42c467cc59664639bf70b8225b1b4a9c30d926f3e010c29e804bf940d618c663"
 dependencies = [
+ "serde",
  "statig_macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [workspace.dependencies]
 hex = "0.4.3"
 lazy_static = { version = "1.5.0", default-features = false }
-serde = { version = "1.0", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0.128"
 thiserror = "1.0.64"
 tracing = { version = "0.1.40", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,7 +38,7 @@ futures-core = { workspace = true }
 bitvm = { workspace = true }
 tempfile = { workspace = true }
 eyre = "0.6.12"
-statig = { version = "0.3.0", features = ["async"] }
+statig = { version = "0.3.0", features = ["async", "serde"] }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/core/build.rs
+++ b/core/build.rs
@@ -52,7 +52,7 @@ fn compile_protobuf() {
         .build_client(true)
         .type_attribute(
             "clementine.KickoffId",
-            "#[derive(Eq, PartialOrd, Ord, Hash)]",
+            "#[derive(Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]",
         )
         .out_dir("./src/rpc")
         .compile_protos(

--- a/core/src/builder/sighash.rs
+++ b/core/src/builder/sighash.rs
@@ -7,8 +7,7 @@
 
 use crate::builder::transaction::deposit_signature_owner::EntityType;
 use crate::builder::transaction::{
-    create_txhandlers, ContractContext, DepositData, OperatorData, ReimburseDbCache,
-    TransactionType, TxHandler,
+    create_txhandlers, ContractContext, DepositData, ReimburseDbCache, TransactionType, TxHandler,
 };
 use crate::config::BridgeConfig;
 use crate::database::Database;
@@ -17,7 +16,7 @@ use crate::rpc::clementine::tagged_signature::SignatureId;
 use crate::rpc::clementine::KickoffId;
 use crate::utils;
 use async_stream::try_stream;
-use bitcoin::{Address, OutPoint, TapSighash, XOnlyPublicKey};
+use bitcoin::{OutPoint, TapSighash, XOnlyPublicKey};
 use futures_core::stream::Stream;
 
 impl BridgeConfig {

--- a/core/src/builder/transaction/creator.rs
+++ b/core/src/builder/transaction/creator.rs
@@ -1,5 +1,5 @@
+use crate::actor::Actor;
 use crate::actor::WinternitzDerivationPath::WatchtowerChallenge;
-use crate::actor::{self, Actor};
 use crate::builder::script::{SpendableScript, WinternitzCommit};
 use crate::builder::transaction::{
     create_assert_timeout_txhandlers, create_challenge_timeout_txhandler, create_kickoff_txhandler,
@@ -7,14 +7,11 @@ use crate::builder::transaction::{
     DepositData, OperatorData, TransactionType, TxHandler,
 };
 use crate::config::protocol::ProtocolParamset;
-use crate::config::BridgeConfig;
 use crate::database::Database;
 use crate::errors::BridgeError;
 use crate::operator::PublicHash;
 use crate::rpc::clementine::KickoffId;
 use crate::{builder, utils};
-use bitcoin::secp256k1::SecretKey;
-use bitcoin::XOnlyPublicKey;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 

--- a/core/src/builder/transaction/mod.rs
+++ b/core/src/builder/transaction/mod.rs
@@ -60,7 +60,7 @@ pub struct DepositData {
     pub nofn_xonly_pk: XOnlyPublicKey,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct OperatorData {
     pub xonly_pk: XOnlyPublicKey,
     pub reimburse_addr: Address,

--- a/core/src/builder/transaction/mod.rs
+++ b/core/src/builder/transaction/mod.rs
@@ -48,7 +48,7 @@ pub mod sign;
 mod txhandler;
 
 /// Type to uniquely identify a deposit.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct DepositData {
     /// User's deposit UTXO.
     pub deposit_outpoint: bitcoin::OutPoint,
@@ -60,11 +60,35 @@ pub struct DepositData {
     pub nofn_xonly_pk: XOnlyPublicKey,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct OperatorData {
     pub xonly_pk: XOnlyPublicKey,
     pub reimburse_addr: Address,
     pub collateral_funding_outpoint: OutPoint,
+}
+
+// TODO: remove this impl, this is done to avoid checking the address, instead
+// we should be checking address against a paramset
+impl<'de> serde::Deserialize<'de> for OperatorData {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct OperatorDataHelper {
+            xonly_pk: XOnlyPublicKey,
+            reimburse_addr: Address<NetworkUnchecked>,
+            collateral_funding_outpoint: OutPoint,
+        }
+
+        let helper = OperatorDataHelper::deserialize(deserializer)?;
+
+        Ok(OperatorData {
+            xonly_pk: helper.xonly_pk,
+            reimburse_addr: helper.reimburse_addr.assume_checked(),
+            collateral_funding_outpoint: helper.collateral_funding_outpoint,
+        })
+    }
 }
 
 /// Types of all transactions that can be created. Some transactions have an (usize) to as they are created

--- a/core/src/builder/transaction/sign.rs
+++ b/core/src/builder/transaction/sign.rs
@@ -8,7 +8,6 @@ use crate::operator::Operator;
 use crate::rpc::clementine::{KickoffId, RawSignedTx, RawSignedTxs};
 use crate::watchtower::Watchtower;
 use crate::{builder, utils};
-use bitcoin::XOnlyPublicKey;
 
 use super::ContractContext;
 
@@ -30,7 +29,6 @@ pub async fn create_and_sign_txs(
     db: Database,
     signer: &Actor,
     config: BridgeConfig,
-    nofn_xonly_pk: XOnlyPublicKey,
     transaction_data: TransactionRequestData,
     block_hash: Option<[u8; 20]>, //to sign kickoff
 ) -> Result<Vec<(TransactionType, RawSignedTx)>, BridgeError> {
@@ -44,7 +42,7 @@ pub async fn create_and_sign_txs(
         transaction_data.transaction_type,
         context,
         None,
-        &mut &mut ReimburseDbCache::new_for_deposit(
+        &mut ReimburseDbCache::new_for_deposit(
             db.clone(),
             transaction_data.kickoff_id.operator_idx,
             transaction_data.deposit_data.clone(),
@@ -127,7 +125,6 @@ impl Watchtower {
     /// Creates and signs the watchtower challenge
     pub async fn create_and_sign_watchtower_challenge(
         &self,
-        nofn_xonly_pk: XOnlyPublicKey,
         transaction_data: TransactionRequestData,
         commit_data: &[u8],
     ) -> Result<RawSignedTx, BridgeError> {
@@ -152,7 +149,7 @@ impl Watchtower {
             TransactionType::WatchtowerChallenge(self.config.index as usize),
             context,
             None,
-            &mut &mut ReimburseDbCache::new_for_deposit(
+            &mut ReimburseDbCache::new_for_deposit(
                 self.db.clone(),
                 transaction_data.kickoff_id.operator_idx,
                 transaction_data.deposit_data.clone(),
@@ -184,7 +181,6 @@ impl Watchtower {
 impl Operator {
     pub async fn create_assert_commitment_txs(
         &self,
-        nofn_xonly_pk: XOnlyPublicKey,
         assert_data: AssertRequestData,
     ) -> Result<RawSignedTxs, BridgeError> {
         let context = ContractContext::new_context_for_asserts(

--- a/core/src/builder/transaction/sign.rs
+++ b/core/src/builder/transaction/sign.rs
@@ -198,7 +198,7 @@ impl Operator {
             TransactionType::MiniAssert(0),
             context,
             None,
-            &mut &mut ReimburseDbCache::new_for_deposit(
+            &mut ReimburseDbCache::new_for_deposit(
                 self.db.clone(),
                 assert_data.kickoff_id.operator_idx,
                 assert_data.deposit_data.clone(),

--- a/core/src/database/mod.rs
+++ b/core/src/database/mod.rs
@@ -12,6 +12,7 @@ use sqlx::{Pool, Postgres};
 mod bitcoin_syncer;
 mod header_chain_prover;
 mod operator;
+mod state_machine;
 mod tx_sender;
 mod verifier;
 mod watchtower;

--- a/core/src/database/state_machine.rs
+++ b/core/src/database/state_machine.rs
@@ -43,7 +43,7 @@ impl Database {
                     created_at,
                     updated_at
                 ) VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
-                ON CONFLICT (machine_type, kickoff_id, operator_idx, owner_type)
+                ON CONFLICT (machine_type, kickoff_id, owner_type)
                 DO UPDATE SET
                     state_json = EXCLUDED.state_json,
                     block_height = EXCLUDED.block_height,
@@ -75,7 +75,7 @@ impl Database {
                     created_at,
                     updated_at
                 ) VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
-                ON CONFLICT (machine_type, kickoff_id, operator_idx, owner_type)
+                ON CONFLICT (machine_type, operator_idx, owner_type)
                 DO UPDATE SET
                     state_json = EXCLUDED.state_json,
                     block_height = EXCLUDED.block_height,

--- a/core/src/database/state_machine.rs
+++ b/core/src/database/state_machine.rs
@@ -1,0 +1,299 @@
+//! # State Machine Related Database Operations
+//!
+//! This module includes database functions for persisting and loading state machines.
+
+use super::{Database, DatabaseTransaction};
+use crate::errors::BridgeError;
+use crate::execute_query_with_tx;
+
+impl Database {
+    /// Saves state machines to the database with the current block height
+    ///
+    /// # Arguments
+    ///
+    /// * `tx` - Optional database transaction
+    /// * `kickoff_machines` - Vector of (state_json, kickoff_id, owner_type, dirty) tuples for kickoff machines
+    /// * `round_machines` - Vector of (state_json, operator_idx, owner_type, dirty) tuples for round machines
+    /// * `block_height` - Current block height
+    ///
+    /// # Errors
+    ///
+    /// Returns a `BridgeError` if the database operation fails
+    pub async fn save_state_machines(
+        &self,
+        mut tx: Option<DatabaseTransaction<'_, '_>>,
+        kickoff_machines: Vec<(String, String, String, bool)>,
+        round_machines: Vec<(String, i32, String, bool)>,
+        block_height: i32,
+    ) -> Result<(), BridgeError> {
+        // Save kickoff machines that are dirty
+        for (state_json, kickoff_id, owner_type, dirty) in kickoff_machines {
+            // Skip machines that are not dirty
+            if !dirty {
+                continue;
+            }
+
+            let query = sqlx::query(
+                "INSERT INTO state_machines (
+                    machine_type,
+                    state_json,
+                    kickoff_id,
+                    owner_type,
+                    block_height,
+                    created_at,
+                    updated_at
+                ) VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+                ON CONFLICT (machine_type, kickoff_id, operator_idx, owner_type)
+                DO UPDATE SET
+                    state_json = EXCLUDED.state_json,
+                    block_height = EXCLUDED.block_height,
+                    updated_at = NOW()",
+            )
+            .bind("kickoff")
+            .bind(&state_json)
+            .bind(kickoff_id)
+            .bind(&owner_type)
+            .bind(block_height);
+
+            execute_query_with_tx!(self.connection, tx.as_deref_mut(), query, execute)?;
+        }
+
+        // Save round machines that are dirty
+        for (state_json, operator_idx, owner_type, dirty) in round_machines {
+            // Skip machines that are not dirty
+            if !dirty {
+                continue;
+            }
+
+            let query = sqlx::query(
+                "INSERT INTO state_machines (
+                    machine_type,
+                    state_json,
+                    operator_idx,
+                    owner_type,
+                    block_height,
+                    created_at,
+                    updated_at
+                ) VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+                ON CONFLICT (machine_type, kickoff_id, operator_idx, owner_type)
+                DO UPDATE SET
+                    state_json = EXCLUDED.state_json,
+                    block_height = EXCLUDED.block_height,
+                    updated_at = NOW()",
+            )
+            .bind("round")
+            .bind(&state_json)
+            .bind(operator_idx)
+            .bind(&owner_type)
+            .bind(block_height);
+
+            execute_query_with_tx!(self.connection, tx.as_deref_mut(), query, execute)?;
+        }
+
+        // Update state manager status
+        let query = sqlx::query(
+            "INSERT INTO state_manager_status (
+                id,
+                last_processed_block_height,
+                updated_at
+            ) VALUES (1, $1, NOW())
+            ON CONFLICT (id)
+            DO UPDATE SET
+                last_processed_block_height = EXCLUDED.last_processed_block_height,
+                updated_at = NOW()",
+        )
+        .bind(block_height);
+
+        execute_query_with_tx!(self.connection, tx, query, execute)?;
+
+        Ok(())
+    }
+
+    /// Gets the last processed block height
+    ///
+    /// # Arguments
+    ///
+    /// * `tx` - Optional database transaction
+    ///
+    /// # Errors
+    ///
+    /// Returns a `BridgeError` if the database operation fails
+    pub async fn get_last_processed_block_height(
+        &self,
+        tx: Option<DatabaseTransaction<'_, '_>>,
+    ) -> Result<Option<i32>, BridgeError> {
+        let query = sqlx::query_as(
+            "SELECT last_processed_block_height FROM state_manager_status WHERE id = 1",
+        );
+
+        let result: Option<(i32,)> =
+            execute_query_with_tx!(self.connection, tx, query, fetch_optional)?;
+
+        Ok(result.map(|(height,)| height))
+    }
+
+    /// Loads kickoff machines from the database
+    ///
+    /// # Arguments
+    ///
+    /// * `tx` - Optional database transaction
+    /// * `owner_type` - The owner type to filter by
+    ///
+    /// # Errors
+    ///
+    /// Returns a `BridgeError` if the database operation fails
+    pub async fn load_kickoff_machines(
+        &self,
+        tx: Option<DatabaseTransaction<'_, '_>>,
+        owner_type: &str,
+    ) -> Result<Vec<(String, String, i32)>, BridgeError> {
+        let query = sqlx::query_as(
+            "SELECT
+                state_json,
+                kickoff_id,
+                block_height
+            FROM state_machines
+            WHERE machine_type = 'kickoff' AND owner_type = $1",
+        )
+        .bind(owner_type);
+
+        let results = execute_query_with_tx!(self.connection, tx, query, fetch_all)?;
+
+        Ok(results)
+    }
+
+    /// Loads round machines from the database
+    ///
+    /// # Arguments
+    ///
+    /// * `tx` - Optional database transaction
+    /// * `owner_type` - The owner type to filter by
+    ///
+    /// # Errors
+    ///
+    /// Returns a `BridgeError` if the database operation fails
+    pub async fn load_round_machines(
+        &self,
+        tx: Option<DatabaseTransaction<'_, '_>>,
+        owner_type: &str,
+    ) -> Result<Vec<(String, i32, i32)>, BridgeError> {
+        let query = sqlx::query_as(
+            "SELECT
+                state_json,
+                operator_idx,
+                block_height
+            FROM state_machines
+            WHERE machine_type = 'round' AND owner_type = $1",
+        )
+        .bind(owner_type);
+
+        let results = execute_query_with_tx!(self.connection, tx, query, fetch_all)?;
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::common::*;
+
+    #[tokio::test]
+    async fn test_save_and_load_state_machines() {
+        let config = create_test_config_with_thread_name(None).await;
+        let db = Database::new(&config).await.unwrap();
+
+        // Create test data with owner_type
+        let owner_type = "test_owner";
+        let kickoff_machines = vec![
+            (
+                "kickoff_state_1".to_string(),
+                "kickoff_id_1".to_string(),
+                owner_type.to_string(),
+                true, // dirty
+            ),
+            (
+                "kickoff_state_2".to_string(),
+                "kickoff_id_2".to_string(),
+                owner_type.to_string(),
+                true, // dirty
+            ),
+        ];
+
+        let round_machines = vec![
+            (
+                "round_state_1".to_string(),
+                1,
+                owner_type.to_string(),
+                true, // dirty
+            ),
+            (
+                "round_state_2".to_string(),
+                2,
+                owner_type.to_string(),
+                true, // dirty
+            ),
+        ];
+
+        // Save state machines
+        db.save_state_machines(None, kickoff_machines.clone(), round_machines.clone(), 123)
+            .await
+            .unwrap();
+
+        // Check last processed block height
+        let block_height = db.get_last_processed_block_height(None).await.unwrap();
+        assert_eq!(block_height, Some(123));
+
+        // Load kickoff machines
+        let loaded_kickoff = db.load_kickoff_machines(None, owner_type).await.unwrap();
+        assert_eq!(loaded_kickoff.len(), 2);
+        assert_eq!(loaded_kickoff[0].0, "kickoff_state_1");
+        assert_eq!(loaded_kickoff[0].1, "kickoff_id_1");
+        assert_eq!(loaded_kickoff[0].2, 123);
+
+        // Load round machines
+        let loaded_round = db.load_round_machines(None, owner_type).await.unwrap();
+        assert_eq!(loaded_round.len(), 2);
+        assert_eq!(loaded_round[0].0, "round_state_1");
+        assert_eq!(loaded_round[0].1, 1);
+        assert_eq!(loaded_round[0].2, 123);
+
+        // Test dirty flag by updating only one machine
+        let kickoff_machines_update = vec![
+            (
+                "kickoff_state_1_updated".to_string(),
+                "kickoff_id_1".to_string(),
+                owner_type.to_string(),
+                true, // dirty - will be updated
+            ),
+            (
+                "kickoff_state_2".to_string(),
+                "kickoff_id_2".to_string(),
+                owner_type.to_string(),
+                false, // not dirty - won't be updated
+            ),
+        ];
+
+        db.save_state_machines(None, kickoff_machines_update, vec![], 124)
+            .await
+            .unwrap();
+
+        // Load kickoff machines again to verify only one was updated
+        let loaded_kickoff = db.load_kickoff_machines(None, owner_type).await.unwrap();
+        assert_eq!(loaded_kickoff.len(), 2);
+
+        // Find the machine with kickoff_id_1 - it should be updated
+        let machine1 = loaded_kickoff
+            .iter()
+            .find(|m| m.1 == "kickoff_id_1")
+            .unwrap();
+        assert_eq!(machine1.0, "kickoff_state_1_updated");
+
+        // Find the machine with kickoff_id_2 - it should not be updated
+        let machine2 = loaded_kickoff
+            .iter()
+            .find(|m| m.1 == "kickoff_id_2")
+            .unwrap();
+        assert_eq!(machine2.0, "kickoff_state_2");
+    }
+}

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -347,6 +347,9 @@ pub enum BridgeError {
     /// 0: Data name, 1: Error message
     #[error("Error while sending {0} data: {1}")]
     SendError(&'static str, String),
+
+    #[error("Eyre error: {0}")]
+    Eyre(#[from] eyre::Report),
 }
 
 impl From<BridgeError> for ErrorObject<'static> {

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -987,6 +987,7 @@ impl Operator {
 
 #[tonic::async_trait]
 impl Owner for Operator {
+    const OWNER_TYPE: &'static str = "operator";
     async fn handle_duty(&self, duty: Duty) -> Result<(), BridgeError> {
         match duty {
             Duty::NewKickoff => {

--- a/core/src/rpc/clementine.rs
+++ b/core/src/rpc/clementine.rs
@@ -99,7 +99,7 @@ pub mod grpc_transaction_id {
         NumberedTransaction(super::NumberedTransactionId),
     }
 }
-#[derive(Eq, PartialOrd, Ord, Hash)]
+#[derive(Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct KickoffId {
     #[prost(uint32, tag = "1")]

--- a/core/src/rpc/operator.rs
+++ b/core/src/rpc/operator.rs
@@ -133,9 +133,7 @@ impl ClementineOperator for Operator {
         let assert_request = request.into_inner();
         let assert_data = parse_assert_request(assert_request)?;
 
-        let raw_txs = self
-            .create_assert_commitment_txs(self.nofn_xonly_pk, assert_data)
-            .await?;
+        let raw_txs = self.create_assert_commitment_txs(assert_data).await?;
 
         Ok(Response::new(raw_txs))
     }
@@ -175,7 +173,6 @@ impl ClementineOperator for Operator {
             self.db.clone(),
             &self.signer,
             self.config.clone(),
-            self.nofn_xonly_pk,
             transaction_data,
             Some([0u8; 20]), // dummy blockhash
         )

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -408,7 +408,6 @@ impl ClementineVerifier for Verifier {
             self.db.clone(),
             &self.signer,
             self.config.clone(),
-            self.nofn_xonly_pk,
             transaction_data,
             None, // empty blockhash, will not sign this
         )

--- a/core/src/rpc/watchtower.rs
+++ b/core/src/rpc/watchtower.rs
@@ -53,7 +53,6 @@ impl ClementineWatchtower for Watchtower {
 
         let raw_tx = self
             .create_and_sign_watchtower_challenge(
-                self.nofn_xonly_pk,
                 transaction_data,
                 &vec![
                     0u8;

--- a/core/src/states/context.rs
+++ b/core/src/states/context.rs
@@ -55,7 +55,7 @@ pub enum Duty {
 
 /// Owner trait with async handling and tx handler creation
 #[async_trait]
-pub trait Owner: Send + Sync + Clone + Default {
+pub trait Owner: Send + Sync + Clone {
     /// A string identifier for this owner type used to distinguish between
     /// state machines with different owners in the database.
     ///

--- a/core/src/states/kickoff.rs
+++ b/core/src/states/kickoff.rs
@@ -107,7 +107,7 @@ impl<T: Owner> KickoffStateMachine<T> {
 #[state_machine(
     initial = "State::kickoff_started()",
     on_dispatch = "Self::on_dispatch",
-    state(derive(Debug, Clone, serde::Serialize, serde::Deserialize))
+    state(derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize))
 )]
 impl<T: Owner> KickoffStateMachine<T> {
     pub fn wrap_err(

--- a/core/src/states/kickoff.rs
+++ b/core/src/states/kickoff.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use bitcoin::{OutPoint, Txid, Witness};
+use bitcoin::{OutPoint, Witness};
 use eyre::Report;
 use statig::prelude::*;
 
@@ -15,7 +15,7 @@ use crate::{
 
 use super::{
     block_cache::BlockCache,
-    context::StateContext,
+    context::{Duty, StateContext},
     matcher::{BlockMatcher, Matcher},
     Owner,
 };
@@ -60,7 +60,6 @@ pub struct KickoffStateMachine<T: Owner> {
     pub(crate) matchers: HashMap<Matcher, KickoffEvent>,
     pub(crate) dirty: bool,
     pub(crate) kickoff_id: KickoffId,
-    num_watchtowers: u32,
     deposit_data: DepositData,
     kickoff_height: u32,
     spent_watchtower_utxos: HashSet<usize>,

--- a/core/src/states/matcher.rs
+++ b/core/src/states/matcher.rs
@@ -2,7 +2,6 @@ use bitcoin::{OutPoint, Txid};
 use std::cmp::Ordering;
 
 use super::block_cache::BlockCache;
-use bitcoin::{OutPoint, Txid};
 
 pub(crate) trait BlockMatcher {
     type StateEvent;

--- a/core/src/states/matcher.rs
+++ b/core/src/states/matcher.rs
@@ -1,13 +1,4 @@
-use super::context::StateContext;
-
 use bitcoin::{OutPoint, Txid};
-use statig::awaitable;
-use statig::awaitable::InitializedStateMachine;
-use statig::IntoStateMachine;
-
-use std::future::Future;
-
-use super::Owner;
 
 use super::block_cache::BlockCache;
 
@@ -18,7 +9,7 @@ pub(crate) trait BlockMatcher {
 }
 
 // Matcher for state machines to define what they're interested in
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum Matcher {
     SentTx(Txid),
     SpentUtxo(OutPoint),

--- a/core/src/states/matcher.rs
+++ b/core/src/states/matcher.rs
@@ -6,11 +6,13 @@ use super::block_cache::BlockCache;
 pub(crate) trait BlockMatcher {
     type StateEvent;
 
-    fn match_block(& self, block: &super::block_cache::BlockCache) -> Vec<Self::StateEvent>;
+    fn match_block(&self, block: &super::block_cache::BlockCache) -> Vec<Self::StateEvent>;
 }
 
 // Matcher for state machines to define what they're interested in
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd,serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, serde::Serialize, serde::Deserialize,
+)]
 pub enum Matcher {
     SentTx(Txid),
     SpentUtxo(OutPoint),
@@ -28,19 +30,18 @@ pub enum MatcherOrd {
 
 impl PartialOrd for MatcherOrd {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        match (self, other) {
-            (MatcherOrd::TxIndex(a), MatcherOrd::TxIndex(b)) => a.partial_cmp(b),
-            (MatcherOrd::BlockHeight, MatcherOrd::BlockHeight) => Some(Ordering::Equal),
-            (MatcherOrd::BlockHeight, _) => Some(Ordering::Less),
-            (_, MatcherOrd::BlockHeight) => Some(Ordering::Greater),
-        }
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for MatcherOrd {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other)
-            .expect("partial_cmp always returns Some")
+        match (self, other) {
+            (MatcherOrd::TxIndex(a), MatcherOrd::TxIndex(b)) => a.cmp(b),
+            (MatcherOrd::BlockHeight, MatcherOrd::BlockHeight) => Ordering::Equal,
+            (MatcherOrd::BlockHeight, _) => Ordering::Less,
+            (_, MatcherOrd::BlockHeight) => Ordering::Greater,
+        }
     }
 }
 
@@ -48,7 +49,7 @@ impl Matcher {
     pub fn matches(&self, block: &BlockCache) -> Option<MatcherOrd> {
         match self {
             Matcher::SentTx(txid) if block.contains_txid(txid) => Some(MatcherOrd::TxIndex(
-                block.txids.get(txid).expect("txid is in cache").clone(),
+                *block.txids.get(txid).expect("txid is in cache"),
             )),
             Matcher::SpentUtxo(outpoint) if (block.is_utxo_spent(outpoint)) => Some(
                 MatcherOrd::TxIndex(*block.spent_utxos.get(outpoint).expect("utxo is in cache")),

--- a/core/src/states/mod.rs
+++ b/core/src/states/mod.rs
@@ -1,5 +1,4 @@
 use crate::config::protocol::ProtocolParamset;
-use crate::config::protocol::ProtocolParamsetName;
 use crate::database::Database;
 use crate::errors::BridgeError;
 use bitcoin::Block;
@@ -10,7 +9,6 @@ use futures::future::{join, join_all};
 use kickoff::KickoffEvent;
 use matcher::BlockMatcher;
 use round::RoundEvent;
-use serde::{Deserialize, Serialize};
 use statig::awaitable::{InitializedStateMachine, UninitializedStateMachine};
 use statig::prelude::*;
 use std::future::Future;

--- a/core/src/states/mod.rs
+++ b/core/src/states/mod.rs
@@ -1,17 +1,20 @@
-use crate::builder::transaction::{DepositData, OperatorData};
 use crate::config::protocol::ProtocolParamset;
+use crate::config::protocol::ProtocolParamsetName;
 use crate::database::Database;
 use crate::errors::BridgeError;
 use bitcoin::Block;
 use context::Owner;
-use futures::future::{self, join, join_all, Map};
+use eyre::eyre;
+use eyre::Context;
+use futures::future::{join, join_all};
+use kickoff::KickoffEvent;
 use matcher::BlockMatcher;
-use statig::awaitable::InitializedStateMachine;
+use round::RoundEvent;
+use serde::{Deserialize, Serialize};
+use statig::awaitable::{InitializedStateMachine, UninitializedStateMachine};
 use statig::prelude::*;
 use std::future::Future;
 use std::sync::Arc;
-use thiserror::Error;
-use tonic::async_trait;
 
 mod block_cache;
 mod context;
@@ -86,7 +89,7 @@ pub struct StateManager<T: Owner> {
     paramset: &'static ProtocolParamset,
 }
 
-impl<T: Owner + 'static> StateManager<T> {
+impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
     pub fn new(db: Database, handler: T, paramset: &'static ProtocolParamset) -> Self {
         Self {
             context: context::StateContext::new(
@@ -103,13 +106,210 @@ impl<T: Owner + 'static> StateManager<T> {
         }
     }
 
-    pub fn load_from_db(&mut self) -> Result<(), BridgeError> {
-        // TODO: implement
+    /// Loads the state machines from the database.
+    /// This method should be called when initializing the StateManager.
+    ///
+    /// # Errors
+    /// Returns a `BridgeError` if the database operation fails
+    pub async fn load_from_db(&mut self) -> Result<(), BridgeError> {
+        // Start a transaction
+        let mut tx = self.db.begin_transaction().await?;
+
+        // First, check if we have any state saved
+        let status = self
+            .db
+            .get_last_processed_block_height(Some(&mut tx))
+            .await?;
+
+        // If no state is saved, return early
+        let Some(block_height) = status else {
+            tracing::info!("No state machines found in the database");
+            tx.commit().await?;
+            return Ok(());
+        };
+
+        tracing::info!("Loading state machines from block height {}", block_height);
+
+        // Get the owner type from the context
+        let owner_type = &self.context.owner_type;
+
+        // Load kickoff machines
+        let kickoff_machines = self
+            .db
+            .load_kickoff_machines(Some(&mut tx), owner_type)
+            .await?;
+
+        // Process and recreate kickoff machines
+        for (state_json, kickoff_id, saved_block_height) in &kickoff_machines {
+            tracing::debug!(
+                "Loaded kickoff machine: state={}, block_height={}",
+                state_json,
+                saved_block_height
+            );
+
+            // Deserialize the machine state from JSON
+            let machine: Result<UninitializedStateMachine<kickoff::KickoffStateMachine<T>>, _> =
+                serde_json::from_str(state_json);
+
+            match machine {
+                Ok(uninitialized) => {
+                    // Create a context for initialization
+                    let mut ctx = context::StateContext::new(
+                        self.db.clone(),
+                        Arc::new(self.owner.clone()),
+                        Default::default(),
+                        self.paramset,
+                    );
+
+                    // Initialize the machine with the context
+                    let initialized = uninitialized.init_with_context(&mut ctx).await;
+                    self.kickoff_machines.push(initialized);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to deserialize kickoff machine with ID {}: {}",
+                        kickoff_id,
+                        e
+                    );
+                }
+            }
+        }
+
+        // Load round machines
+        let round_machines = self
+            .db
+            .load_round_machines(Some(&mut tx), owner_type)
+            .await?;
+
+        // Process and recreate round machines
+        for (state_json, operator_idx, saved_block_height) in &round_machines {
+            tracing::debug!(
+                "Loaded round machine: state={}, block_height={}",
+                state_json,
+                saved_block_height
+            );
+
+            // Deserialize the machine state from JSON
+            let machine: Result<UninitializedStateMachine<round::RoundStateMachine<T>>, _> =
+                serde_json::from_str(state_json);
+
+            match machine {
+                Ok(uninitialized) => {
+                    // Create a context for initialization
+                    let mut ctx = context::StateContext::new(
+                        self.db.clone(),
+                        Arc::new(self.owner.clone()),
+                        Default::default(),
+                        self.paramset,
+                    );
+
+                    // Initialize the machine with the context
+                    let initialized = uninitialized.init_with_context(&mut ctx).await;
+                    self.round_machines.push(initialized);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to deserialize round machine with operator index {:?}: {}",
+                        operator_idx,
+                        e
+                    );
+                }
+            }
+        }
+
+        tracing::info!(
+            "Loaded {} kickoff machines and {} round machines from the database",
+            kickoff_machines.len(),
+            round_machines.len()
+        );
+
+        tx.commit().await?;
         Ok(())
     }
 
-    pub fn save_to_db(&self) -> Result<(), BridgeError> {
-        // TODO: implement
+    /// Saves the state machines to the database. Resets the dirty flag for all machines after successful save.
+    ///
+    /// # Errors
+    /// Returns a `BridgeError` if the database operation fails.
+    ///
+    /// # TODO
+    /// We should only save `dirty` machines but we currently save all of them.
+    pub async fn save_state_to_db(&mut self, block_height: u32) -> eyre::Result<()> {
+        // Start a database transaction
+        let mut transaction = self.db.begin_transaction().await?;
+
+        // Get the owner type from the context
+        let owner_type = &self.context.owner_type;
+
+        // Prepare kickoff machines data with direct serialization
+        let kickoff_machines: eyre::Result<Vec<_>> = self
+            .kickoff_machines
+            .iter()
+            .map(|machine| -> eyre::Result<_> {
+                // Directly serialize the machine
+                let state_json = serde_json::to_string(&machine).wrap_err_with(|| {
+                    format!("Failed to serialize kickoff machine: {:?}", machine)
+                })?;
+                let kickoff_id =
+                    serde_json::to_string(&machine.kickoff_id).wrap_err_with(|| {
+                        format!("Failed to serialize kickoff id for machine: {:?}", machine)
+                    })?;
+
+                // Use the machine's dirty flag to determine if it needs updating
+                Ok((state_json, (kickoff_id), owner_type.clone(), machine.dirty))
+            })
+            .collect();
+
+        // Prepare round machines data with direct serialization
+        let round_machines: eyre::Result<Vec<_>> = self
+            .round_machines
+            .iter()
+            .map(|machine| -> eyre::Result<_> {
+                let state_json = serde_json::to_string(machine).wrap_err_with(|| {
+                    format!("Failed to serialize round machine: {:?}", machine)
+                })?;
+                let operator_idx = machine.operator_idx;
+
+                // Use the machine's dirty flag to determine if it needs updating
+                Ok((
+                    state_json,
+                    (operator_idx as i32),
+                    owner_type.clone(),
+                    machine.dirty,
+                ))
+            })
+            .collect();
+
+        // Use the database function to save the state machines
+        self.db
+            .save_state_machines(
+                Some(&mut transaction),
+                kickoff_machines?,
+                round_machines?,
+                block_height as i32,
+            )
+            .await?;
+
+        // Commit the transaction
+        transaction.commit().await?;
+
+        // Reset the dirty flag for all machines after successful save
+        for machine in &mut self.kickoff_machines {
+            if machine.dirty {
+                machine
+                    .handle_with_context(&KickoffEvent::SavedToDb, &mut self.context)
+                    .await;
+            }
+        }
+
+        for machine in &mut self.round_machines {
+            if machine.dirty {
+                machine
+                    .handle_with_context(&RoundEvent::SavedToDb, &mut self.context)
+                    .await;
+            }
+        }
+
         Ok(())
     }
 
@@ -119,14 +319,18 @@ impl<T: Owner + 'static> StateManager<T> {
         cache: block_cache::BlockCache,
         paramset: &'static ProtocolParamset,
     ) -> context::StateContext<T> {
+        let owner = Arc::new(handler);
+        let owner_type = owner.owner_type_str().to_string();
+
         context::StateContext {
             db: db.clone(),
-            owner: Arc::new(handler),
+            owner,
             cache: Arc::new(cache),
             new_kickoff_machines: Vec::new(),
             new_round_machines: Vec::new(),
             errors: Vec::new(),
             paramset,
+            owner_type,
         }
     }
 
@@ -182,7 +386,7 @@ impl<T: Owner + 'static> StateManager<T> {
         &mut self,
         block: &Block,
         block_height: u32,
-    ) -> Result<(), BridgeError> {
+    ) -> Result<(), eyre::Report> {
         let mut cache: block_cache::BlockCache = Default::default();
         cache.update_with_block(block, block_height);
 
@@ -221,7 +425,8 @@ impl<T: Owner + 'static> StateManager<T> {
                 // Return first error or create a combined error
                 return Err(BridgeError::Error(
                     "Multiple errors occurred during state processing".into(),
-                ));
+                )
+                .into());
             }
 
             // Append the newly generated state machines into the changed machines list
@@ -229,12 +434,18 @@ impl<T: Owner + 'static> StateManager<T> {
                 #[cfg(debug_assertions)]
                 for machine in &ctx.new_round_machines {
                     if !machine.dirty {
-                        panic!("Round machine not dirty despite having been newly created: {:?}", machine.state());
+                        panic!(
+                            "Round machine not dirty despite having been newly created: {:?}",
+                            machine.state()
+                        );
                     }
                 }
                 for machine in &ctx.new_kickoff_machines {
                     if !machine.dirty {
-                        panic!("Kickoff machine not dirty despite having been newly created: {:?}", machine.state());
+                        panic!(
+                            "Kickoff machine not dirty despite having been newly created: {:?}",
+                            machine.state()
+                        );
                     }
                 }
                 changed_round_machines.extend(std::mem::take(&mut ctx.new_round_machines));
@@ -242,7 +453,7 @@ impl<T: Owner + 'static> StateManager<T> {
             }
 
             if iterations > 50 {
-                return Err(BridgeError::Error(format!(
+                return Err(eyre!(format!(
                     r#"{}/{} kickoff and {}/{} round state machines did not stabilize after 50 iterations, debug repr of changed machines:
                         ---- Kickoff machines ----
                         {:?}
@@ -279,11 +490,12 @@ impl<T: Owner + 'static> StateManager<T> {
             iterations += 1;
         }
 
-        // TODO: commit to db
-
         // Set back the original machines
         self.round_machines = final_round_machines;
         self.kickoff_machines = final_kickoff_machines;
+
+        // Save the state machines to the database with the current block height
+        self.save_state_to_db(block_height).await?;
 
         Ok(())
     }

--- a/core/src/states/mod.rs
+++ b/core/src/states/mod.rs
@@ -320,7 +320,7 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
         paramset: &'static ProtocolParamset,
     ) -> context::StateContext<T> {
         let owner = Arc::new(handler);
-        let owner_type = owner.owner_type_str().to_string();
+        let owner_type = T::OWNER_TYPE.to_string();
 
         context::StateContext {
             db: db.clone(),

--- a/core/src/states/mod.rs
+++ b/core/src/states/mod.rs
@@ -438,6 +438,7 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
                         );
                     }
                 }
+                #[cfg(debug_assertions)]
                 for machine in &ctx.new_kickoff_machines {
                     if !machine.dirty {
                         panic!(

--- a/core/src/states/round.rs
+++ b/core/src/states/round.rs
@@ -1,9 +1,5 @@
-use eyre::Context;
 use statig::prelude::*;
-use std::{
-    collections::{HashMap, HashSet},
-    ops::DerefMut,
-};
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     builder::transaction::{ContractContext, OperatorData, TransactionType},

--- a/core/src/states/round.rs
+++ b/core/src/states/round.rs
@@ -30,7 +30,7 @@ pub enum RoundEvent {
     SavedToDb,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct RoundStateMachine<T: Owner> {
     pub(crate) matchers: HashMap<matcher::Matcher, RoundEvent>,
     operator_data: OperatorData,
@@ -72,7 +72,7 @@ use eyre::Report;
 #[state_machine(
     initial = "State::initial_collateral()",
     on_dispatch = "Self::on_dispatch",
-    state(derive(Debug, Clone, serde::Serialize, serde::Deserialize))
+    state(derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize))
 )]
 // TODO: Add exit conditions too (ex: burn connector spent on smth else)
 impl<T: Owner> RoundStateMachine<T> {

--- a/core/src/test/common/mod.rs
+++ b/core/src/test/common/mod.rs
@@ -23,7 +23,7 @@ pub use test_utils::*;
 use tonic::transport::Channel;
 use tonic::Request;
 
-mod test_utils;
+pub mod test_utils;
 // pub async fn run_multiple_deposits(test_config_name: &str) {
 //     let config = create_test_config_with_thread_name(test_config_name, None);
 //     let rpc = ExtendedRpc::connect(

--- a/core/src/test/mod.rs
+++ b/core/src/test/mod.rs
@@ -4,4 +4,5 @@ mod full_flow;
 mod misc;
 mod musig2;
 mod rpc;
+mod state_manager;
 mod taproot;

--- a/core/src/test/state_manager.rs
+++ b/core/src/test/state_manager.rs
@@ -1,0 +1,144 @@
+// use crate::{database::Database, test::common::*};
+
+// /// Tests basic saving and loading of state machine data directly from the database
+// #[tokio::test]
+// async fn test_database_save_and_load_state_machines() {
+//     // Create a test configuration and database
+//     let config = create_test_config_with_thread_name(None).await;
+//     let db = Database::new(&config).await.unwrap();
+
+//     // Create test data
+//     let kickoff_machines = vec![
+//         (
+//             0,
+//             "kickoff_state_1".to_string(),
+//             Some("kickoff_id_1".to_string()),
+//         ),
+//         (
+//             1,
+//             "kickoff_state_2".to_string(),
+//             Some("kickoff_id_2".to_string()),
+//         ),
+//     ];
+
+//     let round_machines = vec![
+//         (0, "round_state_1".to_string(), Some(1)),
+//         (1, "round_state_2".to_string(), Some(2)),
+//     ];
+
+//     // Save state to the database with a specific block height
+//     let block_height = 123;
+//     let save_result = db
+//         .save_state_machines(
+//             None,
+//             kickoff_machines.clone(),
+//             round_machines.clone(),
+//             block_height,
+//         )
+//         .await;
+//     assert!(save_result.is_ok(), "Saving state should succeed");
+
+//     // Verify that the last processed block height was saved correctly
+//     let db_block_height = db.get_last_processed_block_height(None).await.unwrap();
+//     assert_eq!(
+//         db_block_height,
+//         Some(block_height),
+//         "Last processed block height should match"
+//     );
+
+//     // Load kickoff machines
+//     let loaded_kickoff = db.load_kickoff_machines(None).await.unwrap();
+//     assert_eq!(loaded_kickoff.len(), 2, "Should have 2 kickoff machines");
+//     assert_eq!(
+//         loaded_kickoff[0].0, 0,
+//         "First kickoff machine idx should be 0"
+//     );
+//     assert_eq!(
+//         loaded_kickoff[0].1, "kickoff_state_1",
+//         "First kickoff machine state should match"
+//     );
+//     assert_eq!(
+//         loaded_kickoff[0].2,
+//         Some("kickoff_id_1".to_string()),
+//         "First kickoff machine ID should match"
+//     );
+//     assert_eq!(
+//         loaded_kickoff[0].3, block_height,
+//         "First kickoff machine block height should match"
+//     );
+
+//     // Load round machines
+//     let loaded_round = db.load_round_machines(None).await.unwrap();
+//     assert_eq!(loaded_round.len(), 2, "Should have 2 round machines");
+//     assert_eq!(loaded_round[0].0, 0, "First round machine idx should be 0");
+//     assert_eq!(
+//         loaded_round[0].1, "round_state_1",
+//         "First round machine state should match"
+//     );
+//     assert_eq!(
+//         loaded_round[0].2,
+//         Some(1),
+//         "First round machine operator idx should match"
+//     );
+//     assert_eq!(
+//         loaded_round[0].3, block_height,
+//         "First round machine block height should match"
+//     );
+// }
+
+// #[tokio::test]
+// async fn test_transaction_isolation() {
+//     // Create a test configuration and database with a unique name
+//     let config = create_test_config_with_thread_name(Some("transaction_isolation")).await;
+//     let db = Database::new(&config).await.unwrap();
+
+//     // Save initial state with a specific block height
+//     let initial_block_height = 789;
+//     db.save_state_machines(None, Vec::new(), Vec::new(), initial_block_height)
+//         .await
+//         .unwrap();
+
+//     // Start a transaction but don't commit it
+//     let mut tx = db.begin_transaction().await.unwrap();
+
+//     // Update state in the transaction
+//     let transaction_block_height = 999;
+//     db.save_state_machines(
+//         Some(&mut tx),
+//         Vec::new(),
+//         Vec::new(),
+//         transaction_block_height,
+//     )
+//     .await
+//     .unwrap();
+
+//     // Verify that within the transaction we see the updated state
+//     let tx_block_height = db
+//         .get_last_processed_block_height(Some(&mut tx))
+//         .await
+//         .unwrap();
+//     assert_eq!(
+//         tx_block_height,
+//         Some(transaction_block_height),
+//         "Within the transaction, block height should match transaction block height"
+//     );
+
+//     // But outside the transaction we still see the old value
+//     let global_block_height = db.get_last_processed_block_height(None).await.unwrap();
+//     assert_eq!(
+//         global_block_height,
+//         Some(initial_block_height),
+//         "Outside the transaction, block height should remain unchanged"
+//     );
+
+//     // Roll back the transaction
+//     tx.rollback().await.unwrap();
+
+//     // Verify that the global state is unchanged
+//     let final_block_height = db.get_last_processed_block_height(None).await.unwrap();
+//     assert_eq!(
+//         final_block_height,
+//         Some(initial_block_height),
+//         "After rollback, block height should remain unchanged"
+//     );
+// }

--- a/core/src/test/state_manager.rs
+++ b/core/src/test/state_manager.rs
@@ -55,7 +55,8 @@ async fn create_test_state_manager(
         .expect("Failed to create database");
     let owner = Default::default();
 
-    let state_manager = StateManager::new(db, owner, config.protocol_paramset());
+    let state_manager =
+        StateManager::new(db, owner, config.protocol_paramset(), "test".to_string(), 0);
 
     (state_manager, config.clone())
 }

--- a/core/src/test/state_manager.rs
+++ b/core/src/test/state_manager.rs
@@ -1,144 +1,151 @@
-// use crate::{database::Database, test::common::*};
+use std::collections::BTreeMap;
+use std::sync::Arc;
 
-// /// Tests basic saving and loading of state machine data directly from the database
-// #[tokio::test]
-// async fn test_database_save_and_load_state_machines() {
-//     // Create a test configuration and database
-//     let config = create_test_config_with_thread_name(None).await;
-//     let db = Database::new(&config).await.unwrap();
+use async_trait::async_trait;
+use bitcoin::{consensus, Block};
+use tokio::sync::Mutex;
 
-//     // Create test data
-//     let kickoff_machines = vec![
-//         (
-//             0,
-//             "kickoff_state_1".to_string(),
-//             Some("kickoff_id_1".to_string()),
-//         ),
-//         (
-//             1,
-//             "kickoff_state_2".to_string(),
-//             Some("kickoff_id_2".to_string()),
-//         ),
-//     ];
+use super::common::{create_test_config_with_thread_name, initialize_database};
+use crate::states::context::{Duty, Owner};
+use crate::{
+    builder::transaction::{ContractContext, TransactionType, TxHandler},
+    config::BridgeConfig,
+    database::Database,
+    errors::BridgeError,
+    states::StateManager,
+};
 
-//     let round_machines = vec![
-//         (0, "round_state_1".to_string(), Some(1)),
-//         (1, "round_state_2".to_string(), Some(2)),
-//     ];
+// Mock implementation of the Owner trait for testing
+#[derive(Debug, Clone, Default)]
+struct MockOwner {
+    cached_duties: Arc<Mutex<Vec<Duty>>>,
+}
 
-//     // Save state to the database with a specific block height
-//     let block_height = 123;
-//     let save_result = db
-//         .save_state_machines(
-//             None,
-//             kickoff_machines.clone(),
-//             round_machines.clone(),
-//             block_height,
-//         )
-//         .await;
-//     assert!(save_result.is_ok(), "Saving state should succeed");
+impl PartialEq for MockOwner {
+    fn eq(&self, other: &Self) -> bool {
+        true // all mock owners are equal
+    }
+}
 
-//     // Verify that the last processed block height was saved correctly
-//     let db_block_height = db.get_last_processed_block_height(None).await.unwrap();
-//     assert_eq!(
-//         db_block_height,
-//         Some(block_height),
-//         "Last processed block height should match"
-//     );
+// Implement the Owner trait for MockOwner
+#[async_trait]
+impl Owner for MockOwner {
+    const OWNER_TYPE: &'static str = "test_owner";
 
-//     // Load kickoff machines
-//     let loaded_kickoff = db.load_kickoff_machines(None).await.unwrap();
-//     assert_eq!(loaded_kickoff.len(), 2, "Should have 2 kickoff machines");
-//     assert_eq!(
-//         loaded_kickoff[0].0, 0,
-//         "First kickoff machine idx should be 0"
-//     );
-//     assert_eq!(
-//         loaded_kickoff[0].1, "kickoff_state_1",
-//         "First kickoff machine state should match"
-//     );
-//     assert_eq!(
-//         loaded_kickoff[0].2,
-//         Some("kickoff_id_1".to_string()),
-//         "First kickoff machine ID should match"
-//     );
-//     assert_eq!(
-//         loaded_kickoff[0].3, block_height,
-//         "First kickoff machine block height should match"
-//     );
+    async fn handle_duty(&self, duty: Duty) -> Result<(), BridgeError> {
+        self.cached_duties.lock().await.push(duty);
+        Ok(())
+    }
 
-//     // Load round machines
-//     let loaded_round = db.load_round_machines(None).await.unwrap();
-//     assert_eq!(loaded_round.len(), 2, "Should have 2 round machines");
-//     assert_eq!(loaded_round[0].0, 0, "First round machine idx should be 0");
-//     assert_eq!(
-//         loaded_round[0].1, "round_state_1",
-//         "First round machine state should match"
-//     );
-//     assert_eq!(
-//         loaded_round[0].2,
-//         Some(1),
-//         "First round machine operator idx should match"
-//     );
-//     assert_eq!(
-//         loaded_round[0].3, block_height,
-//         "First round machine block height should match"
-//     );
-// }
+    async fn create_txhandlers(
+        &self,
+        _tx_type: TransactionType,
+        _contract_context: ContractContext,
+    ) -> Result<BTreeMap<TransactionType, TxHandler>, BridgeError> {
+        Ok(BTreeMap::new())
+    }
+}
 
-// #[tokio::test]
-// async fn test_transaction_isolation() {
-//     // Create a test configuration and database with a unique name
-//     let config = create_test_config_with_thread_name(Some("transaction_isolation")).await;
-//     let db = Database::new(&config).await.unwrap();
+// Helper function to create a test state manager
+async fn create_test_state_manager(
+    config: &BridgeConfig,
+) -> (StateManager<MockOwner>, BridgeConfig) {
+    let db = Database::new(config)
+        .await
+        .expect("Failed to create database");
+    let owner = Default::default();
 
-//     // Save initial state with a specific block height
-//     let initial_block_height = 789;
-//     db.save_state_machines(None, Vec::new(), Vec::new(), initial_block_height)
-//         .await
-//         .unwrap();
+    let state_manager = StateManager::new(db, owner, config.protocol_paramset());
 
-//     // Start a transaction but don't commit it
-//     let mut tx = db.begin_transaction().await.unwrap();
+    (state_manager, config.clone())
+}
 
-//     // Update state in the transaction
-//     let transaction_block_height = 999;
-//     db.save_state_machines(
-//         Some(&mut tx),
-//         Vec::new(),
-//         Vec::new(),
-//         transaction_block_height,
-//     )
-//     .await
-//     .unwrap();
+async fn create_test_config() -> BridgeConfig {
+    let config = create_test_config_with_thread_name(Some("state_manager_test")).await;
+    initialize_database(&config).await;
+    config
+}
 
-//     // Verify that within the transaction we see the updated state
-//     let tx_block_height = db
-//         .get_last_processed_block_height(Some(&mut tx))
-//         .await
-//         .unwrap();
-//     assert_eq!(
-//         tx_block_height,
-//         Some(transaction_block_height),
-//         "Within the transaction, block height should match transaction block height"
-//     );
+// Helper function to create an empty block for testing
+fn create_empty_block() -> Block {
+    // from bitcoin tests
+    let some_block = hex::decode("010000004ddccd549d28f385ab457e98d1b11ce80bfea2c5ab93015ade4973e400000000bf4473e53794beae34e64fccc471dace6ae544180816f89591894e0f417a914cd74d6e49ffff001d323b3a7b0201000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0804ffff001d026e04ffffffff0100f2052a0100000043410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac00000000010000000321f75f3139a013f50f315b23b0c9a2b6eac31e2bec98e5891c924664889942260000000049483045022100cb2c6b346a978ab8c61b18b5e9397755cbd17d6eb2fe0083ef32e067fa6c785a02206ce44e613f31d9a6b0517e46f3db1576e9812cc98d159bfdaf759a5014081b5c01ffffffff79cda0945903627c3da1f85fc95d0b8ee3e76ae0cfdc9a65d09744b1f8fc85430000000049483045022047957cdd957cfd0becd642f6b84d82f49b6cb4c51a91f49246908af7c3cfdf4a022100e96b46621f1bffcf5ea5982f88cef651e9354f5791602369bf5a82a6cd61a62501fffffffffe09f5fe3ffbf5ee97a54eb5e5069e9da6b4856ee86fc52938c2f979b0f38e82000000004847304402204165be9a4cbab8049e1af9723b96199bfd3e85f44c6b4c0177e3962686b26073022028f638da23fc003760861ad481ead4099312c60030d4cb57820ce4d33812a5ce01ffffffff01009d966b01000000434104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac00000000").unwrap();
 
-//     // But outside the transaction we still see the old value
-//     let global_block_height = db.get_last_processed_block_height(None).await.unwrap();
-//     assert_eq!(
-//         global_block_height,
-//         Some(initial_block_height),
-//         "Outside the transaction, block height should remain unchanged"
-//     );
+    consensus::deserialize(&some_block).unwrap()
+}
 
-//     // Roll back the transaction
-//     tx.rollback().await.unwrap();
+#[tokio::test]
+async fn test_process_empty_block_with_no_machines() {
+    let (mut state_manager, _config) = create_test_state_manager(&create_test_config().await).await;
 
-//     // Verify that the global state is unchanged
-//     let final_block_height = db.get_last_processed_block_height(None).await.unwrap();
-//     assert_eq!(
-//         final_block_height,
-//         Some(initial_block_height),
-//         "After rollback, block height should remain unchanged"
-//     );
-// }
+    let block = create_empty_block();
+    let block_height = 1;
+
+    // Process an empty block with no state machines
+    let result = state_manager
+        .process_block_parallel(&block, block_height)
+        .await;
+
+    // Should succeed with no state changes
+    assert!(
+        result.is_ok(),
+        "Failed to process empty block: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_process_block_parallel() {
+    let (mut state_manager, _config) = create_test_state_manager(&create_test_config().await).await;
+
+    // Create a block
+    let block = create_empty_block();
+
+    // Process the block multiple times to test the iteration logic
+    for i in 1..=3 {
+        let result = state_manager.process_block_parallel(&block, i).await;
+        assert!(
+            result.is_ok(),
+            "Failed to process block on iteration {}: {:?}",
+            i,
+            result
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_save_and_load_state() {
+    let (mut state_manager, config) = create_test_state_manager(&create_test_config().await).await;
+
+    // Process a block to ensure the state is initialized
+    let block = create_empty_block();
+    let result = state_manager.process_block_parallel(&block, 1).await;
+    assert!(result.is_ok(), "Failed to process block: {:?}", result);
+
+    // Save state to DB
+    let result = state_manager.save_state_to_db(1).await;
+    assert!(result.is_ok(), "Failed to save state to DB: {:?}", result);
+
+    // Create a new state manager to load from DB
+    let (mut new_state_manager, _) = create_test_state_manager(&config).await;
+
+    // Load state from DB
+    let result = new_state_manager.load_from_db().await;
+    assert!(result.is_ok(), "Failed to load state from DB: {:?}", result);
+
+    // Check that the state is the same
+    let mut round_machines = new_state_manager.round_machines();
+    let mut kickoff_machines = new_state_manager.kickoff_machines();
+
+    round_machines.sort_by_key(|m| m.operator_idx);
+    kickoff_machines.sort_by_key(|m| m.kickoff_id);
+
+    let mut round_machines_old = state_manager.round_machines();
+    let mut kickoff_machines_old = state_manager.kickoff_machines();
+
+    round_machines_old.sort_by_key(|m| m.operator_idx);
+    kickoff_machines_old.sort_by_key(|m| m.kickoff_id);
+
+    assert_eq!(round_machines, round_machines_old);
+    assert_eq!(kickoff_machines, kickoff_machines_old);
+}

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -308,3 +308,39 @@ create table if not exists tx_sender_activate_try_to_send_outpoints (
 );
 
 COMMIT;
+
+-- Add state machine tables at the end of the file:
+
+-- State machines table to store serialized machines
+CREATE TABLE IF NOT EXISTS state_machines (
+    id SERIAL PRIMARY KEY,
+    machine_type VARCHAR(50) NOT NULL, -- 'kickoff' or 'round'
+    machine_idx INT NULL, -- Optional reference for backward compatibility
+    state_json TEXT NOT NULL,
+    kickoff_id TEXT NULL, -- only for kickoff machines
+    operator_idx INT NULL, -- only for round machines
+    owner_type VARCHAR(100) NOT NULL DEFAULT 'default', -- Type of the owner managing this state machine
+    block_height INT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE(machine_type, kickoff_id, operator_idx, owner_type)
+);
+
+-- Status table to track the last processed block
+CREATE TABLE IF NOT EXISTS state_manager_status (
+    id SERIAL PRIMARY KEY,
+    last_processed_block_height INT NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Insert a default record in the status table
+INSERT INTO state_manager_status (id, last_processed_block_height, updated_at)
+VALUES (1, 0, NOW())
+ON CONFLICT (id) DO NOTHING;
+
+-- Create indexes for better query performance
+CREATE INDEX IF NOT EXISTS state_machines_block_height_idx ON state_machines(block_height);
+CREATE INDEX IF NOT EXISTS state_machines_machine_type_idx ON state_machines(machine_type);
+CREATE INDEX IF NOT EXISTS state_machines_kickoff_id_idx ON state_machines(kickoff_id) WHERE kickoff_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS state_machines_operator_idx_idx ON state_machines(operator_idx) WHERE operator_idx IS NOT NULL;
+CREATE INDEX IF NOT EXISTS state_machines_owner_type_idx ON state_machines(owner_type);

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -286,7 +286,6 @@ create table if not exists tx_sender_activate_try_to_send_outpoints (
 CREATE TABLE IF NOT EXISTS state_machines (
     id SERIAL PRIMARY KEY,
     machine_type VARCHAR(50) NOT NULL, -- 'kickoff' or 'round'
-    machine_idx INT NULL, -- Optional reference for backward compatibility
     state_json TEXT NOT NULL,
     kickoff_id TEXT NULL, -- only for kickoff machines
     operator_idx INT NULL, -- only for round machines
@@ -294,7 +293,8 @@ CREATE TABLE IF NOT EXISTS state_machines (
     block_height INT NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    UNIQUE(machine_type, kickoff_id, operator_idx, owner_type)
+    UNIQUE(machine_type, kickoff_id, owner_type), -- For kickoff machines
+    UNIQUE(machine_type, operator_idx, owner_type)  -- For round machines
 );
 
 -- Status table to track the last processed block


### PR DESCRIPTION
- Implement database storage for state machines (kickoff and round)
- Add serde serialization/deserialization for state machine types
- Create new database schema for state machine persistence
- Implement load_from_db and save_state_to_db methods in StateManager
- Add owner type tracking and serialization support
- Enhance state machine handling with improved error reporting

# Description

Describe what this pull request does, here.

## Linked Issues

- Closes # (issue, if applicable)
- Related to # (issue)

## Testing

Describe how these changes were tested. If you've added new features, have you
added unit tests?

## Docs

Describe where this code is documented. If it changes a documented interface,
have the docs been updated?
