### PR TITLE
remove risc0 to bitvm dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,8 @@ dependencies = [
  "bitcoin",
  "borsh",
  "circuits-lib",
+ "final-spv",
+ "header-chain",
  "hex",
  "hex-literal",
  "num-bigint 0.4.6",
@@ -1914,7 +1916,6 @@ dependencies = [
  "rand 0.8.5",
  "risc0-circuit-recursion",
  "risc0-groth16",
- "risc0-to-bitvm2-core",
  "risc0-zkp",
  "risc0-zkvm",
  "serde",
@@ -2081,6 +2082,8 @@ dependencies = [
  "borsh",
  "crypto-bigint",
  "derive_more 1.0.0",
+ "final-spv",
+ "header-chain",
  "hex",
  "hex-literal",
  "itertools 0.14.0",
@@ -2091,7 +2094,6 @@ dependencies = [
  "rand 0.8.5",
  "ripemd",
  "risc0-groth16",
- "risc0-to-bitvm2-core",
  "risc0-zkvm",
  "serde",
  "serde_json",
@@ -2224,7 +2226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2824,7 +2826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2915,6 +2917,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "final-spv"
+version = "0.1.0"
+source = "git+https://github.com/chainwayxyz/BitVM?rev=8508328#8508328d1823ea0c6675af6cb0168de1d1f0cdbc"
+dependencies = [
+ "bitcoin",
+ "blake3",
+ "borsh",
+ "crypto-bigint",
+ "header-chain",
+ "risc0-zkvm",
+ "serde",
+ "sha2",
 ]
 
 [[package]]
@@ -3258,6 +3275,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "header-chain"
+version = "0.1.0"
+source = "git+https://github.com/chainwayxyz/BitVM?rev=8508328#8508328d1823ea0c6675af6cb0168de1d1f0cdbc"
+dependencies = [
+ "bitcoin",
+ "borsh",
+ "crypto-bigint",
+ "risc0-zkvm",
+ "serde",
+ "sha2",
 ]
 
 [[package]]
@@ -4879,7 +4909,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -4984,7 +5014,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5662,7 +5692,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6539,7 +6569,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7392,7 +7422,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,8 +65,9 @@ jmt = "0.11.0"
 derive_more = "1.0.0"
 blake3 = "1.5.1"
 itertools = "0.14.0"
-header-chain = { git = "https://github.com/chainwayxyz/risc0-to-bitvm2", rev = "a233e27" }
+header-chain = { git = "https://github.com/chainwayxyz/BitVM", rev = "8508328" }
 bitvm = { git = "https://github.com/chainwayxyz/BitVM", rev = "8508328" }
+final-spv = { git = "https://github.com/chainwayxyz/BitVM", rev = "8508328" }
 risc0-to-bitvm2-core = { git = "https://github.com/chainwayxyz/risc0-to-bitvm2.git", branch = "main" }
 
 ark-groth16 = { version = "0.5.0", default-features = false }

--- a/bridge-circuit-host/Cargo.toml
+++ b/bridge-circuit-host/Cargo.toml
@@ -32,6 +32,8 @@ num-bigint = { workspace = true }
 num-traits = { workspace = true }
 anyhow = { workspace = true }
 bitcoin = { workspace = true, features = ["serde"] }
+final-spv = { workspace = true }
+header-chain = { workspace = true }
 
 tokio = { workspace = true, features = ["rt-multi-thread"]}
 bincode = { workspace = true }
@@ -42,7 +44,7 @@ thiserror = { workspace = true }
 
 circuits-lib = { path = "../circuits-lib", features = ["not_patched"] }
 
-risc0-to-bitvm2-core = { workspace = true } # remove later
+
 
 
 

--- a/bridge-circuit-host/src/bridge_circuit_host.rs
+++ b/bridge-circuit-host/src/bridge_circuit_host.rs
@@ -54,10 +54,13 @@ mod tests {
     use borsh::BorshDeserialize;
     use circuits_lib::bridge_circuit_core::groth16::CircuitGroth16Proof;
     use circuits_lib::bridge_circuit_core::structs::WorkOnlyCircuitInput;
+    use circuits_lib::bridge_circuit_core::winternitz::{generate_public_key, sign_digits, Parameters, WinternitzHandler};
     use final_spv::merkle_tree::BitcoinMerkleTree;
     use final_spv::spv::SPV;
     use header_chain::header_chain::{BlockHeaderCircuitOutput, CircuitBlockHeader};
     use header_chain::mmr_native::MMRNative;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
     use risc0_zkvm::Receipt;
     use std::convert::TryInto;
 

--- a/bridge-circuit-host/src/bridge_circuit_host.rs
+++ b/bridge-circuit-host/src/bridge_circuit_host.rs
@@ -54,15 +54,10 @@ mod tests {
     use borsh::BorshDeserialize;
     use circuits_lib::bridge_circuit_core::groth16::CircuitGroth16Proof;
     use circuits_lib::bridge_circuit_core::structs::WorkOnlyCircuitInput;
-    use circuits_lib::bridge_circuit_core::winternitz::{
-        generate_public_key, sign_digits, Parameters, WinternitzHandler,
-    };
-    use rand::{rngs::SmallRng, Rng, SeedableRng};
-    use risc0_to_bitvm2_core::header_chain::BlockHeaderCircuitOutput;
-    use risc0_to_bitvm2_core::header_chain::CircuitBlockHeader;
-    use risc0_to_bitvm2_core::merkle_tree::BitcoinMerkleTree;
-    use risc0_to_bitvm2_core::mmr_native::MMRNative;
-    use risc0_to_bitvm2_core::spv::SPV;
+    use final_spv::merkle_tree::BitcoinMerkleTree;
+    use final_spv::spv::SPV;
+    use header_chain::header_chain::{BlockHeaderCircuitOutput, CircuitBlockHeader};
+    use header_chain::mmr_native::MMRNative;
     use risc0_zkvm::Receipt;
     use std::convert::TryInto;
 

--- a/bridge-circuit-host/src/bridge_circuit_host.rs
+++ b/bridge-circuit-host/src/bridge_circuit_host.rs
@@ -54,7 +54,9 @@ mod tests {
     use borsh::BorshDeserialize;
     use circuits_lib::bridge_circuit_core::groth16::CircuitGroth16Proof;
     use circuits_lib::bridge_circuit_core::structs::WorkOnlyCircuitInput;
-    use circuits_lib::bridge_circuit_core::winternitz::{generate_public_key, sign_digits, Parameters, WinternitzHandler};
+    use circuits_lib::bridge_circuit_core::winternitz::{
+        generate_public_key, sign_digits, Parameters, WinternitzHandler,
+    };
     use final_spv::merkle_tree::BitcoinMerkleTree;
     use final_spv::spv::SPV;
     use header_chain::header_chain::{BlockHeaderCircuitOutput, CircuitBlockHeader};

--- a/bridge-circuit-host/src/structs.rs
+++ b/bridge-circuit-host/src/structs.rs
@@ -2,7 +2,8 @@ use circuits_lib::bridge_circuit_core::{
     structs::{LightClientProof, StorageProof},
     winternitz::WinternitzHandler,
 };
-use risc0_to_bitvm2_core::{header_chain::BlockHeaderCircuitOutput, spv::SPV};
+use final_spv::spv::SPV;
+use header_chain::header_chain::BlockHeaderCircuitOutput;
 use risc0_zkvm::Receipt;
 
 pub struct BridgeCircuitHostParams {

--- a/circuits-lib/Cargo.toml
+++ b/circuits-lib/Cargo.toml
@@ -40,8 +40,8 @@ derive_more = { workspace = true, features = ["display"]}
 crypto-bigint = { workspace = true }
 blake3 = { workspace = true }
 itertools = { workspace = true }
-
-risc0-to-bitvm2-core = { workspace = true } # Remove later
+final-spv = { workspace = true }
+header-chain = { workspace = true }
 
 [features]
 not_patched = []

--- a/circuits-lib/src/bridge_circuit_core/structs.rs
+++ b/circuits-lib/src/bridge_circuit_core/structs.rs
@@ -1,6 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use risc0_to_bitvm2_core::header_chain::BlockHeaderCircuitOutput;
-use risc0_to_bitvm2_core::spv::SPV;
+use final_spv::spv::SPV;
+use header_chain::header_chain::BlockHeaderCircuitOutput;
 use serde::{Deserialize, Serialize};
 
 use super::winternitz::WinternitzHandler;

--- a/risc0-circuits/bridge-circuit/guest/Cargo.lock
+++ b/risc0-circuits/bridge-circuit/guest/Cargo.lock
@@ -1182,6 +1182,8 @@ dependencies = [
  "borsh",
  "crypto-bigint",
  "derive_more 1.0.0",
+ "final-spv",
+ "header-chain",
  "hex",
  "hex-literal",
  "itertools 0.14.0",
@@ -1192,7 +1194,6 @@ dependencies = [
  "rand",
  "ripemd",
  "risc0-groth16",
- "risc0-to-bitvm2-core",
  "risc0-zkvm",
  "serde",
  "serde_json",
@@ -1609,6 +1610,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "final-spv"
+version = "0.1.0"
+source = "git+https://github.com/chainwayxyz/BitVM?rev=8508328#8508328d1823ea0c6675af6cb0168de1d1f0cdbc"
+dependencies = [
+ "bitcoin",
+ "blake3",
+ "borsh",
+ "crypto-bigint",
+ "header-chain",
+ "risc0-zkvm",
+ "serde",
+ "sha2",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,6 +1829,19 @@ dependencies = [
  "allocator-api2",
  "foldhash",
  "serde",
+]
+
+[[package]]
+name = "header-chain"
+version = "0.1.0"
+source = "git+https://github.com/chainwayxyz/BitVM?rev=8508328#8508328d1823ea0c6675af6cb0168de1d1f0cdbc"
+dependencies = [
+ "bitcoin",
+ "borsh",
+ "crypto-bigint",
+ "risc0-zkvm",
+ "serde",
+ "sha2",
 ]
 
 [[package]]
@@ -3094,19 +3123,6 @@ dependencies = [
  "risc0-zkp",
  "serde",
  "stability",
-]
-
-[[package]]
-name = "risc0-to-bitvm2-core"
-version = "1.0.0"
-source = "git+https://github.com/chainwayxyz/risc0-to-bitvm2.git?branch=main#932b7578508aa0f5964bbb30a8348c0d101f79fc"
-dependencies = [
- "bitcoin",
- "borsh",
- "crypto-bigint",
- "risc0-zkvm",
- "serde",
- "sha2",
 ]
 
 [[package]]

--- a/risc0-circuits/work-only/guest/Cargo.lock
+++ b/risc0-circuits/work-only/guest/Cargo.lock
@@ -1174,6 +1174,8 @@ dependencies = [
  "borsh",
  "crypto-bigint",
  "derive_more 1.0.0",
+ "final-spv",
+ "header-chain",
  "hex",
  "hex-literal",
  "itertools 0.14.0",
@@ -1184,7 +1186,6 @@ dependencies = [
  "rand",
  "ripemd",
  "risc0-groth16",
- "risc0-to-bitvm2-core",
  "risc0-zkvm",
  "serde",
  "serde_json",
@@ -1601,6 +1602,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "final-spv"
+version = "0.1.0"
+source = "git+https://github.com/chainwayxyz/BitVM?rev=8508328#8508328d1823ea0c6675af6cb0168de1d1f0cdbc"
+dependencies = [
+ "bitcoin",
+ "blake3",
+ "borsh",
+ "crypto-bigint",
+ "header-chain",
+ "risc0-zkvm",
+ "serde",
+ "sha2",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1821,19 @@ dependencies = [
  "allocator-api2",
  "foldhash",
  "serde",
+]
+
+[[package]]
+name = "header-chain"
+version = "0.1.0"
+source = "git+https://github.com/chainwayxyz/BitVM?rev=8508328#8508328d1823ea0c6675af6cb0168de1d1f0cdbc"
+dependencies = [
+ "bitcoin",
+ "borsh",
+ "crypto-bigint",
+ "risc0-zkvm",
+ "serde",
+ "sha2",
 ]
 
 [[package]]
@@ -3086,19 +3115,6 @@ dependencies = [
  "risc0-zkp",
  "serde",
  "stability",
-]
-
-[[package]]
-name = "risc0-to-bitvm2-core"
-version = "1.0.0"
-source = "git+https://github.com/chainwayxyz/risc0-to-bitvm2.git?branch=main#932b7578508aa0f5964bbb30a8348c0d101f79fc"
-dependencies = [
- "bitcoin",
- "borsh",
- "crypto-bigint",
- "risc0-zkvm",
- "serde",
- "sha2",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR replaces the **risc0-to-bitvm-core** dependency with **final-spv** and **header-chains** dependencies in the BitVM repository. The necessary structs are now imported from the newly added dependencies.