### PR TITLE
refactor(error): replace #[from] variants with wrap_err

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -17,6 +17,7 @@ use bitcoin::{
 };
 use bitcoin::{TapNodeHash, TapSighashType, Witness};
 use bitvm::signatures::winternitz::{self, BinarysearchVerifier, ToBytesConverter, Winternitz};
+use eyre::Context;
 
 #[derive(Debug, Clone)]
 pub enum WinternitzDerivationPath {
@@ -139,10 +140,14 @@ impl Actor {
     ) -> Result<schnorr::Signature, BridgeError> {
         Ok(bitvm_client::SECP.sign_schnorr(
             &Message::from_digest(*sighash.as_byte_array()),
-            &self.keypair.add_xonly_tweak(
-                &SECP,
-                &TapTweakHash::from_key_and_tweak(self.xonly_public_key, merkle_root).to_scalar(),
-            )?,
+            &self
+                .keypair
+                .add_xonly_tweak(
+                    &SECP,
+                    &TapTweakHash::from_key_and_tweak(self.xonly_public_key, merkle_root)
+                        .to_scalar(),
+                )
+                .wrap_err("Failed to add xonly tweak to keypair")?,
         ))
     }
 

--- a/core/src/bitcoin_syncer.rs
+++ b/core/src/bitcoin_syncer.rs
@@ -3,7 +3,6 @@
 //! This module provides common utilities to fetch Bitcoin state. Other modules
 //! can use this module to operate over Bitcoin.
 
-use eyre::Context;
 use crate::{
     config::protocol::ProtocolParamset,
     database::{Database, DatabaseTransaction},
@@ -13,6 +12,7 @@ use crate::{
 };
 use bitcoin::{block::Header, BlockHash, OutPoint};
 use bitcoincore_rpc::RpcApi;
+use eyre::Context;
 use std::time::Duration;
 use tonic::async_trait;
 
@@ -43,8 +43,16 @@ async fn fetch_block_info_from_height(
     rpc: &ExtendedRpc,
     height: u32,
 ) -> Result<BlockInfo, BridgeError> {
-    let hash = rpc.client.get_block_hash(height as u64).await.wrap_err("Failed to get block hash")?;
-    let header = rpc.client.get_block_header(&hash).await.wrap_err("Failed to get block header")?;
+    let hash = rpc
+        .client
+        .get_block_hash(height as u64)
+        .await
+        .wrap_err("Failed to get block hash")?;
+    let header = rpc
+        .client
+        .get_block_header(&hash)
+        .await
+        .wrap_err("Failed to get block header")?;
 
     Ok(BlockInfo {
         hash,
@@ -95,7 +103,11 @@ async fn _get_block_info_from_hash(
     rpc: &ExtendedRpc,
     hash: BlockHash,
 ) -> Result<(BlockInfo, Vec<Vec<OutPoint>>), BridgeError> {
-    let block = rpc.client.get_block(&hash).await.wrap_err("Failed to get block")?;
+    let block = rpc
+        .client
+        .get_block(&hash)
+        .await
+        .wrap_err("Failed to get block")?;
     let block_height = db
         .get_block_info_from_hash(Some(dbtx), hash)
         .await?
@@ -163,21 +175,34 @@ pub async fn set_initial_block_info_if_not_exists(
     }
 
     // TODO: save blocks starting from start_height in config paramset
-    let current_height = u32::try_from(rpc.client.get_block_count().await.wrap_err("Failed to get block count")?)
-        .map_err(|e| BridgeError::ConversionError(e.to_string()))?;
+    let current_height = u32::try_from(
+        rpc.client
+            .get_block_count()
+            .await
+            .wrap_err("Failed to get block count")?,
+    )
+    .map_err(|e| BridgeError::ConversionError(e.to_string()))?;
     let mut height = paramset.start_height;
     let mut dbtx = db.begin_transaction().await?;
     // first collect previous needed blocks according to paramset start height
     while height < current_height {
         let block_info = fetch_block_info_from_height(rpc, height).await?;
-        let block = rpc.client.get_block(&block_info.hash).await.wrap_err("Failed to get block")?;
+        let block = rpc
+            .client
+            .get_block(&block_info.hash)
+            .await
+            .wrap_err("Failed to get block")?;
         let block_id = save_block(db, &mut dbtx, &block, height).await?;
         db.add_event(Some(&mut dbtx), BitcoinSyncerEvent::NewBlock(block_id))
             .await?;
         height += 1;
     }
     let block_info = fetch_block_info_from_height(rpc, current_height).await?;
-    let block = rpc.client.get_block(&block_info.hash).await.wrap_err("Failed to get block")?;
+    let block = rpc
+        .client
+        .get_block(&block_info.hash)
+        .await
+        .wrap_err("Failed to get block")?;
 
     let block_id = save_block(db, &mut dbtx, &block, current_height).await?;
     db.add_event(Some(&mut dbtx), BitcoinSyncerEvent::NewBlock(block_id))
@@ -213,7 +238,11 @@ async fn fetch_new_blocks(
     tracing::debug!("New block hash: {:?}, height {}", block_hash, next_height);
 
     // Fetch its header.
-    let mut block_header = rpc.client.get_block_header(&block_hash).await.wrap_err("Failed to get block header")?;
+    let mut block_header = rpc
+        .client
+        .get_block_header(&block_hash)
+        .await
+        .wrap_err("Failed to get block header")?;
     let mut new_blocks = vec![BlockInfo {
         hash: block_hash,
         _header: block_header,
@@ -227,7 +256,11 @@ async fn fetch_new_blocks(
         .is_none()
     {
         let prev_block_hash = block_header.prev_blockhash;
-        block_header = rpc.client.get_block_header(&prev_block_hash).await.wrap_err("Failed to get block header")?;
+        block_header = rpc
+            .client
+            .get_block_header(&prev_block_hash)
+            .await
+            .wrap_err("Failed to get block header")?;
         let new_height = new_blocks.last().expect("new_blocks is empty").height - 1;
         new_blocks.push(BlockInfo {
             hash: prev_block_hash,
@@ -272,7 +305,11 @@ async fn process_new_blocks(
     new_blocks: &[BlockInfo],
 ) -> Result<(), BridgeError> {
     for block_info in new_blocks {
-        let block = rpc.client.get_block(&block_info.hash).await.wrap_err("Failed to get block")?;
+        let block = rpc
+            .client
+            .get_block(&block_info.hash)
+            .await
+            .wrap_err("Failed to get block")?;
 
         let block_id = save_block(db, dbtx, &block, block_info.height).await?;
         db.add_event(Some(dbtx), BitcoinSyncerEvent::NewBlock(block_id))

--- a/core/src/builder/address.rs
+++ b/core/src/builder/address.rs
@@ -14,6 +14,7 @@ use bitcoin::{
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, ScriptBuf,
 };
+use eyre::Context;
 
 pub fn taproot_builder_with_scripts(scripts: &[ScriptBuf]) -> TaprootBuilder {
     let builder = TaprootBuilder::new();
@@ -134,7 +135,8 @@ pub fn generate_deposit_address(
         .script_pubkey();
 
     let recovery_extracted_xonly_pk =
-        XOnlyPublicKey::from_slice(&recovery_script_pubkey.as_bytes()[2..34])?;
+        XOnlyPublicKey::from_slice(&recovery_script_pubkey.as_bytes()[2..34])
+            .wrap_err("Failed to extract xonly public key from recovery taproot address")?;
 
     let script_timelock =
         TimelockScript::new(Some(recovery_extracted_xonly_pk), user_takes_after).to_script_buf();

--- a/core/src/builder/transaction/mod.rs
+++ b/core/src/builder/transaction/mod.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use eyre::Context;
 use serde::{Deserialize, Serialize};
 
 use super::script::SpendPath;
@@ -325,7 +326,8 @@ pub fn create_move_to_vault_txhandler(
         .script_pubkey();
 
     let recovery_extracted_xonly_pk =
-        XOnlyPublicKey::from_slice(&recovery_script_pubkey.as_bytes()[2..34])?;
+        XOnlyPublicKey::from_slice(&recovery_script_pubkey.as_bytes()[2..34])
+            .wrap_err("Failed to extract xonly public key from recovery script pubkey")?;
 
     let script_timelock = Arc::new(TimelockScript::new(
         Some(recovery_extracted_xonly_pk),

--- a/core/src/database/tx_sender.rs
+++ b/core/src/database/tx_sender.rs
@@ -12,6 +12,7 @@ use bitcoin::{
     consensus::{deserialize, serialize},
     Amount, FeeRate, Transaction, Txid,
 };
+use eyre::{Context, OptionExt};
 use std::ops::DerefMut;
 // Add this at the top with other imports
 
@@ -50,7 +51,7 @@ impl Database {
             AND tap.seen_block_id IS NULL",
             common_ctes
         ))
-        .bind(i32::try_from(block_id)?)
+        .bind(i32::try_from(block_id).wrap_err("Failed to convert block id to i32")?)
         .execute(tx.deref_mut())
         .await?;
 
@@ -63,7 +64,7 @@ impl Database {
             AND tap.seen_block_id IS NULL",
             common_ctes
         ))
-        .bind(i32::try_from(block_id)?)
+        .bind(i32::try_from(block_id).wrap_err("Failed to convert block id to i32")?)
         .execute(tx.deref_mut())
         .await?;
 
@@ -76,7 +77,7 @@ impl Database {
             AND ctt.seen_block_id IS NULL",
             common_ctes
         ))
-        .bind(i32::try_from(block_id)?)
+        .bind(i32::try_from(block_id).wrap_err("Failed to convert block id to i32")?)
         .execute(tx.deref_mut())
         .await?;
 
@@ -89,7 +90,7 @@ impl Database {
             AND cto.seen_block_id IS NULL",
             common_ctes
         ))
-        .bind(i32::try_from(block_id)?)
+        .bind(i32::try_from(block_id).wrap_err("Failed to convert block id to i32")?)
         .execute(tx.deref_mut())
         .await?;
 
@@ -102,7 +103,7 @@ impl Database {
             AND fpu.seen_block_id IS NULL",
             common_ctes
         ))
-        .bind(i32::try_from(block_id)?)
+        .bind(i32::try_from(block_id).wrap_err("Failed to convert block id to i32")?)
         .execute(tx.deref_mut())
         .await?;
 
@@ -115,7 +116,7 @@ impl Database {
             AND txs.seen_block_id IS NULL",
             common_ctes
         ))
-        .bind(i32::try_from(block_id)?)
+        .bind(i32::try_from(block_id).wrap_err("Failed to convert block id to i32")?)
         .execute(tx.deref_mut())
         .await?;
 
@@ -128,7 +129,7 @@ impl Database {
             AND txs.seen_block_id IS NULL",
             common_ctes
         ))
-        .bind(i32::try_from(block_id)?)
+        .bind(i32::try_from(block_id).wrap_err("Failed to convert block id to i32")?)
         .execute(tx.deref_mut())
         .await?;
 
@@ -174,7 +175,7 @@ impl Database {
             WHERE txs.seen_block_id = $1;
             "#,
         )
-        .bind(i32::try_from(block_id)?)
+        .bind(i32::try_from(block_id).wrap_err("Failed to convert block id to i32")?)
         .execute(tx.deref_mut())
         .await?;
 
@@ -202,13 +203,11 @@ impl Database {
             "INSERT INTO tx_sender_fee_payer_utxos (bumped_id, fee_payer_txid, vout, amount, replacement_of_id)
              VALUES ($1, $2, $3, $4, $5)",
         )
-        .bind(i32::try_from(bumped_id)?)
+        .bind(i32::try_from(bumped_id).wrap_err("Failed to convert bumped id to i32")?)
         .bind(TxidDB(fee_payer_txid))
-        .bind(i32::try_from(vout)?)
-        .bind(i64::try_from(amount.to_sat())?)
-        .bind(replacement_of_id.map(|id| -> Result<i32, BridgeError> {
-            i32::try_from(id).map_err(|e| BridgeError::ConversionError(e.to_string()))
-        }).transpose()?);
+        .bind(i32::try_from(vout).wrap_err("Failed to convert vout to i32")?)
+        .bind(i64::try_from(amount.to_sat()).wrap_err("Failed to convert amount to i64")?)
+        .bind(replacement_of_id.map( i32::try_from).transpose().wrap_err("Failed to convert replacement of id to i32")?);
 
         execute_query_with_tx!(self.connection, tx, query, execute)?;
 
@@ -236,7 +235,7 @@ impl Database {
               )
             ",
         )
-        .bind(i32::try_from(bumped_id)?);
+        .bind(i32::try_from(bumped_id).wrap_err("Failed to convert bumped id to i32")?);
 
         let results: Vec<(i32, TxidDB, i32, i64)> =
             execute_query_with_tx!(self.connection, tx, query, fetch_all)?;
@@ -245,13 +244,11 @@ impl Database {
             .iter()
             .map(|(id, fee_payer_txid, vout, amount)| {
                 Ok((
-                    u32::try_from(*id).map_err(|e| BridgeError::ConversionError(e.to_string()))?,
+                    u32::try_from(*id).wrap_err("Failed to convert id to u32")?,
                     fee_payer_txid.0,
-                    u32::try_from(*vout)
-                        .map_err(|e| BridgeError::ConversionError(e.to_string()))?,
+                    u32::try_from(*vout).wrap_err("Failed to convert vout to u32")?,
                     Amount::from_sat(
-                        u64::try_from(*amount)
-                            .map_err(|e| BridgeError::ConversionError(e.to_string()))?,
+                        u64::try_from(*amount).wrap_err("Failed to convert amount to u64")?,
                     ),
                 ))
             })
@@ -268,7 +265,7 @@ impl Database {
              FROM tx_sender_fee_payer_utxos fpu
              WHERE fpu.bumped_id = $1 AND fpu.seen_block_id IS NOT NULL",
         )
-        .bind(i32::try_from(id)?);
+        .bind(i32::try_from(id).wrap_err("Failed to convert id to i32")?);
 
         let results: Vec<(TxidDB, i32, i64)> =
             execute_query_with_tx!(self.connection, tx, query, fetch_all)?;
@@ -278,11 +275,9 @@ impl Database {
             .map(|(fee_payer_txid, vout, amount)| {
                 Ok((
                     fee_payer_txid.0,
-                    u32::try_from(*vout)
-                        .map_err(|e| BridgeError::ConversionError(e.to_string()))?,
+                    u32::try_from(*vout).wrap_err("Failed to convert vout to u32")?,
                     Amount::from_sat(
-                        u64::try_from(*amount)
-                            .map_err(|e| BridgeError::ConversionError(e.to_string()))?,
+                        u64::try_from(*amount).wrap_err("Failed to convert amount to u64")?,
                     ),
                 ))
             })
@@ -302,11 +297,13 @@ impl Database {
         )
         .bind(serialize(raw_tx))
         .bind(fee_paying_type)
-        .bind(serde_json::to_string(&tx_data_for_logging).map_err(|e| BridgeError::ConversionError(e.to_string()))?)
+        .bind(serde_json::to_string(&tx_data_for_logging).wrap_err("Failed to encode tx_data_for_logging to JSON")?)
         .bind(TxidDB(txid));
 
         let id: i32 = execute_query_with_tx!(self.connection, tx, query, fetch_one)?;
-        u32::try_from(id).map_err(BridgeError::IntConversionError)
+        u32::try_from(id)
+            .wrap_err("Failed to convert id to u32")
+            .map_err(Into::into)
     }
 
     pub async fn save_rbf_txid(
@@ -316,7 +313,7 @@ impl Database {
         txid: Txid,
     ) -> Result<(), BridgeError> {
         let query = sqlx::query("INSERT INTO tx_sender_rbf_txids (id, txid) VALUES ($1, $2)")
-            .bind(i32::try_from(id)?)
+            .bind(i32::try_from(id).wrap_err("Failed to convert id to i32")?)
             .bind(TxidDB(txid));
 
         execute_query_with_tx!(self.connection, tx, query, execute)?;
@@ -329,7 +326,7 @@ impl Database {
         id: u32,
     ) -> Result<Option<Txid>, BridgeError> {
         let query = sqlx::query_as::<_, (TxidDB,)>("SELECT txid FROM tx_sender_rbf_txids WHERE id = $1 ORDER BY insertion_order DESC LIMIT 1")
-            .bind(i32::try_from(id)?);
+            .bind(i32::try_from(id).wrap_err("Failed to convert id to i32")?);
 
         let result: Option<(TxidDB,)> =
             execute_query_with_tx!(self.connection, tx, query, fetch_optional)?;
@@ -345,9 +342,9 @@ impl Database {
         let query = sqlx::query(
             "INSERT INTO tx_sender_cancel_try_to_send_outpoints (cancelled_id, txid, vout) VALUES ($1, $2, $3)"
         )
-        .bind(i32::try_from(cancelled_id)?)
+        .bind(i32::try_from(cancelled_id).wrap_err("Failed to convert cancelled id to i32")?)
         .bind(TxidDB(outpoint.txid))
-        .bind(i32::try_from(outpoint.vout)?);
+        .bind(i32::try_from(outpoint.vout).wrap_err("Failed to convert vout to i32")?);
 
         execute_query_with_tx!(self.connection, tx, query, execute)?;
         Ok(())
@@ -362,7 +359,7 @@ impl Database {
         let query = sqlx::query(
             "INSERT INTO tx_sender_cancel_try_to_send_txids (cancelled_id, txid) VALUES ($1, $2)",
         )
-        .bind(i32::try_from(cancelled_id)?)
+        .bind(i32::try_from(cancelled_id).wrap_err("Failed to convert cancelled id to i32")?)
         .bind(TxidDB(txid));
 
         execute_query_with_tx!(self.connection, tx, query, execute)?;
@@ -378,9 +375,9 @@ impl Database {
         let query = sqlx::query(
             "INSERT INTO tx_sender_activate_try_to_send_txids (activated_id, txid, timelock) VALUES ($1, $2, $3)"
         )
-        .bind(i32::try_from(activated_id)?)
+        .bind(i32::try_from(activated_id).wrap_err("Failed to convert activated id to i32")?)
         .bind(TxidDB(prerequisite_tx.txid))
-        .bind(i32::try_from(prerequisite_tx.relative_block_height)?);
+        .bind(i32::try_from(prerequisite_tx.relative_block_height).wrap_err("Failed to convert relative block height to i32")?);
 
         execute_query_with_tx!(self.connection, tx, query, execute)?;
         Ok(())
@@ -395,10 +392,10 @@ impl Database {
         let query = sqlx::query(
             "INSERT INTO tx_sender_activate_try_to_send_outpoints (activated_id, txid, vout, timelock) VALUES ($1, $2, $3, $4)"
         )
-        .bind(i32::try_from(activated_id)?)
+        .bind(i32::try_from(activated_id).wrap_err("Failed to convert activated id to i32")?)
         .bind(TxidDB(activated_outpoint.outpoint.txid))
-        .bind(i32::try_from(activated_outpoint.outpoint.vout)?)
-        .bind(i32::try_from(activated_outpoint.relative_block_height)?);
+        .bind(i32::try_from(activated_outpoint.outpoint.vout).wrap_err("Failed to convert vout to i32")?)
+        .bind(i32::try_from(activated_outpoint.relative_block_height).wrap_err("Failed to convert relative block height to i32")?);
 
         execute_query_with_tx!(self.connection, tx, query, execute)?;
         Ok(())
@@ -411,31 +408,31 @@ impl Database {
         current_tip_height: u32,
     ) -> Result<Vec<u32>, BridgeError> {
         let select_query = sqlx::query_as::<_, (i32,)>(
-            "WITH 
+            "WITH
                 -- Find non-active transactions (not seen or timelock not passed)
                 non_active_txs AS (
                     -- Transactions with txid activations that aren't active yet
                     SELECT DISTINCT
                         activate_txid.activated_id AS tx_id
-                    FROM 
+                    FROM
                         tx_sender_activate_try_to_send_txids AS activate_txid
-                    LEFT JOIN 
+                    LEFT JOIN
                         bitcoin_syncer AS syncer ON activate_txid.seen_block_id = syncer.id
-                    WHERE 
-                        activate_txid.seen_block_id IS NULL 
+                    WHERE
+                        activate_txid.seen_block_id IS NULL
                         OR (syncer.height + activate_txid.timelock > $2)
-                    
+
                     UNION
-                    
+
                     -- Transactions with outpoint activations that aren't active yet
                     SELECT DISTINCT
                         activate_outpoint.activated_id AS tx_id
-                    FROM 
+                    FROM
                         tx_sender_activate_try_to_send_outpoints AS activate_outpoint
-                    LEFT JOIN 
+                    LEFT JOIN
                         bitcoin_syncer AS syncer ON activate_outpoint.seen_block_id = syncer.id
-                    WHERE 
-                        activate_outpoint.seen_block_id IS NULL 
+                    WHERE
+                        activate_outpoint.seen_block_id IS NULL
                         OR (syncer.height + activate_outpoint.timelock > $2)
                 ),
 
@@ -444,28 +441,28 @@ impl Database {
                     -- Transactions with cancelled outpoints
                     SELECT DISTINCT
                         cancelled_id AS tx_id
-                    FROM 
+                    FROM
                         tx_sender_cancel_try_to_send_outpoints
-                    WHERE 
+                    WHERE
                         seen_block_id IS NOT NULL
-                    
+
                     UNION
-                    
+
                     -- Transactions with cancelled txids
                     SELECT DISTINCT
                         cancelled_id AS tx_id
-                    FROM 
+                    FROM
                         tx_sender_cancel_try_to_send_txids
-                    WHERE 
+                    WHERE
                         seen_block_id IS NOT NULL
                 )
 
                 -- Final query to get sendable transactions
-                SELECT 
+                SELECT
                     txs.id
-                FROM 
+                FROM
                     tx_sender_try_to_send_txs AS txs
-                WHERE 
+                WHERE
                     -- Transaction must not be in the non-active list
                     txs.id NOT IN (SELECT tx_id FROM non_active_txs)
                     -- Transaction must not be in the cancelled list
@@ -475,17 +472,22 @@ impl Database {
                     -- Check if fee_rate is lower than the provided fee rate or null
                     AND (txs.effective_fee_rate IS NULL OR txs.effective_fee_rate < $1);",
         )
-        .bind(i64::try_from(fee_rate.to_sat_per_vb_ceil())?)
-        .bind(i32::try_from(current_tip_height)?);
+        .bind(
+            i64::try_from(fee_rate.to_sat_per_vb_ceil())
+                .wrap_err("Failed to convert fee rate to i64")?,
+        )
+        .bind(
+            i32::try_from(current_tip_height)
+                .wrap_err("Failed to convert current tip height to i32")?,
+        );
 
         let results = execute_query_with_tx!(self.connection, tx, select_query, fetch_all)?;
 
         let txs = results
             .into_iter()
-            .map(|(id,)| -> Result<u32, BridgeError> {
-                u32::try_from(id).map_err(|e| BridgeError::ConversionError(e.to_string()))
-            })
-            .collect::<Result<Vec<_>, BridgeError>>()?;
+            .map(|(id,)| u32::try_from(id))
+            .collect::<Result<Vec<_>, _>>()
+            .wrap_err("Failed to convert id to u32")?;
 
         Ok(txs)
     }
@@ -499,8 +501,11 @@ impl Database {
         let query = sqlx::query(
             "UPDATE tx_sender_try_to_send_txs SET effective_fee_rate = $1 WHERE id = $2",
         )
-        .bind(i64::try_from(effective_fee_rate.to_sat_per_vb_ceil())?)
-        .bind(i32::try_from(id)?);
+        .bind(
+            i64::try_from(effective_fee_rate.to_sat_per_vb_ceil())
+                .wrap_err("Failed to convert effective fee rate to i64")?,
+        )
+        .bind(i32::try_from(id).wrap_err("Failed to convert id to i32")?);
 
         execute_query_with_tx!(self.connection, tx, query, execute)?;
 
@@ -526,23 +531,28 @@ impl Database {
              FROM tx_sender_try_to_send_txs
              WHERE id = $1 LIMIT 1",
             )
-            .bind(i32::try_from(id)?);
+            .bind(i32::try_from(id).wrap_err("Failed to convert id to i32")?);
 
         let result = execute_query_with_tx!(self.connection, tx, query, fetch_one)?;
         Ok((
             result
                 .0
-                .map(|s| serde_json::from_str(&s))
+                .as_deref()
+                .map(serde_json::from_str)
                 .transpose()
-                .map_err(|e| BridgeError::ConversionError(e.to_string()))?
-                .ok_or_else(|| BridgeError::ConversionError("TxDataForLogging".to_string()))?,
-            deserialize(&result.1.unwrap_or_default())
-                .map_err(|e| BridgeError::Error(format!("Bitcoin deserialization error: {}", e)))?,
+                .wrap_err("Failed to decode tx_data_for_logging")?,
+            result
+                .1
+                .as_deref()
+                .map(deserialize)
+                .ok_or_eyre("Expected raw_tx to be present")?
+                .wrap_err("Failed to deserialize raw_tx")?,
             result.2,
             result
                 .3
-                .map(|id| u32::try_from(id).map_err(BridgeError::IntConversionError))
-                .transpose()?,
+                .map(u32::try_from)
+                .transpose()
+                .wrap_err("Failed to convert seen_block_id to u32")?,
         ))
     }
 }

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -4,7 +4,7 @@
 
 use crate::builder::transaction::TransactionType;
 use bitcoin::{
-    consensus::encode::FromHexError, merkle_tree::MerkleBlockError, BlockHash, FeeRate, OutPoint,
+    consensus::encode::FromHexError, BlockHash, FeeRate, OutPoint,
     Txid,
 };
 use core::fmt::Debug;
@@ -17,20 +17,6 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum BridgeError {
-    /// Returned when the bitcoin::secp256k1 crate returns an error
-    #[error("Secpk256Error: {0}")]
-    BitcoinSecp256k1Error(#[from] bitcoin::secp256k1::Error),
-    /// Returned when the bitcoin crate returns an error in the sighash taproot module
-    #[error("BitcoinSighashTaprootError: {0}")]
-    BitcoinSighashTaprootError(#[from] bitcoin::sighash::TaprootError),
-    #[error("Invalid bitcoin block hash: {0}")]
-    BitcoinBlockHashInvalid(#[from] bitcoin::hex::HexToArrayError),
-
-    #[error("Secp256k1 returned an error: {0}")]
-    Secp256k1Error(#[from] secp256k1::Error),
-    #[error("Scalar can't be build: {0}")]
-    Secp256k1ScalarOutOfRange(#[from] secp256k1::scalar::OutOfRangeError),
-
     /// Returned when a non finalized deposit request is found
     #[error("DepositNotFinalized")]
     DepositNotFinalized,
@@ -49,9 +35,6 @@ pub enum BridgeError {
     /// Returned when there are unconfirmed fee payer UTXOs left
     #[error("UnconfirmedFeePayerUTXOsLeft")]
     UnconfirmedFeePayerUTXOsLeft,
-    /// Returned in RPC error
-    #[error("BitcoinCoreRPCError: {0}")]
-    BitcoinRpcError(#[from] bitcoincore_rpc::Error),
     /// Returned if there is no confirmation data
     #[error("NoConfirmationData")]
     NoConfirmationData,
@@ -61,9 +44,6 @@ pub enum BridgeError {
     /// For TryFromSliceError
     #[error("TryFromSliceError")]
     TryFromSliceError,
-    /// Returned when bitcoin::Transaction error happens, also returns the error
-    #[error("BitcoinTransactionError: {0}")]
-    BitcoinConsensusEncodeError(#[from] bitcoin::consensus::encode::Error),
     /// TxInputNotFound is returned when the input is not found in the transaction
     #[error("TxInputNotFound")]
     TxInputNotFound,
@@ -103,15 +83,10 @@ pub enum BridgeError {
     /// Block not found
     #[error("Block not found")]
     BlockNotFound,
-    /// Merkle Block Error
-    #[error("MerkleBlockError: {0}")]
-    MerkleBlockError(#[from] MerkleBlockError),
     /// Merkle Proof Error
     #[error("MerkleProofError")]
     MerkleProofError,
 
-    #[error("JsonRpcError: {0}")]
-    JsonRpcError(#[from] jsonrpsee::core::client::Error),
     #[error("RPC function field {0} is required!")]
     RPCRequiredParam(&'static str),
     #[error("RPC function parameter {0} is malformed: {1}")]
@@ -120,16 +95,11 @@ pub enum BridgeError {
     RPCStreamEndedUnexpectedly(String),
     #[error("Invalid response from an RPC endpoint: {0}")]
     RPCInvalidResponse(String),
-    #[error("RPCBroadcastRecvError: {0}")]
-    RPCBroadcastRecvError(#[from] tokio::sync::broadcast::error::RecvError),
     #[error("RPCBroadcastSendError: {0}")]
     RPCBroadcastSendError(String),
     /// ConfigError is returned when the configuration is invalid
     #[error("ConfigError: {0}")]
     ConfigError(String),
-    /// Bitcoin Address Parse Error, probably given address network is invalid
-    #[error("BitcoinAddressParseError: {0}")]
-    BitcoinAddressParseError(#[from] bitcoin::address::ParseError),
     /// Port error for tests
     #[error("PortError: {0}")]
     PortError(String),
@@ -234,16 +204,8 @@ pub enum BridgeError {
     #[error("ConversionError: {0}")]
     ConversionError(String),
 
-    #[error("IntConversionError: {0}")]
-    IntConversionError(#[from] std::num::TryFromIntError),
-
     #[error("ERROR: {0}")]
     Error(String),
-
-    #[error("RPC endpoint returned an error: {0}")]
-    TonicError(#[from] tonic::Status),
-    #[error("RPC client couldn't start: {0}")]
-    RPCClientCouldntStart(#[from] tonic::transport::Error),
 
     #[error("No root Winternitz secret key is provided in configuration file")]
     NoWinternitzSecretKey,
@@ -353,13 +315,6 @@ pub enum BridgeError {
 
     #[error("Eyre error: {0}")]
     Eyre(#[from] eyre::Report),
-
-    #[error("Error while calling EVM contract: {0}")]
-    AlloyContract(#[from] alloy::contract::Error),
-    #[error("Error while calling EVM RPC function: {0}")]
-    AlloyRpc(#[from] alloy::transports::RpcError<alloy::transports::TransportErrorKind>),
-    #[error("Error while encoding/decoding EVM type: {0}")]
-    AlloySolTypes(#[from] alloy::sol_types::Error),
 
     #[error("Transaction is already in block: {0}")]
     TransactionAlreadyInBlock(BlockHash),

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -3,10 +3,7 @@
 //! This module defines errors, returned by the library.
 
 use crate::builder::transaction::TransactionType;
-use bitcoin::{
-    consensus::encode::FromHexError, BlockHash, FeeRate, OutPoint,
-    Txid,
-};
+use bitcoin::{consensus::encode::FromHexError, BlockHash, FeeRate, OutPoint, Txid};
 use core::fmt::Debug;
 use jsonrpsee::types::ErrorObject;
 use secp256k1::musig;

--- a/core/src/extended_rpc.rs
+++ b/core/src/extended_rpc.rs
@@ -223,7 +223,8 @@ impl ExtendedRpc {
                     .expect("Blockhash should be present"),
             ));
         }
-        let tx = transaction_info.transaction()
+        let tx = transaction_info
+            .transaction()
             .wrap_err("Failed to get transaction")?;
         let tx_size = tx.weight().to_vbytes_ceil();
         let current_fee_sat = u64::try_from(

--- a/core/src/header_chain_prover/mod.rs
+++ b/core/src/header_chain_prover/mod.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use bitcoin::{hashes::Hash, BlockHash};
 use bitcoincore_rpc::RpcApi;
+use eyre::Context;
 use risc0_to_bitvm2_core::header_chain::BlockHeaderCircuitOutput;
 use risc0_zkvm::Receipt;
 use std::{
@@ -48,7 +49,7 @@ impl HeaderChainProver {
             let block_hash = BlockHash::from_raw_hash(Hash::from_slice(
                 &proof_output.chain_state.best_block_hash,
             )?);
-            let block_header = rpc.client.get_block_header(&block_hash).await?;
+            let block_header = rpc.client.get_block_header(&block_hash).await.wrap_err("Failed to get block header")?;
             // Ignore error if block entry is in database already.
             let _ = db
                 .set_new_block(

--- a/core/src/header_chain_prover/mod.rs
+++ b/core/src/header_chain_prover/mod.rs
@@ -49,7 +49,11 @@ impl HeaderChainProver {
             let block_hash = BlockHash::from_raw_hash(Hash::from_slice(
                 &proof_output.chain_state.best_block_hash,
             )?);
-            let block_header = rpc.client.get_block_header(&block_hash).await.wrap_err("Failed to get block header")?;
+            let block_header = rpc
+                .client
+                .get_block_header(&block_hash)
+                .await
+                .wrap_err("Failed to get block header")?;
             // Ignore error if block entry is in database already.
             let _ = db
                 .set_new_block(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod watchtower;
 #[cfg(test)]
 pub mod test;
 
+
 macro_rules! impl_try_from_vec_u8 {
     ($name:ident, $size:expr) => {
         impl TryFrom<Vec<u8>> for $name {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,7 +35,6 @@ pub mod watchtower;
 #[cfg(test)]
 pub mod test;
 
-
 macro_rules! impl_try_from_vec_u8 {
     ($name:ident, $size:expr) => {
         impl TryFrom<Vec<u8>> for $name {

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -10,7 +10,6 @@ use crate::config::BridgeConfig;
 use crate::rpc::clementine::clementine_operator_client::ClementineOperatorClient;
 use crate::rpc::clementine::clementine_verifier_client::ClementineVerifierClient;
 use crate::rpc::clementine::VerifierDepositSignParams;
-use crate::rpc::error::output_stream_ended_prematurely;
 use crate::rpc::parser;
 use crate::tx_sender::{FeePayingType, TxDataForLogging};
 use crate::{
@@ -24,6 +23,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::schnorr::Signature;
 use bitcoin::secp256k1::{Message, PublicKey};
 use bitcoin::TapSighash;
+use eyre::{Context, OptionExt};
 use futures::{
     future::try_join_all,
     stream::{BoxStream, TryStreamExt},
@@ -43,6 +43,16 @@ struct FinalSigQueueItem {
     final_sig: Vec<u8>,
 }
 
+#[derive(Debug, thiserror::Error)]
+enum AggregatorError {
+    #[error("Failed to receive from {stream_name} stream.")]
+    InputStreamEndedEarlyUnknownSize { stream_name: String },
+    #[error("Failed to send to {stream_name} stream.")]
+    OutputStreamEndedEarly { stream_name: String },
+    #[error("Failed to send request to {request_name} stream.")]
+    RequestFailed { request_name: String },
+}
+
 /// For each expected sighash, we collect a batch of public nonces from all verifiers. We aggregate and send to the agg_nonce_sender. Then repeat for the next sighash.
 async fn nonce_aggregator(
     mut nonce_streams: Vec<
@@ -55,46 +65,53 @@ async fn nonce_aggregator(
     agg_nonce_sender: Sender<AggNonceQueueItem>,
 ) -> Result<MusigAggNonce, BridgeError> {
     let mut total_sigs = 0;
+
     tracing::info!("Starting nonce aggregation");
+
+    // We assume the sighash stream returns the correct number of items.
     while let Some(msg) = sighash_stream.next().await {
-        let sighash = msg
-            .map_err(|e| {
-                tracing::error!("Error when reading from sighash stream: {}", e);
-                BridgeError::RPCStreamEndedUnexpectedly("Sighash stream ended unexpectedly".into())
-            })?
-            .0;
+        let (sighash, siginfo) = msg.wrap_err("Sighash stream failed")?;
 
         total_sigs += 1;
 
         let pub_nonces = try_join_all(nonce_streams.iter_mut().enumerate().map(
             |(i, s)| async move {
-                s.next().await.ok_or_else(|| {
-                    BridgeError::RPCStreamEndedUnexpectedly(format!(
-                        "Not enough nonces from verifier {i}",
-                    ))
-                })?
+                s.next()
+                    .await
+                    .transpose()? // Return the inner error if it exists
+                    .ok_or_else(|| -> eyre::Report {
+                        AggregatorError::InputStreamEndedEarlyUnknownSize {
+                            // Return an early end error if the stream is empty
+                            stream_name: format!("Nonce stream {i}"),
+                        }
+                        .into()
+                    })
             },
         ))
-        .await?;
+        .await
+        .wrap_err_with(|| {
+            format!("Failed to aggregate nonces for sighash with info: {siginfo:?}")
+        })?;
 
         tracing::debug!(
-            "Received nonces for sighash {} in nonce_aggregator",
-            total_sigs
+            "Received nonces for signature id {:?} in nonce_aggregator",
+            siginfo.signature_id
         );
 
+        // TODO: consider spawn_blocking here
         let agg_nonce = aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice());
 
         agg_nonce_sender
             .send(AggNonceQueueItem { agg_nonce, sighash })
             .await
-            .map_err(|e| {
-                BridgeError::RPCStreamEndedUnexpectedly(format!(
-                    "Can't send aggregated nonces: {}",
-                    e
-                ))
+            .wrap_err_with(|| AggregatorError::OutputStreamEndedEarly {
+                stream_name: "nonce_aggregator".to_string(),
             })?;
 
-        tracing::debug!("Sent nonces for sighash {} in nonce_aggregator", total_sigs);
+        tracing::debug!(
+            "Sent nonces for signature id {:?} in nonce_aggregator",
+            siginfo.signature_id
+        );
     }
 
     if total_sigs == 0 {
@@ -102,16 +119,23 @@ async fn nonce_aggregator(
     }
     // Finally, aggregate nonces for the movetx signature
     let pub_nonces = try_join_all(nonce_streams.iter_mut().map(|s| async {
-        s.next().await.ok_or_else(|| {
-            BridgeError::RPCStreamEndedUnexpectedly(
-                "Not enough nonces (expected movetx nonce)".into(),
-            )
-        })?
+        s.next()
+            .await
+            .transpose()? // Return the inner error if it exists
+            .ok_or_else(|| -> eyre::Report {
+                AggregatorError::InputStreamEndedEarlyUnknownSize {
+                    // Return an early end error if the stream is empty
+                    stream_name: "Nonce stream".to_string(),
+                }
+                .into()
+            })
     }))
-    .await?;
+    .await
+    .wrap_err("Failed to aggregate nonces for the move tx")?;
 
     tracing::debug!("Received nonces for movetx in nonce_aggregator");
 
+    // TODO: consider spawn_blocking here
     let agg_nonce = aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice());
 
     Ok(agg_nonce)
@@ -129,6 +153,7 @@ async fn nonce_distributor(
     let mut sig_count = 0;
     while let Some(queue_item) = agg_nonce_receiver.recv().await {
         sig_count += 1;
+
         tracing::debug!(
             "Received aggregated nonce {} in nonce_distributor",
             sig_count
@@ -140,28 +165,45 @@ async fn nonce_distributor(
             )),
         };
 
-        for (_, tx) in partial_sig_streams.iter_mut() {
-            tx.send(agg_nonce_wrapped.clone()).await.map_err(|e| {
-                BridgeError::RPCStreamEndedUnexpectedly(format!(
-                    "Can't send aggregated nonces: {}",
-                    e
-                ))
-            })?;
-        }
+        // Broadcast aggregated nonce to all streams
+        try_join_all(
+            partial_sig_streams
+                .iter_mut()
+                .enumerate()
+                .map(|(idx, (_, tx))| {
+                    let agg_nonce_wrapped = agg_nonce_wrapped.clone();
+                    async move {
+                        tx.send(agg_nonce_wrapped).await.wrap_err_with(|| {
+                            AggregatorError::OutputStreamEndedEarly {
+                                stream_name: format!("Partial sig stream {idx}"),
+                            }
+                        })
+                    }
+                }),
+        )
+        .await
+        .wrap_err("Failed to send aggregated nonces to verifiers")?;
 
         tracing::debug!(
             "Sent aggregated nonce {} to verifiers in nonce_distributor",
             sig_count
         );
 
-        let partial_sigs = try_join_all(partial_sig_streams.iter_mut().map(|(stream, _)| async {
-            let partial_sig = stream
-                .message()
-                .await?
-                .ok_or(BridgeError::Error("No partial sig received".into()))?;
+        let partial_sigs = try_join_all(partial_sig_streams.iter_mut().enumerate().map(
+            |(idx, (stream, _))| async move {
+                let partial_sig = stream
+                    .message()
+                    .await
+                    .wrap_err_with(|| AggregatorError::RequestFailed {
+                        request_name: format!("Partial sig stream {idx}"),
+                    })?
+                    .ok_or_eyre(AggregatorError::InputStreamEndedEarlyUnknownSize {
+                        stream_name: format!("Partial sig stream {idx}"),
+                    })?;
 
-            Ok::<_, BridgeError>(MusigPartialSignature::from_slice(&partial_sig.partial_sig)?)
-        }))
+                Ok::<_, BridgeError>(MusigPartialSignature::from_slice(&partial_sig.partial_sig)?)
+            },
+        ))
         .await?;
 
         tracing::debug!(
@@ -239,19 +281,32 @@ async fn signature_distributor(
             params: Some(Params::SchnorrSig(queue_item.final_sig)),
         };
 
-        for tx in &deposit_finalize_sender {
-            tx.send(final_params.clone())
-                .await
-                .map_err(output_stream_ended_prematurely)?;
-        }
+        // TODO: consider the waiting of each verifier here.
+        try_join_all(deposit_finalize_sender.iter().map(|tx| {
+            let final_params = final_params.clone();
+            async move {
+                tx.send(final_params).await.wrap_err_with(|| {
+                    AggregatorError::OutputStreamEndedEarly {
+                        stream_name: "Deposit finalize sender".to_string(),
+                    }
+                })
+            }
+        }))
+        .await
+        .wrap_err("Failed to send final signatures to verifiers")?;
+
         tracing::debug!(
             "Sent signature {} to verifiers in signature_distributor",
             sig_count
         );
     }
 
-    let movetx_agg_nonce = movetx_agg_nonce.await?;
+    let movetx_agg_nonce = movetx_agg_nonce
+        .await
+        .wrap_err("Failed to get movetx aggregated nonce")?;
+
     tracing::debug!("Got movetx aggregated nonce in signature distributor");
+
     // Send the movetx agg nonce to the verifiers.
     for tx in &deposit_finalize_sender {
         tx.send(VerifierDepositFinalizeParams {
@@ -260,7 +315,9 @@ async fn signature_distributor(
             )),
         })
         .await
-        .map_err(output_stream_ended_prematurely)?
+        .wrap_err_with(|| AggregatorError::OutputStreamEndedEarly {
+            stream_name: "Deposit finalize sender (for movetx agg nonce)".to_string(),
+        })?;
     }
     tracing::debug!("Sent movetx aggregated nonce to verifiers in signature distributor");
 
@@ -284,33 +341,54 @@ async fn create_nonce_streams(
     ),
     BridgeError,
 > {
-    let mut nonce_streams = try_join_all(verifier_clients.into_iter().map(|client| {
-        let mut client = client.clone();
+    let mut nonce_streams = try_join_all(verifier_clients.into_iter().enumerate().map(
+        |(idx, client)| {
+            let mut client = client.clone();
 
-        async move {
-            let response_stream = client
-                .nonce_gen(tonic::Request::new(clementine::NonceGenRequest {
-                    num_nonces,
-                }))
-                .await?;
+            async move {
+                let response_stream = client
+                    .nonce_gen(tonic::Request::new(clementine::NonceGenRequest {
+                        num_nonces,
+                    }))
+                    .await
+                    .wrap_err_with(|| AggregatorError::RequestFailed {
+                        request_name: format!("Nonce gen stream for verifier {idx}"),
+                    })?;
 
-            Ok::<_, Status>(response_stream.into_inner())
-        }
-    }))
+                Ok::<_, BridgeError>(response_stream.into_inner())
+            }
+        },
+    ))
     .await?;
 
     // Get the first responses from verifiers.
-    let first_responses: Vec<clementine::NonceGenFirstResponse> =
-        try_join_all(nonce_streams.iter_mut().map(|stream| async {
-            parser::verifier::parse_nonce_gen_first_response(stream).await
-        }))
-        .await?;
+    let first_responses: Vec<clementine::NonceGenFirstResponse> = try_join_all(
+        nonce_streams
+            .iter_mut()
+            .enumerate()
+            .map(|(idx, stream)| async move {
+                parser::verifier::parse_nonce_gen_first_response(stream)
+                    .await
+                    .wrap_err_with(|| format!("Failed to get initial response from verifier {idx}"))
+            }),
+    )
+    .await
+    .wrap_err("Failed to get nonce gen's initial responses from verifiers")?;
 
     let transformed_streams = nonce_streams
         .into_iter()
-        .map(|stream| {
+        .enumerate()
+        .map(|(idx, stream)| {
             stream
-                .map(|result| Aggregator::extract_pub_nonce(result?.response))
+                .map(move |result| {
+                    Aggregator::extract_pub_nonce(
+                        result
+                            .wrap_err_with(|| AggregatorError::InputStreamEndedEarlyUnknownSize {
+                                stream_name: format!("Nonce gen stream for verifier {idx}"),
+                            })?
+                            .response,
+                    )
+                })
                 .boxed()
         })
         .collect::<Vec<_>>();
@@ -365,8 +443,8 @@ impl Aggregator {
         }
     }
 
-    /// For a specific deposit, gets needed signatures from each operator and returns a Vec with signatures from each operator
-    async fn get_operator_sigs(
+    /// For a specific deposit, collects needed signatures from all operators into a [`Vec<Vec<Signature>>`].
+    async fn collect_operator_sigs(
         operator_clients: Vec<ClementineOperatorClient<tonic::transport::Channel>>,
         config: BridgeConfig,
         mut deposit_sign_session: DepositSignSession,
@@ -374,36 +452,53 @@ impl Aggregator {
         deposit_sign_session.nonce_gen_first_responses = Vec::new(); // not needed for operators
         let mut operator_sigs_streams =
             // create deposit sign streams with each operator
-            try_join_all(operator_clients.into_iter().map(|mut operator_client| {
+            try_join_all(operator_clients.into_iter().enumerate().map(|(idx, mut operator_client)| {
                 let sign_session = deposit_sign_session.clone();
                 async move {
                     let stream = operator_client
                         .deposit_sign(tonic::Request::new(sign_session))
-                        .await?;
-                    Ok::<_, Status>(stream.into_inner())
+                        .await.wrap_err_with(|| AggregatorError::RequestFailed {
+                            request_name: format!("Deposit sign stream for operator {idx}"),
+                        })?;
+                    Ok::<_, BridgeError>(stream.into_inner())
                 }
             }))
                 .await?;
+
         // calculate number of signatures needed from each operator
         let needed_sigs = config.get_num_required_operator_sigs();
+
         // get signatures from each operator's signature streams
-        let operator_sigs = try_join_all(operator_sigs_streams.iter_mut().map(|stream| async {
-            let mut sigs: Vec<Signature> = Vec::with_capacity(needed_sigs);
-            while let Some(sig) = stream.message().await? {
-                sigs.push(Signature::from_slice(&sig.schnorr_sig)?);
-            }
-            Ok::<_, BridgeError>(sigs)
-        }))
+        let operator_sigs = try_join_all(operator_sigs_streams.iter_mut().enumerate().map(
+            |(idx, stream)| async move {
+                let mut sigs: Vec<Signature> = Vec::with_capacity(needed_sigs);
+                while let Some(sig) =
+                    stream
+                        .message()
+                        .await
+                        .wrap_err_with(|| AggregatorError::RequestFailed {
+                            request_name: format!("Deposit sign stream for operator {idx}"),
+                        })?
+                {
+                    sigs.push(Signature::from_slice(&sig.schnorr_sig).wrap_err_with(|| {
+                        format!("Failed to parse Schnorr signature from operator {idx}")
+                    })?);
+                }
+                Ok::<_, BridgeError>(sigs)
+            },
+        ))
         .await?;
+
         // check if all signatures are received
         for (idx, sigs) in operator_sigs.iter().enumerate() {
             if sigs.len() != needed_sigs {
-                return Err(BridgeError::Error(format!(
-                    "Not all operator sigs received from op: {}.\n Expected: {}, got: {}",
+                return Err(eyre::eyre!(
+                    "Not all operator sigs received from operator {}.\n Expected: {}, got: {}",
                     idx,
                     needed_sigs,
                     sigs.len()
-                )));
+                )
+                .into());
             }
         }
         Ok(operator_sigs)
@@ -793,7 +888,7 @@ impl ClementineAggregator for Aggregator {
 
         tracing::debug!("Getting signatures from operators");
         // Get sigs from each operator in background
-        let operator_sigs_fut = tokio::spawn(Aggregator::get_operator_sigs(
+        let operator_sigs_fut = tokio::spawn(Aggregator::collect_operator_sigs(
             self.operator_clients.clone(),
             self.config.clone(),
             deposit_sign_session,

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -12,6 +12,7 @@ use crate::verifier::VerifierServer;
 use crate::watchtower::Watchtower;
 use crate::{config::BridgeConfig, errors};
 use errors::BridgeError;
+use eyre::Context;
 use std::thread;
 use tokio::sync::oneshot;
 use tonic::server::NamedService;
@@ -142,7 +143,8 @@ pub async fn create_verifier_grpc_server(
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
     )
-    .await?;
+    .await
+    .wrap_err("Failed to connect to Bitcoin RPC")?;
 
     let addr: std::net::SocketAddr = format!("{}:{}", config.host, config.port).parse()?;
     let verifier = VerifierServer::new(config).await?;
@@ -218,7 +220,8 @@ pub async fn create_verifier_unix_server(
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
     )
-    .await?;
+    .await
+    .wrap_err("Failed to connect to Bitcoin RPC")?;
 
     let verifier = VerifierServer::new(config).await?;
     let svc = ClementineVerifierServer::new(verifier);
@@ -252,7 +255,8 @@ pub async fn create_operator_unix_server(
         config.bitcoin_rpc_user.clone(),
         config.bitcoin_rpc_password.clone(),
     )
-    .await?;
+    .await
+    .wrap_err("Failed to connect to Bitcoin RPC")?;
 
     let operator = OperatorServer::new(config).await?;
     let svc = ClementineOperatorServer::new(operator);

--- a/core/src/test/full_flow.rs
+++ b/core/src/test/full_flow.rs
@@ -7,7 +7,7 @@ use crate::database::Database;
 use crate::extended_rpc::ExtendedRpc;
 use crate::musig2::AggregateFromPublicKeys;
 use crate::rpc::clementine::{
-    DepositParams, Empty, FinalizedPayoutParams, KickoffId, TransactionRequest,
+    AssertRequest, DepositParams, Empty, FinalizedPayoutParams, KickoffId, TransactionRequest,
 };
 use crate::test::common::*;
 use crate::tx_sender::{FeePayingType, TxDataForLogging, TxSenderClient};
@@ -676,26 +676,32 @@ pub async fn run_happy_path_2(config: &mut BridgeConfig, rpc: ExtendedRpc) -> Re
 
     // 10. Send Assert Transactions
     // TODO: Add assert transactions
-    // let assert_txs = operators[0]
-    //     .internal_create_assert_commitment_txs(AssertRequest {
-    //         deposit_params: Some(dep_params.clone()),
-    //         kickoff_id: Some(KickoffId {
-    //             operator_idx: 0,
-    //             round_idx: 0,
-    //             kickoff_idx: 0,
-    //         }),
-    //     })
-    //     .await?
-    //     .into_inner();
-    // for (assert_idx, tx) in assert_txs.raw_txs.iter().enumerate() {
-    //     tracing::info!("Sending mini assert transaction {}", assert_idx);
-    //      send_tx(&tx_sender, &tx_sender_db, &rpc, &tx.raw_tx)
-    //         .await
-    //         .context(format!(
-    //             "failed to send mini assert transaction {}",
-    //             assert_idx
-    //         ))?;
-    // }
+    let assert_txs = operators[0]
+        .internal_create_assert_commitment_txs(AssertRequest {
+            deposit_params: Some(dep_params.clone()),
+            kickoff_id: Some(KickoffId {
+                operator_idx: 0,
+                round_idx: 0,
+                kickoff_idx,
+            }),
+        })
+        .await?
+        .into_inner();
+    for (assert_idx, tx) in assert_txs.signed_txs.iter().enumerate() {
+        tracing::info!("Sending mini assert transaction {}", assert_idx);
+        send_tx(
+            &tx_sender,
+            &tx_sender_db,
+            &rpc,
+            tx.raw_tx.as_slice(),
+            TransactionType::MiniAssert(assert_idx),
+        )
+        .await
+        .context(format!(
+            "failed to send mini assert transaction {}",
+            assert_idx
+        ))?;
+    }
 
     rpc.mine_blocks(BLOCKS_PER_DAY * 5).await?;
     // 11. Send Disprove Timeout Transaction
@@ -742,7 +748,7 @@ pub async fn run_happy_path_2(config: &mut BridgeConfig, rpc: ExtendedRpc) -> Re
             kickoff_id: Some(KickoffId {
                 operator_idx: 0,
                 round_idx: 1,
-                kickoff_idx: 0,
+                kickoff_idx,
             }),
             ..base_tx_req.clone()
         })

--- a/core/src/tx_sender.rs
+++ b/core/src/tx_sender.rs
@@ -497,7 +497,12 @@ impl TxSender {
                         .hex,
                 )
                 .wrap_err("Failed to deserialize signed transaction")?;
-                let txid = self.rpc.client.send_raw_transaction(&signed_tx).await.wrap_err("Failed to send raw transaction")?;
+                let txid = self
+                    .rpc
+                    .client
+                    .send_raw_transaction(&signed_tx)
+                    .await
+                    .wrap_err("Failed to send raw transaction")?;
                 self.db.save_rbf_txid(Some(&mut dbtx), id, txid).await?;
             } else {
                 let bumped_txid = self

--- a/core/src/watchtower.rs
+++ b/core/src/watchtower.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use bitcoin::{Txid, XOnlyPublicKey};
 use bitvm::signatures::winternitz;
+use eyre::Context;
 
 #[derive(Debug, Clone)]
 pub struct Watchtower {
@@ -25,7 +26,8 @@ impl Watchtower {
             config.bitcoin_rpc_user.clone(),
             config.bitcoin_rpc_password.clone(),
         )
-        .await?;
+        .await
+        .wrap_err("Failed to connect to Bitcoin RPC")?;
 
         let nofn_xonly_pk =
             XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys.clone(), None)?;


### PR DESCRIPTION
# Description

Modules should have independent error types that are composed with `eyre::Report`. BridgeError will be split into their respective modules' error types.

#### Tentative
BridgeError will have a variant for all errors and will be included inside eyre::Report's

## Linked Issues

- Closes #624
- Related to #481

## Docs

> TODO
Docs will be updated in the errors module. We include module docs for the general error handling paradigms (eyre, composition, conversion, wrap_err, module-specific errors), and each module's error type should include docs on the possible errors.