### PR TITLE
Remove all public keys in config and return verifiers' public keys in `aggregator::setup`

### DIFF
--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -235,7 +235,7 @@ impl Aggregator {
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    fn aggregate_move_partial_sigs(
+    async fn aggregate_move_partial_sigs(
         &self,
         deposit_data: DepositData,
         agg_nonce: &MusigAggNonce,
@@ -251,16 +251,13 @@ impl Aggregator {
                 .to_byte_array(),
         );
 
-        let verifiers_public_keys = futures::executor::block_on(async {
-            Ok::<_, BridgeError>(
-                self.nofn
-                    .read()
-                    .await
-                    .clone()
-                    .ok_or(eyre!("N-of-N not set, yet"))?
-                    .public_keys,
-            )
-        })?;
+        let verifiers_public_keys = self
+            .nofn
+            .read()
+            .await
+            .clone()
+            .ok_or(eyre!("N-of-N not set, yet"))?
+            .public_keys;
 
         let final_sig = aggregate_partial_signatures(
             &verifiers_public_keys,

--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{schnorr, Message};
+use eyre::eyre;
 use futures_util::future::try_join_all;
 use secp256k1::musig::{MusigAggNonce, MusigPartialSignature};
 use std::sync::Arc;
@@ -254,9 +255,9 @@ impl Aggregator {
         let verifiers_public_keys = self
             .nofn
             .try_read()
-            .map_err(|_| BridgeError::NofNNotSet)?
+            .map_err(|_| eyre!("Verifier index not set, yet"))?
             .clone()
-            .ok_or(BridgeError::NofNNotSet)?
+            .ok_or(eyre!("Verifier index not set, yet"))?
             .public_keys;
 
         let final_sig = aggregate_partial_signatures(

--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -256,7 +256,7 @@ impl Aggregator {
             .read()
             .await
             .clone()
-            .ok_or(BridgeError::Error(format!("N-of-N not set!")))?
+            .ok_or(BridgeError::Error("N-of-N not set!".to_string()))?
             .public_keys;
         let final_sig = aggregate_partial_signatures(
             &verifiers_public_keys,

--- a/core/src/builder/transaction/creator.rs
+++ b/core/src/builder/transaction/creator.rs
@@ -996,7 +996,7 @@ mod tests {
         let mut config = create_test_config_with_thread_name().await;
         let WithProcessCleanup(_, ref rpc, _, _) = create_regtest_rpc(&mut config).await;
 
-        let (verifiers, operators, _, _cleanup, deposit_params, _, deposit_blockhash) =
+        let (verifiers, operators, _, _cleanup, deposit_params, _, deposit_blockhash, _) =
             run_single_deposit::<MockCitreaClient>(&mut config, rpc.clone(), None)
                 .await
                 .unwrap();

--- a/core/src/builder/transaction/mod.rs
+++ b/core/src/builder/transaction/mod.rs
@@ -3,10 +3,6 @@
 //! Transaction builder provides useful functions for building typical Bitcoin
 //! transactions.
 
-use std::sync::Arc;
-
-use serde::{Deserialize, Serialize};
-
 use super::script::{BaseDepositScript, CheckSig, TimelockScript};
 use super::script::{ReplacementDepositScript, SpendPath};
 use crate::builder::transaction::challenge::*;
@@ -29,6 +25,8 @@ use bitcoin::opcodes::all::{OP_PUSHNUM_1, OP_RETURN};
 use bitcoin::script::Builder;
 use bitcoin::transaction::Version;
 use bitcoin::{Address, Amount, OutPoint, ScriptBuf, TxOut, Txid, XOnlyPublicKey};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 // Exports to the outside
 pub use crate::builder::transaction::txhandler::*;

--- a/core/src/builder/transaction/mod.rs
+++ b/core/src/builder/transaction/mod.rs
@@ -3,8 +3,6 @@
 //! Transaction builder provides useful functions for building typical Bitcoin
 //! transactions.
 
-use eyre::Context;
-use thiserror::Error;
 use super::script::{BaseDepositScript, CheckSig, TimelockScript};
 use super::script::{ReplacementDepositScript, SpendPath};
 use crate::builder::transaction::challenge::*;
@@ -27,8 +25,10 @@ use bitcoin::opcodes::all::{OP_PUSHNUM_1, OP_RETURN};
 use bitcoin::script::Builder;
 use bitcoin::transaction::Version;
 use bitcoin::{Address, Amount, OutPoint, ScriptBuf, TxOut, Txid, XOnlyPublicKey};
+use eyre::Context;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use thiserror::Error;
 
 // Exports to the outside
 pub use crate::builder::transaction::txhandler::*;

--- a/core/src/builder/transaction/sign.rs
+++ b/core/src/builder/transaction/sign.rs
@@ -204,9 +204,16 @@ where
             .remove(&TransactionType::Kickoff)
             .ok_or(BridgeError::TxHandlerNotFound(TransactionType::Kickoff))?;
 
+        let verifier_index = self
+            .idx
+            .read()
+            .await
+            .clone()
+            .ok_or(BridgeError::Error(format!("Verifier index not set!")))?;
+
         let mut watchtower_challenge_txhandler = create_watchtower_challenge_txhandler(
             &kickoff_txhandler,
-            self.idx,
+            verifier_index,
             commit_data,
             self.config.protocol_paramset(),
         )?;
@@ -217,7 +224,7 @@ where
         let checked_txhandler = watchtower_challenge_txhandler.promote()?;
 
         Ok((
-            TransactionType::WatchtowerChallenge(self.idx),
+            TransactionType::WatchtowerChallenge(verifier_index),
             checked_txhandler.get_cached_tx().clone(),
         ))
     }

--- a/core/src/builder/transaction/sign.rs
+++ b/core/src/builder/transaction/sign.rs
@@ -208,7 +208,7 @@ where
             .idx
             .read()
             .await
-            .ok_or(BridgeError::Error("Verifier index not set!".to_string()))?;
+            .ok_or(BridgeError::VerifierIndexNotSet)?;
 
         let mut watchtower_challenge_txhandler = create_watchtower_challenge_txhandler(
             &kickoff_txhandler,

--- a/core/src/builder/transaction/sign.rs
+++ b/core/src/builder/transaction/sign.rs
@@ -208,8 +208,7 @@ where
             .idx
             .read()
             .await
-            .clone()
-            .ok_or(BridgeError::Error(format!("Verifier index not set!")))?;
+            .ok_or(BridgeError::Error("Verifier index not set!".to_string()))?;
 
         let mut watchtower_challenge_txhandler = create_watchtower_challenge_txhandler(
             &kickoff_txhandler,

--- a/core/src/builder/transaction/sign.rs
+++ b/core/src/builder/transaction/sign.rs
@@ -15,6 +15,7 @@ use crate::rpc::clementine::KickoffId;
 use crate::verifier::Verifier;
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, Transaction, XOnlyPublicKey};
+use eyre::eyre;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha12Rng;
 use secp256k1::rand::seq::SliceRandom;
@@ -208,7 +209,7 @@ where
             .idx
             .read()
             .await
-            .ok_or(BridgeError::VerifierIndexNotSet)?;
+            .ok_or(eyre!("Verifier index not set, yet"))?;
 
         let mut watchtower_challenge_txhandler = create_watchtower_challenge_txhandler(
             &kickoff_txhandler,

--- a/core/src/citrea/mod.rs
+++ b/core/src/citrea/mod.rs
@@ -379,7 +379,7 @@ type CitreaContract = BRIDGE_CONTRACT::BRIDGE_CONTRACTInstance<
 mod tests {
     use crate::citrea::CitreaClientT;
     use crate::citrea::BRIDGE_CONTRACT::Withdrawal;
-    use crate::test::common::citrea::BRIDGE_PARAMS;
+    use crate::test::common::citrea::get_bridge_params;
     use crate::{
         citrea::CitreaClient,
         test::common::{
@@ -424,7 +424,7 @@ mod tests {
 
         fn sequencer_config() -> SequencerConfig {
             SequencerConfig {
-                bridge_initialize_params: BRIDGE_PARAMS.to_string(),
+                bridge_initialize_params: get_bridge_params().to_string(),
                 ..Default::default()
             }
         }

--- a/core/src/config/env.rs
+++ b/core/src/config/env.rs
@@ -2,10 +2,7 @@
 
 use super::{protocol::ProtocolParamset, BridgeConfig};
 use crate::errors::BridgeError;
-use bitcoin::{
-    secp256k1::{PublicKey, SecretKey},
-    Amount, Network, XOnlyPublicKey,
-};
+use bitcoin::{secp256k1::SecretKey, Amount, Network, XOnlyPublicKey};
 use std::{path::PathBuf, str::FromStr};
 
 fn read_string_from_env(env_var: &'static str) -> Result<String, BridgeError> {
@@ -25,13 +22,13 @@ where
 
 impl BridgeConfig {
     pub fn from_env() -> Result<Self, BridgeError> {
-        let verifiers_public_keys = read_string_from_env("VERIFIERS_PUBLIC_KEYS")?;
-        let verifiers_public_keys = verifiers_public_keys.split(",").collect::<Vec<&str>>();
-        let verifiers_public_keys = verifiers_public_keys
-            .iter()
-            .map(|x| PublicKey::from_str(x))
-            .collect::<Result<Vec<PublicKey>, _>>()
-            .map_err(|e| BridgeError::EnvVarMalformed("VERIFIERS_PUBLIC_KEYS", e.to_string()))?;
+        // let verifiers_public_keys = read_string_from_env("VERIFIERS_PUBLIC_KEYS")?;
+        // let verifiers_public_keys = verifiers_public_keys.split(",").collect::<Vec<&str>>();
+        // let verifiers_public_keys = verifiers_public_keys
+        //     .iter()
+        //     .map(|x| PublicKey::from_str(x))
+        //     .collect::<Result<Vec<PublicKey>, _>>()
+        //     .map_err(|e| BridgeError::EnvVarMalformed("VERIFIERS_PUBLIC_KEYS", e.to_string()))?;
 
         let operators_xonly_pks = read_string_from_env("OPERATOR_XONLY_PKS")?;
         let operators_xonly_pks = operators_xonly_pks.split(",").collect::<Vec<&str>>();
@@ -131,7 +128,7 @@ impl BridgeConfig {
             index: read_string_from_env_then_parse::<u32>("INDEX")?,
             secret_key: read_string_from_env_then_parse::<SecretKey>("SECRET_KEY")?,
             winternitz_secret_key,
-            verifiers_public_keys,
+            // verifiers_public_keys,
             num_verifiers: read_string_from_env_then_parse::<usize>("NUM_VERIFIERS")?,
             operators_xonly_pks,
             num_operators: read_string_from_env_then_parse::<usize>("NUM_OPERATORS")?,
@@ -254,15 +251,15 @@ mod tests {
                 winternitz_secret_key.display_secret().to_string(),
             );
         }
-        std::env::set_var(
-            "VERIFIERS_PUBLIC_KEYS",
-            default_config
-                .verifiers_public_keys
-                .iter()
-                .map(|pk| pk.to_string())
-                .collect::<Vec<String>>()
-                .join(","),
-        );
+        // std::env::set_var(
+        //     "VERIFIERS_PUBLIC_KEYS",
+        //     default_config
+        //         .verifiers_public_keys
+        //         .iter()
+        //         .map(|pk| pk.to_string())
+        //         .collect::<Vec<String>>()
+        //         .join(","),
+        // );
         std::env::set_var("NUM_VERIFIERS", default_config.num_verifiers.to_string());
         std::env::set_var(
             "OPERATOR_XONLY_PKS",

--- a/core/src/config/env.rs
+++ b/core/src/config/env.rs
@@ -22,14 +22,6 @@ where
 
 impl BridgeConfig {
     pub fn from_env() -> Result<Self, BridgeError> {
-        // let verifiers_public_keys = read_string_from_env("VERIFIERS_PUBLIC_KEYS")?;
-        // let verifiers_public_keys = verifiers_public_keys.split(",").collect::<Vec<&str>>();
-        // let verifiers_public_keys = verifiers_public_keys
-        //     .iter()
-        //     .map(|x| PublicKey::from_str(x))
-        //     .collect::<Result<Vec<PublicKey>, _>>()
-        //     .map_err(|e| BridgeError::EnvVarMalformed("VERIFIERS_PUBLIC_KEYS", e.to_string()))?;
-
         let operators_xonly_pks = read_string_from_env("OPERATOR_XONLY_PKS")?;
         let operators_xonly_pks = operators_xonly_pks.split(",").collect::<Vec<&str>>();
         let operators_xonly_pks = operators_xonly_pks
@@ -128,7 +120,6 @@ impl BridgeConfig {
             index: read_string_from_env_then_parse::<u32>("INDEX")?,
             secret_key: read_string_from_env_then_parse::<SecretKey>("SECRET_KEY")?,
             winternitz_secret_key,
-            // verifiers_public_keys,
             num_verifiers: read_string_from_env_then_parse::<usize>("NUM_VERIFIERS")?,
             operators_xonly_pks,
             num_operators: read_string_from_env_then_parse::<usize>("NUM_OPERATORS")?,
@@ -251,15 +242,6 @@ mod tests {
                 winternitz_secret_key.display_secret().to_string(),
             );
         }
-        // std::env::set_var(
-        //     "VERIFIERS_PUBLIC_KEYS",
-        //     default_config
-        //         .verifiers_public_keys
-        //         .iter()
-        //         .map(|pk| pk.to_string())
-        //         .collect::<Vec<String>>()
-        //         .join(","),
-        // );
         std::env::set_var("NUM_VERIFIERS", default_config.num_verifiers.to_string());
         std::env::set_var(
             "OPERATOR_XONLY_PKS",

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -54,9 +54,6 @@ pub struct BridgeConfig {
     pub secret_key: SecretKey,
     /// Additional secret key that will be used for creating Winternitz one time signature.
     pub winternitz_secret_key: Option<SecretKey>,
-    /// Verifiers public keys.
-    /// In the future, we won't get verifiers public keys from config files, rather in set_verifiers rpc call
-    // pub verifiers_public_keys: Vec<PublicKey>,
     /// Number of verifiers.
     pub num_verifiers: usize,
     /// Operators x-only public keys.
@@ -162,24 +159,7 @@ impl Default for BridgeConfig {
             .expect("known valid input"),
 
             num_verifiers: 4,
-            // verifiers_public_keys: vec![
-            //     PublicKey::from_str(
-            //         "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
-            //     )
-            //     .expect("known valid input"),
-            //     PublicKey::from_str(
-            //         "02466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
-            //     )
-            //     .expect("known valid input"),
-            //     PublicKey::from_str(
-            //         "023c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1",
-            //     )
-            //     .expect("known valid input"),
-            //     PublicKey::from_str(
-            //         "032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991",
-            //     )
-            //     .expect("known valid input"),
-            // ],
+
             num_operators: 2,
             operators_xonly_pks: vec![
                 XOnlyPublicKey::from_str(

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -11,7 +11,7 @@
 //! described in `BridgeConfig` struct.
 
 use crate::errors::BridgeError;
-use bitcoin::secp256k1::{PublicKey, SecretKey};
+use bitcoin::secp256k1::SecretKey;
 use bitcoin::{Amount, XOnlyPublicKey};
 use protocol::{ProtocolParamset, ProtocolParamsetName};
 use serde::{Deserialize, Serialize};
@@ -56,7 +56,7 @@ pub struct BridgeConfig {
     pub winternitz_secret_key: Option<SecretKey>,
     /// Verifiers public keys.
     /// In the future, we won't get verifiers public keys from config files, rather in set_verifiers rpc call
-    pub verifiers_public_keys: Vec<PublicKey>,
+    // pub verifiers_public_keys: Vec<PublicKey>,
     /// Number of verifiers.
     pub num_verifiers: usize,
     /// Operators x-only public keys.
@@ -162,25 +162,24 @@ impl Default for BridgeConfig {
             .expect("known valid input"),
 
             num_verifiers: 4,
-            verifiers_public_keys: vec![
-                PublicKey::from_str(
-                    "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
-                )
-                .expect("known valid input"),
-                PublicKey::from_str(
-                    "02466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
-                )
-                .expect("known valid input"),
-                PublicKey::from_str(
-                    "023c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1",
-                )
-                .expect("known valid input"),
-                PublicKey::from_str(
-                    "032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991",
-                )
-                .expect("known valid input"),
-            ],
-
+            // verifiers_public_keys: vec![
+            //     PublicKey::from_str(
+            //         "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
+            //     )
+            //     .expect("known valid input"),
+            //     PublicKey::from_str(
+            //         "02466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27",
+            //     )
+            //     .expect("known valid input"),
+            //     PublicKey::from_str(
+            //         "023c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1",
+            //     )
+            //     .expect("known valid input"),
+            //     PublicKey::from_str(
+            //         "032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991",
+            //     )
+            //     .expect("known valid input"),
+            // ],
             num_operators: 2,
             operators_xonly_pks: vec![
                 XOnlyPublicKey::from_str(

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -371,6 +371,11 @@ pub enum BridgeError {
     EnvVarNotSet(std::env::VarError, &'static str),
     #[error("Environment variable {0} is malformed: {1}")]
     EnvVarMalformed(&'static str, String),
+
+    #[error("N-of-N not set, yet")]
+    NofNNotSet,
+    #[error("Verifier index is not set, yet")]
+    VerifierIndexNotSet,
 }
 
 impl From<BridgeError> for ErrorObject<'static> {

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -132,10 +132,6 @@ pub enum BridgeError {
     #[error("Error while encoding/decoding EVM type")]
     AlloySolTypes(#[from] alloy::sol_types::Error),
 
-    #[error("N-of-N not set, yet")]
-    NofNNotSet,
-    #[error("Verifier index is not set, yet")]
-    VerifierIndexNotSet,
     #[error("Tonic status")]
     TonicStatus(#[from] tonic::Status),
 

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -19,7 +19,6 @@ use crate::database::Database;
 use crate::database::DatabaseTransaction;
 use crate::errors::BridgeError;
 use crate::extended_rpc::ExtendedRpc;
-use crate::musig2::AggregateFromPublicKeys;
 use crate::rpc::clementine::KickoffId;
 use crate::states::{block_cache, Duty, Owner, StateManager};
 use crate::task::manager::BackgroundTaskManager;
@@ -56,7 +55,6 @@ pub struct Operator<C: CitreaClientT> {
     pub db: Database,
     pub signer: Actor,
     pub config: BridgeConfig,
-    pub nofn_xonly_pk: XOnlyPublicKey,
     pub collateral_funding_outpoint: OutPoint,
     pub idx: usize,
     pub(crate) reimburse_addr: Address,
@@ -135,8 +133,8 @@ where
         )
         .await?;
 
-        let nofn_xonly_pk =
-            XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys.clone(), None)?;
+        // let nofn_xonly_pk =
+        //     XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys.clone(), None)?;
         let idx = config
             .operators_xonly_pks
             .iter()
@@ -197,12 +195,14 @@ where
             config.db_name
         );
 
+        // let nofn_xonly_pk = Arc::new(tokio::sync::RwLock::new(None));
+
         Ok(Operator {
             rpc,
             db: db.clone(),
             signer,
             config,
-            nofn_xonly_pk,
+            // nofn_xonly_pk,
             idx,
             collateral_funding_outpoint,
             tx_sender,
@@ -1082,6 +1082,7 @@ mod tests {
     use crate::test::common::*;
     use bitcoin::hashes::Hash;
     use bitcoin::Txid;
+
     // #[tokio::test]
     // async fn set_funding_utxo() {
     //     let mut config = create_test_config_with_thread_name().await;

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -133,8 +133,6 @@ where
         )
         .await?;
 
-        // let nofn_xonly_pk =
-        //     XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys.clone(), None)?;
         let idx = config
             .operators_xonly_pks
             .iter()
@@ -195,14 +193,11 @@ where
             config.db_name
         );
 
-        // let nofn_xonly_pk = Arc::new(tokio::sync::RwLock::new(None));
-
         Ok(Operator {
             rpc,
             db: db.clone(),
             signer,
             config,
-            // nofn_xonly_pk,
             idx,
             collateral_funding_outpoint,
             tx_sender,

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -535,7 +535,7 @@ impl Aggregator {
             .read()
             .await
             .clone()
-            .ok_or(BridgeError::NofNNotSet)?
+            .ok_or(Status::internal("N-of-N not set"))?
             .public_keys;
         let final_sig = crate::musig2::aggregate_partial_signatures(
             &verifiers_public_keys,
@@ -895,7 +895,7 @@ impl ClementineAggregator for Aggregator {
             .read()
             .await
             .clone()
-            .ok_or(BridgeError::NofNNotSet)?
+            .ok_or(Status::internal("N-of-N not set"))?
             .public_keys;
         let sig_agg_handle = tokio::spawn(signature_aggregator(
             partial_sig_receiver,

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -435,7 +435,7 @@ impl Aggregator {
             .read()
             .await
             .clone()
-            .ok_or(BridgeError::Error(format!("N-of-N not set!")))?
+            .ok_or(BridgeError::Error("N-of-N not set!".to_string()))?
             .public_keys;
         let final_sig = crate::musig2::aggregate_partial_signatures(
             &verifiers_public_keys,
@@ -766,7 +766,7 @@ impl ClementineAggregator for Aggregator {
             .read()
             .await
             .clone()
-            .ok_or(BridgeError::Error(format!("N-of-N not set!")))?
+            .ok_or(BridgeError::Error("N-of-N not set!".to_string()))?
             .public_keys;
         let sig_agg_handle = tokio::spawn(signature_aggregator(
             partial_sig_receiver,

--- a/core/src/rpc/clementine.proto
+++ b/core/src/rpc/clementine.proto
@@ -463,10 +463,15 @@ message AggregatorWithdrawResponse {
 
 service ClementineAggregator {
   // Sets up the system of verifiers, watchtowers and operators by:
-  // 1. Collecting verifier keys, then distributing all verifier keys to all verifiers
-  // 2. Collecting all operator configs, and distributing them to all verifiers
-  // 3. Collecting all possible Winternitz pubkeys (determined by operator idx, seqcol idx, kickoff idx) from watchtowers, and distributing to verifiers.
-  rpc Setup(Empty) returns (Empty) {}
+  //
+  // 1. Collects verifier keys from each verifier
+  // 2. Distributes these verifier keys to all verifiers
+  // 3. Collects all operator configs from each operator
+  // 4. Distributes these operator configs to all verifiers
+  // 5. Collects all possible Winternitz pubkeys (determined by operator idx, seqcol idx, kickoff idx) from each watchtower
+  // 6. Distributes these Winternitz pubkeys to all verifiers
+  rpc Setup(Empty) returns (VerifierPublicKeys) {}
+
   // This will call, DepositNonceGen for every verifier,
   // then it will aggregate one by one and then send it to DepositSign,
   // then it will aggregate the partial sigs and send it to DepositFinalize,

--- a/core/src/rpc/clementine.proto
+++ b/core/src/rpc/clementine.proto
@@ -340,7 +340,7 @@ service ClementineOperator {
 // Verifier --------------------------------------------------------------------
 
 message VerifierParams {
-  uint32 id = 1;
+  optional uint32 id = 1;
   bytes public_key = 2;
   uint32 num_verifiers = 3;
   uint32 num_operators = 4;

--- a/core/src/rpc/clementine.proto
+++ b/core/src/rpc/clementine.proto
@@ -468,8 +468,6 @@ service ClementineAggregator {
   // 2. Distributes these verifier keys to all verifiers
   // 3. Collects all operator configs from each operator
   // 4. Distributes these operator configs to all verifiers
-  // 5. Collects all possible Winternitz pubkeys (determined by operator idx, seqcol idx, kickoff idx) from each watchtower
-  // 6. Distributes these Winternitz pubkeys to all verifiers
   rpc Setup(Empty) returns (VerifierPublicKeys) {}
 
   // This will call, DepositNonceGen for every verifier,

--- a/core/src/rpc/clementine.rs
+++ b/core/src/rpc/clementine.rs
@@ -1507,13 +1507,20 @@ pub mod clementine_aggregator_client {
             self
         }
         /// Sets up the system of verifiers, watchtowers and operators by:
-        /// 1. Collecting verifier keys, then distributing all verifier keys to all verifiers
-        /// 2. Collecting all operator configs, and distributing them to all verifiers
-        /// 3. Collecting all possible Winternitz pubkeys (determined by operator idx, seqcol idx, kickoff idx) from watchtowers, and distributing to verifiers.
+        ///
+        /// 1. Collects verifier keys from each verifier
+        /// 2. Distributes these verifier keys to all verifiers
+        /// 3. Collects all operator configs from each operator
+        /// 4. Distributes these operator configs to all verifiers
+        /// 5. Collects all possible Winternitz pubkeys (determined by operator idx, seqcol idx, kickoff idx) from each watchtower
+        /// 6. Distributes these Winternitz pubkeys to all verifiers
         pub async fn setup(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
-        ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status> {
+        ) -> std::result::Result<
+            tonic::Response<super::VerifierPublicKeys>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -2992,13 +2999,20 @@ pub mod clementine_aggregator_server {
     #[async_trait]
     pub trait ClementineAggregator: std::marker::Send + std::marker::Sync + 'static {
         /// Sets up the system of verifiers, watchtowers and operators by:
-        /// 1. Collecting verifier keys, then distributing all verifier keys to all verifiers
-        /// 2. Collecting all operator configs, and distributing them to all verifiers
-        /// 3. Collecting all possible Winternitz pubkeys (determined by operator idx, seqcol idx, kickoff idx) from watchtowers, and distributing to verifiers.
+        ///
+        /// 1. Collects verifier keys from each verifier
+        /// 2. Distributes these verifier keys to all verifiers
+        /// 3. Collects all operator configs from each operator
+        /// 4. Distributes these operator configs to all verifiers
+        /// 5. Collects all possible Winternitz pubkeys (determined by operator idx, seqcol idx, kickoff idx) from each watchtower
+        /// 6. Distributes these Winternitz pubkeys to all verifiers
         async fn setup(
             &self,
             request: tonic::Request<super::Empty>,
-        ) -> std::result::Result<tonic::Response<super::Empty>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::VerifierPublicKeys>,
+            tonic::Status,
+        >;
         /// This will call, DepositNonceGen for every verifier,
         /// then it will aggregate one by one and then send it to DepositSign,
         /// then it will aggregate the partial sigs and send it to DepositFinalize,
@@ -3106,7 +3120,7 @@ pub mod clementine_aggregator_server {
                     impl<
                         T: ClementineAggregator,
                     > tonic::server::UnaryService<super::Empty> for SetupSvc<T> {
-                        type Response = super::Empty;
+                        type Response = super::VerifierPublicKeys;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,

--- a/core/src/rpc/clementine.rs
+++ b/core/src/rpc/clementine.rs
@@ -1512,8 +1512,6 @@ pub mod clementine_aggregator_client {
         /// 2. Distributes these verifier keys to all verifiers
         /// 3. Collects all operator configs from each operator
         /// 4. Distributes these operator configs to all verifiers
-        /// 5. Collects all possible Winternitz pubkeys (determined by operator idx, seqcol idx, kickoff idx) from each watchtower
-        /// 6. Distributes these Winternitz pubkeys to all verifiers
         pub async fn setup(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
@@ -3004,8 +3002,6 @@ pub mod clementine_aggregator_server {
         /// 2. Distributes these verifier keys to all verifiers
         /// 3. Collects all operator configs from each operator
         /// 4. Distributes these operator configs to all verifiers
-        /// 5. Collects all possible Winternitz pubkeys (determined by operator idx, seqcol idx, kickoff idx) from each watchtower
-        /// 6. Distributes these Winternitz pubkeys to all verifiers
         async fn setup(
             &self,
             request: tonic::Request<super::Empty>,

--- a/core/src/rpc/clementine.rs
+++ b/core/src/rpc/clementine.rs
@@ -271,8 +271,8 @@ pub struct FinalizedPayoutParams {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct VerifierParams {
-    #[prost(uint32, tag = "1")]
-    pub id: u32,
+    #[prost(uint32, optional, tag = "1")]
+    pub id: ::core::option::Option<u32>,
     #[prost(bytes = "vec", tag = "2")]
     pub public_key: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint32, tag = "3")]

--- a/core/src/rpc/parser/verifier.rs
+++ b/core/src/rpc/parser/verifier.rs
@@ -31,13 +31,14 @@ where
     type Error = Status;
 
     fn try_from(verifier: &Verifier<C>) -> Result<Self, Self::Error> {
-        let idx = verifier
-            .idx
-            .blocking_read()
-            .ok_or(BridgeError::Error("Verifier index not set!".to_string()))?;
+        let idx = verifier.idx.try_read().unwrap();
+        let id = match *idx {
+            Some(idx) => Some(convert_int_to_another("id", idx, u32::try_from)?),
+            None => None,
+        };
 
         Ok(VerifierParams {
-            id: convert_int_to_another("id", idx, u32::try_from)?,
+            id,
             public_key: verifier.signer.public_key.serialize().to_vec(),
             num_verifiers: convert_int_to_another(
                 "num_verifiers",

--- a/core/src/rpc/parser/verifier.rs
+++ b/core/src/rpc/parser/verifier.rs
@@ -31,8 +31,14 @@ where
     type Error = Status;
 
     fn try_from(verifier: &Verifier<C>) -> Result<Self, Self::Error> {
+        let idx = verifier
+            .idx
+            .blocking_read()
+            .clone()
+            .ok_or(BridgeError::Error(format!("Verifier index not set!")))?;
+
         Ok(VerifierParams {
-            id: convert_int_to_another("id", verifier.idx, u32::try_from)?,
+            id: convert_int_to_another("id", idx, u32::try_from)?,
             public_key: verifier.signer.public_key.serialize().to_vec(),
             num_verifiers: convert_int_to_another(
                 "num_verifiers",

--- a/core/src/rpc/parser/verifier.rs
+++ b/core/src/rpc/parser/verifier.rs
@@ -34,8 +34,7 @@ where
         let idx = verifier
             .idx
             .blocking_read()
-            .clone()
-            .ok_or(BridgeError::Error(format!("Verifier index not set!")))?;
+            .ok_or(BridgeError::Error("Verifier index not set!".to_string()))?;
 
         Ok(VerifierParams {
             id: convert_int_to_another("id", idx, u32::try_from)?,

--- a/core/src/rpc/parser/verifier.rs
+++ b/core/src/rpc/parser/verifier.rs
@@ -35,7 +35,7 @@ where
         let idx = verifier
             .idx
             .try_read()
-            .map_err(|_| BridgeError::VerifierIndexNotSet)?;
+            .map_err(|_| Status::internal("Verifier index not set, yet"))?;
         let id = match *idx {
             Some(idx) => Some(convert_int_to_another("id", idx, u32::try_from)?),
             None => None,

--- a/core/src/rpc/parser/verifier.rs
+++ b/core/src/rpc/parser/verifier.rs
@@ -31,7 +31,10 @@ where
     type Error = Status;
 
     fn try_from(verifier: &Verifier<C>) -> Result<Self, Self::Error> {
-        let idx = verifier.idx.try_read().unwrap();
+        let idx = verifier
+            .idx
+            .try_read()
+            .map_err(|_| Status::internal("Failed to read verifier index from RwLock"))?;
         let id = match *idx {
             Some(idx) => Some(convert_int_to_another("id", idx, u32::try_from)?),
             None => None,

--- a/core/src/rpc/parser/verifier.rs
+++ b/core/src/rpc/parser/verifier.rs
@@ -34,7 +34,7 @@ where
         let idx = verifier
             .idx
             .try_read()
-            .map_err(|_| Status::internal("Failed to read verifier index from RwLock"))?;
+            .map_err(|_| BridgeError::VerifierIndexNotSet)?;
         let id = match *idx {
             Some(idx) => Some(convert_int_to_another("id", idx, u32::try_from)?),
             None => None,

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -162,7 +162,7 @@ where
             .idx
             .read()
             .await
-            .ok_or(BridgeError::VerifierIndexNotSet)?;
+            .ok_or(Status::internal("Verifier index not set, yet"))?;
 
         let (tx, rx) = mpsc::channel(1280);
         let out_stream: Self::DepositSignStream = ReceiverStream::new(rx);
@@ -262,7 +262,7 @@ where
             .idx
             .read()
             .await
-            .ok_or(BridgeError::VerifierIndexNotSet)?;
+            .ok_or(Status::internal("Verifier index not set, yet"))?;
         tracing::trace!("In verifier {} deposit_finalize()", verifier_index);
 
         let (sig_tx, sig_rx) = mpsc::channel(1280);

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -74,7 +74,7 @@ where
         Ok(Response::new(Empty {}))
     }
 
-    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
+    #[tracing::instrument(skip_all, err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
     async fn set_operator(
         &self,
         req: Request<Streaming<OperatorParams>>,

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -162,7 +162,7 @@ where
             .idx
             .read()
             .await
-            .ok_or(BridgeError::Error("Verifier index not set!".to_string()))?;
+            .ok_or(BridgeError::VerifierIndexNotSet)?;
 
         let (tx, rx) = mpsc::channel(1280);
         let out_stream: Self::DepositSignStream = ReceiverStream::new(rx);
@@ -263,7 +263,7 @@ where
             .idx
             .read()
             .await
-            .ok_or(BridgeError::Error("Verifier index not set!".to_string()))?;
+            .ok_or(BridgeError::VerifierIndexNotSet)?;
         tracing::trace!("In verifier {} deposit_finalize()", verifier_index);
 
         let (sig_tx, sig_rx) = mpsc::channel(1280);

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -162,8 +162,7 @@ where
             .idx
             .read()
             .await
-            .clone()
-            .ok_or(BridgeError::Error(format!("Verifier index not set!")))?;
+            .ok_or(BridgeError::Error("Verifier index not set!".to_string()))?;
 
         let (tx, rx) = mpsc::channel(1280);
         let out_stream: Self::DepositSignStream = ReceiverStream::new(rx);
@@ -264,8 +263,7 @@ where
             .idx
             .read()
             .await
-            .clone()
-            .ok_or(BridgeError::Error(format!("Verifier index not set!")))?;
+            .ok_or(BridgeError::Error("Verifier index not set!".to_string()))?;
         tracing::trace!("In verifier {} deposit_finalize()", verifier_index);
 
         let (sig_tx, sig_rx) = mpsc::channel(1280);

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -157,6 +157,13 @@ where
     ) -> Result<Response<Self::DepositSignStream>, Status> {
         let mut in_stream = req.into_inner();
         let verifier = self.verifier.clone();
+        let verifier_index = self
+            .verifier
+            .idx
+            .read()
+            .await
+            .clone()
+            .ok_or(BridgeError::Error(format!("Verifier index not set!")))?;
 
         let (tx, rx) = mpsc::channel(1280);
         let out_stream: Self::DepositSignStream = ReceiverStream::new(rx);
@@ -172,7 +179,7 @@ where
                     deposit_sign_session,
                 ) => parser::verifier::parse_deposit_sign_session(
                     deposit_sign_session,
-                    verifier.idx,
+                    verifier_index,
                 )?,
                 _ => return Err(Status::invalid_argument("Expected DepositOutpoint")),
             };
@@ -228,7 +235,7 @@ where
                 nonce_idx += 1;
                 tracing::trace!(
                     "Verifier {} signed and sent sighash {} of {} through rpc deposit_sign",
-                    verifier.idx,
+                    verifier_index,
                     nonce_idx,
                     num_required_sigs
                 );
@@ -252,7 +259,14 @@ where
         req: Request<Streaming<VerifierDepositFinalizeParams>>,
     ) -> Result<Response<PartialSig>, Status> {
         let mut in_stream = req.into_inner();
-        tracing::trace!("In verifier {} deposit_finalize()", self.verifier.idx);
+        let verifier_index = self
+            .verifier
+            .idx
+            .read()
+            .await
+            .clone()
+            .ok_or(BridgeError::Error(format!("Verifier index not set!")))?;
+        tracing::trace!("In verifier {} deposit_finalize()", verifier_index);
 
         let (sig_tx, sig_rx) = mpsc::channel(1280);
         let (agg_nonce_tx, agg_nonce_rx) = mpsc::channel(1);
@@ -261,16 +275,13 @@ where
         let params = fetch_next_message_from_stream!(in_stream, params)?;
         let (deposit_data, session_id) = match params {
             Params::DepositSignFirstParam(deposit_sign_session) => {
-                parser::verifier::parse_deposit_sign_session(
-                    deposit_sign_session,
-                    self.verifier.idx,
-                )?
+                parser::verifier::parse_deposit_sign_session(deposit_sign_session, verifier_index)?
             }
             _ => Err(Status::internal("Expected DepositOutpoint"))?,
         };
         tracing::trace!(
             "verifier {} got DepositSignFirstParam in deposit_finalize()",
-            self.verifier.idx
+            verifier_index
         );
 
         // Start deposit finalize job.

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -164,11 +164,12 @@ pub async fn create_operator_grpc_server<C: CitreaClientT>(
         config.port
     );
     let addr: std::net::SocketAddr = format!("{}:{}", config.host, config.port).parse()?;
-    let operator = OperatorServer::<C>::new(config).await?;
-    tracing::info!("Operator gRPC server created");
-    let svc = ClementineOperatorServer::new(operator);
 
+    let operator = OperatorServer::<C>::new(config).await?;
+
+    let svc = ClementineOperatorServer::new(operator);
     let (server_addr, shutdown_tx) = create_grpc_server(addr.into(), svc, "Operator").await?;
+    tracing::info!("Operator gRPC server created");
 
     match server_addr {
         ServerAddr::Tcp(socket_addr) => Ok((socket_addr, shutdown_tx)),
@@ -180,7 +181,7 @@ pub async fn create_aggregator_grpc_server(
     config: BridgeConfig,
 ) -> Result<(std::net::SocketAddr, oneshot::Sender<()>), BridgeError> {
     let addr: std::net::SocketAddr = format!("{}:{}", config.host, config.port).parse()?;
-    let aggregator = Aggregator::new(config).await?;
+    let aggregator = Aggregator::new(config.clone()).await?;
     let svc = ClementineAggregatorServer::new(aggregator);
 
     let (server_addr, shutdown_tx) = create_grpc_server(addr.into(), svc, "Aggregator").await?;

--- a/core/src/test/common/citrea/bitcoin_merkle.rs
+++ b/core/src/test/common/citrea/bitcoin_merkle.rs
@@ -69,7 +69,7 @@ impl BitcoinMerkleTree {
                 tree.nodes[curr_level_offset].push(combined_hash);
             }
             curr_level_offset += 1;
-            prev_level_size = (prev_level_size + 1) / 2;
+            prev_level_size = prev_level_size.div_ceil(2) / 2;
             prev_level_index_offset = 0;
         }
         tree

--- a/core/src/test/common/citrea/mod.rs
+++ b/core/src/test/common/citrea/mod.rs
@@ -1,8 +1,10 @@
 //! # Citrea Related Utilities
 
 use crate::citrea::mock::MockCitreaClient;
+use crate::musig2::AggregateFromPublicKeys;
+use crate::rpc::clementine::Empty;
 use crate::{config::BridgeConfig, errors::BridgeError, test::common::create_actors};
-use bitcoin::XOnlyPublicKey;
+use bitcoin::secp256k1::PublicKey;
 use citrea_e2e::{
     bitcoin::BitcoinNode,
     config::{BatchProverConfig, EmptyConfig, LightClientProverConfig, SequencerConfig},
@@ -12,48 +14,55 @@ use citrea_e2e::{
 use jsonrpsee::http_client::HttpClient;
 pub use parameters::*;
 pub use requests::*;
+use tonic::Request;
 
 mod bitcoin_merkle;
 mod parameters;
 mod requests;
 
-lazy_static::lazy_static! {
-    pub static ref NOFN: XOnlyPublicKey = {
-        tokio::runtime::Runtime::new().unwrap().block_on(async {
-            let config = BridgeConfig::default();
-            let (verifiers, mut operators, mut aggregator, cleanup) =
-                create_actors::<MockCitreaClient>(&config).await;
-            let verifiers_public_keys: Vec<bitcoin::secp256k1::PublicKey> = aggregator
-                .setup(Request::new(Empty {}))
-                .await
-                .unwrap()
-                .into_inner()
-                .try_into()
-                .unwrap();
-
-            bitcoin::XOnlyPublicKey::from_musig2_pks(verifiers_public_keys, None).unwrap()
-        })
-    };
-}
-
-lazy_static::lazy_static! {
-    /// Citrea bridge params. This string includes N-of-N public key for the current
-    /// test setup. If that setup changes, this string should be updated or needs to
-    /// calculated dynamically.
-    ///
-    /// CAUTION: This will create N-of-N public key using the default `BridgeConfig`!
-    pub static ref BRIDGE_PARAMS: String = {
+/// Calculates bridge params dynamically with a setup.
+///
+/// CAUTION: This will create N-of-N public key using the default `BridgeConfig`!
+pub fn get_bridge_params() -> String {
+    futures::executor::block_on(async move {
         let config = BridgeConfig::default();
-        let nofn_xonly_pk =
-            bitcoin::XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys, None)
-            .unwrap()
-            .to_string();
+        let (_, _, mut aggregator, _cleanup) = create_actors::<MockCitreaClient>(&config).await;
 
-        "000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000008ac7230489e80000000000000000000000000000000000000000000000000000000000000000002d4a20".to_owned() +
-        &nofn_xonly_pk +
-        "ac0063066369747265611400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a08000000003b9aca006800000000000000000000000000000000000000000000"
-    };
+        let verifiers_public_keys: Vec<PublicKey> = aggregator
+            .setup(Request::new(Empty {}))
+            .await
+            .unwrap()
+            .into_inner()
+            .try_into()
+            .unwrap();
+
+        let nofn_xonly_pk =
+            bitcoin::XOnlyPublicKey::from_musig2_pks(verifiers_public_keys.clone(), None)
+                .unwrap()
+                .to_string();
+
+        format!("000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000008ac7230489e80000000000000000000000000000000000000000000000000000000000000000002d4a20{}ac0063066369747265611400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a08000000003b9aca006800000000000000000000000000000000000000000000", nofn_xonly_pk)
+    })
 }
+
+// lazy_static::lazy_static! {
+//     /// Citrea bridge params. This string includes N-of-N public key for the current
+//     /// test setup. If that setup changes, this string should be updated or needs to
+//     /// calculated dynamically.
+//     ///
+//     /// CAUTION: This will create N-of-N public key using the default `BridgeConfig`!
+//     pub static ref BRIDGE_PARAMS: String = {
+//         let config = BridgeConfig::default();
+//         let nofn_xonly_pk =
+//             bitcoin::XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys, None)
+//             .unwrap()
+//             .to_string();
+
+//         "000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000008ac7230489e80000000000000000000000000000000000000000000000000000000000000000002d4a20".to_owned() +
+//         &nofn_xonly_pk +
+//         "ac0063066369747265611400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a08000000003b9aca006800000000000000000000000000000000000000000000"
+//     };
+// }
 
 /// Citrea e2e hardcoded EVM secret keys.
 pub const SECRET_KEYS: [&str; 10] = [

--- a/core/src/test/common/citrea/mod.rs
+++ b/core/src/test/common/citrea/mod.rs
@@ -20,7 +20,8 @@ mod bitcoin_merkle;
 mod parameters;
 mod requests;
 
-/// Calculates bridge params dynamically with a setup.
+/// Calculates bridge params dynamically with the N-of-N public key which
+/// retrieved from the aggregator setup.
 ///
 /// CAUTION: This will create N-of-N public key using the default `BridgeConfig`!
 pub fn get_bridge_params() -> String {
@@ -44,25 +45,6 @@ pub fn get_bridge_params() -> String {
         format!("000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000008ac7230489e80000000000000000000000000000000000000000000000000000000000000000002d4a20{}ac0063066369747265611400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a08000000003b9aca006800000000000000000000000000000000000000000000", nofn_xonly_pk)
     })
 }
-
-// lazy_static::lazy_static! {
-//     /// Citrea bridge params. This string includes N-of-N public key for the current
-//     /// test setup. If that setup changes, this string should be updated or needs to
-//     /// calculated dynamically.
-//     ///
-//     /// CAUTION: This will create N-of-N public key using the default `BridgeConfig`!
-//     pub static ref BRIDGE_PARAMS: String = {
-//         let config = BridgeConfig::default();
-//         let nofn_xonly_pk =
-//             bitcoin::XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys, None)
-//             .unwrap()
-//             .to_string();
-
-//         "000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000008ac7230489e80000000000000000000000000000000000000000000000000000000000000000002d4a20".to_owned() +
-//         &nofn_xonly_pk +
-//         "ac0063066369747265611400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a08000000003b9aca006800000000000000000000000000000000000000000000"
-//     };
-// }
 
 /// Citrea e2e hardcoded EVM secret keys.
 pub const SECRET_KEYS: [&str; 10] = [

--- a/core/src/test/common/mod.rs
+++ b/core/src/test/common/mod.rs
@@ -23,8 +23,8 @@ use crate::rpc::clementine::{DepositParams, Empty, FeeType, RawSignedTx, SendTxR
 use crate::EVMAddress;
 use bitcoin::hashes::Hash;
 use bitcoin::key::Keypair;
-use bitcoin::secp256k1::Message;
-use bitcoin::{taproot, BlockHash, OutPoint, Transaction, Txid, Witness};
+use bitcoin::secp256k1::{Message, PublicKey};
+use bitcoin::{taproot, BlockHash, OutPoint, Transaction, Txid, Witness, XOnlyPublicKey};
 use bitcoincore_rpc::RpcApi;
 pub use setup_utils::*;
 use tonic::transport::Channel;
@@ -124,16 +124,20 @@ pub async fn run_multiple_deposits<C: CitreaClientT>(
         config.winternitz_secret_key,
         config.protocol_paramset().network,
     );
-    let (deposit_address, _) = get_deposit_address(config, evm_address)?;
 
-    aggregator.setup(Request::new(Empty {})).await?;
+    let verifiers_public_keys: Vec<PublicKey> = aggregator
+        .setup(Request::new(Empty {}))
+        .await?
+        .into_inner()
+        .try_into()?;
 
+    let (deposit_address, _) =
+        get_deposit_address(config, evm_address, verifiers_public_keys.clone())?;
     let mut deposit_outpoints = Vec::new();
     let mut move_txids = Vec::new();
 
     let nofn_xonly_pk =
-        bitcoin::XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys.clone(), None)
-            .unwrap();
+        bitcoin::XOnlyPublicKey::from_musig2_pks(verifiers_public_keys.clone(), None).unwrap();
 
     for _ in 0..count {
         let deposit_outpoint: OutPoint = rpc
@@ -207,6 +211,7 @@ pub async fn run_single_deposit<C: CitreaClientT>(
         DepositParams,
         Txid,
         BlockHash,
+        Vec<PublicKey>,
     ),
     BridgeError,
 > {
@@ -218,13 +223,18 @@ pub async fn run_single_deposit<C: CitreaClientT>(
         config.winternitz_secret_key,
         config.protocol_paramset().network,
     );
-    let (deposit_address, _) = get_deposit_address(config, evm_address)?;
 
     let setup_start = std::time::Instant::now();
-    aggregator.setup(Request::new(Empty {})).await?;
+    let verifiers_public_keys: Vec<PublicKey> = aggregator
+        .setup(Request::new(Empty {}))
+        .await?
+        .into_inner()
+        .try_into()?;
     let setup_elapsed = setup_start.elapsed();
     tracing::info!("Setup completed in: {:?}", setup_elapsed);
 
+    let (deposit_address, _) =
+        get_deposit_address(config, evm_address, verifiers_public_keys.clone())?;
     let deposit_outpoint = rpc
         .send_to_address(&deposit_address, config.protocol_paramset().bridge_amount)
         .await?;
@@ -233,8 +243,7 @@ pub async fn run_single_deposit<C: CitreaClientT>(
     let deposit_blockhash = rpc.get_blockhash_of_tx(&deposit_outpoint.txid).await?;
 
     let nofn_xonly_pk =
-        bitcoin::XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys.clone(), None)
-            .unwrap();
+        bitcoin::XOnlyPublicKey::from_musig2_pks(verifiers_public_keys.clone(), None).unwrap();
 
     let deposit_data = DepositData::BaseDeposit(BaseDepositData {
         deposit_outpoint,
@@ -267,13 +276,17 @@ pub async fn run_single_deposit<C: CitreaClientT>(
         deposit_params,
         move_txid,
         deposit_blockhash,
+        verifiers_public_keys,
     ))
 }
 
-fn sign_nofn_deposit_tx(deposit_tx: &TxHandler, config: &BridgeConfig) -> Transaction {
+fn sign_nofn_deposit_tx(
+    deposit_tx: &TxHandler,
+    config: &BridgeConfig,
+    verifiers_public_keys: Vec<PublicKey>,
+) -> Transaction {
     let nofn_xonly_pk =
-        bitcoin::XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys.clone(), None)
-            .unwrap();
+        bitcoin::XOnlyPublicKey::from_musig2_pks(verifiers_public_keys.clone(), None).unwrap();
     let msg = Message::from_digest(
         deposit_tx
             .calculate_script_spend_sighash(
@@ -311,7 +324,7 @@ fn sign_nofn_deposit_tx(deposit_tx: &TxHandler, config: &BridgeConfig) -> Transa
         .zip(nonce_pairs)
         .map(|(kp, nonce_pair)| {
             partial_sign(
-                config.verifiers_public_keys.clone(),
+                verifiers_public_keys.clone(),
                 None,
                 nonce_pair.0,
                 agg_nonce,
@@ -323,7 +336,7 @@ fn sign_nofn_deposit_tx(deposit_tx: &TxHandler, config: &BridgeConfig) -> Transa
         .collect::<Vec<_>>();
 
     let final_signature = aggregate_partial_signatures(
-        &config.verifiers_public_keys.clone(),
+        &verifiers_public_keys.clone(),
         None,
         agg_nonce,
         &partial_sigs,
@@ -366,25 +379,41 @@ pub async fn run_replacement_deposit(
     ),
     BridgeError,
 > {
-    let (verifiers, operators, mut aggregator, cleanup, dep_params, move_txid, _) =
-        run_single_deposit::<MockCitreaClient>(config, rpc.clone(), evm_address).await?;
+    let (
+        verifiers,
+        operators,
+        mut aggregator,
+        cleanup,
+        dep_params,
+        move_txid,
+        _,
+        verifiers_public_keys,
+    ) = run_single_deposit::<MockCitreaClient>(config, rpc.clone(), evm_address).await?;
 
     tracing::info!(
         "First deposit {} completed, starting replacement deposit",
-        DepositData::try_from(dep_params)?
+        DepositData::try_from(dep_params.clone())?
             .get_deposit_outpoint()
             .txid
     );
     tracing::info!("First deposit move txid: {}", move_txid);
-    let nofn_xonly_pk =
-        bitcoin::XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys.clone(), None)
-            .unwrap();
+    let nofn_xonly_pk = dep_params.deposit_data.expect("Exists");
+    let nofn_xonly_pk = match nofn_xonly_pk {
+        crate::rpc::clementine::deposit_params::DepositData::BaseDeposit(base_deposit) => {
+            base_deposit.nofn_xonly_pk
+        }
+        crate::rpc::clementine::deposit_params::DepositData::ReplacementDeposit(
+            replacement_deposit,
+        ) => replacement_deposit.nofn_xonly_pk,
+    };
+    let nofn_xonly_pk = XOnlyPublicKey::from_slice(&nofn_xonly_pk).unwrap();
 
     // generate replacement deposit tx
     let new_deposit_tx =
         create_replacement_deposit_txhandler(move_txid, nofn_xonly_pk, config.protocol_paramset())?;
 
-    let replacement_deposit_tx = sign_nofn_deposit_tx(&new_deposit_tx, config);
+    let replacement_deposit_tx =
+        sign_nofn_deposit_tx(&new_deposit_tx, config, verifiers_public_keys);
 
     aggregator
         .internal_send_tx(SendTxRequest {

--- a/core/src/test/common/setup_utils.rs
+++ b/core/src/test/common/setup_utils.rs
@@ -225,7 +225,7 @@ pub async fn create_test_config_with_thread_name() -> BridgeConfig {
         .name()
         .expect("Failed to get thread name")
         .split(':')
-        .last()
+        .next_back()
         .expect("Failed to get thread name")
         .to_owned();
 

--- a/core/src/test/common/setup_utils.rs
+++ b/core/src/test/common/setup_utils.rs
@@ -476,6 +476,7 @@ pub async fn create_actors<C: CitreaClientT>(
 pub fn get_deposit_address(
     config: &BridgeConfig,
     evm_address: EVMAddress,
+    verifiers_public_keys: Vec<bitcoin::secp256k1::PublicKey>,
 ) -> Result<(bitcoin::Address, bitcoin::taproot::TaprootSpendInfo), BridgeError> {
     let signer = Actor::new(
         config.secret_key,
@@ -483,9 +484,8 @@ pub fn get_deposit_address(
         config.protocol_paramset().network,
     );
 
-    let nofn_xonly_pk =
-        bitcoin::XOnlyPublicKey::from_musig2_pks(config.verifiers_public_keys.clone(), None)
-            .expect("Failed to create xonly pk");
+    let nofn_xonly_pk = bitcoin::XOnlyPublicKey::from_musig2_pks(verifiers_public_keys, None)
+        .expect("Failed to create xonly pk");
 
     builder::address::generate_deposit_address(
         nofn_xonly_pk,

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -1,4 +1,3 @@
-use std::time::Instant;
 use super::common::citrea::get_bridge_params;
 use crate::bitvm_client::SECP;
 use crate::citrea::mock::MockCitreaClient;
@@ -36,6 +35,7 @@ use citrea_e2e::{
     test_case::{TestCase, TestCaseRunner},
     Result,
 };
+use std::time::Instant;
 
 struct CitreaDepositAndWithdrawE2E;
 #[async_trait]

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -1,4 +1,4 @@
-use super::common::citrea::BRIDGE_PARAMS;
+use super::common::citrea::get_bridge_params;
 use crate::bitvm_client::SECP;
 use crate::citrea::mock::MockCitreaClient;
 use crate::citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER};
@@ -65,7 +65,7 @@ impl TestCase for CitreaDepositAndWithdrawE2E {
 
     fn sequencer_config() -> SequencerConfig {
         SequencerConfig {
-            bridge_initialize_params: BRIDGE_PARAMS.to_string(),
+            bridge_initialize_params: get_bridge_params(),
             ..Default::default()
         }
     }

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -127,6 +127,7 @@ impl TestCase for CitreaDepositAndWithdrawE2E {
             _deposit_params,
             move_txid,
             _deposit_blockhash,
+            _,
         ) = run_single_deposit::<CitreaClient>(&mut config, rpc.clone(), None).await?;
 
         tracing::info!(
@@ -400,6 +401,7 @@ async fn mock_citrea_run() {
         _deposit_params,
         move_txid,
         _deposit_blockhash,
+        _,
     ) = run_single_deposit::<MockCitreaClient>(&mut config, rpc.clone(), None)
         .await
         .unwrap();

--- a/core/src/test/withdraw.rs
+++ b/core/src/test/withdraw.rs
@@ -1,4 +1,3 @@
-use super::common::citrea::BRIDGE_PARAMS;
 use crate::bitvm_client::SECP;
 use crate::citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER};
 use crate::test::common::citrea::SECRET_KEYS;
@@ -22,6 +21,8 @@ use citrea_e2e::{
     test_case::{TestCase, TestCaseRunner},
     Result,
 };
+
+use super::common::citrea::get_bridge_params;
 
 struct CitreaWithdrawAndGetUTXO;
 #[async_trait]
@@ -52,7 +53,7 @@ impl TestCase for CitreaWithdrawAndGetUTXO {
 
     fn sequencer_config() -> SequencerConfig {
         SequencerConfig {
-            bridge_initialize_params: BRIDGE_PARAMS.to_string(),
+            bridge_initialize_params: get_bridge_params(),
             ..Default::default()
         }
     }

--- a/core/src/test/withdraw.rs
+++ b/core/src/test/withdraw.rs
@@ -1,3 +1,4 @@
+use super::common::citrea::get_bridge_params;
 use crate::bitvm_client::SECP;
 use crate::citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER};
 use crate::test::common::citrea::SECRET_KEYS;
@@ -21,8 +22,6 @@ use citrea_e2e::{
     test_case::{TestCase, TestCaseRunner},
     Result,
 };
-
-use super::common::citrea::get_bridge_params;
 
 struct CitreaWithdrawAndGetUTXO;
 #[async_trait]

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::{fmt, EnvFilter, Registry};
 pub fn usize_to_var_len_bytes(x: usize) -> Vec<u8> {
     let usize_bytes = (usize::BITS / 8) as usize;
     let bits = x.max(1).ilog2() + 1;
-    let len = ((bits + 7) / 8) as usize;
+    let len = bits.div_ceil(8) as usize;
     let empty = usize_bytes - len;
     let op_idx_bytes = x.to_be_bytes();
     let op_idx_bytes = &op_idx_bytes[empty..];

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -105,7 +105,7 @@ where
             verifier.signer.clone(),
             rpc.clone(),
             verifier.db.clone(),
-            format!("verifier_").to_string(),
+            "verifier_".to_string(),
             config.protocol_paramset().network,
         );
 
@@ -218,7 +218,7 @@ where
         };
 
         // TODO: Removing index causes to remove the index from the tx_sender handle as well
-        let tx_sender = TxSenderClient::new(db.clone(), format!("verifier_").to_string());
+        let tx_sender = TxSenderClient::new(db.clone(), "verifier_".to_string());
 
         // tracing::info!(
         //     "Verifier {} created with nofn_xonly_pk: {}",
@@ -455,8 +455,7 @@ where
             .idx
             .read()
             .await
-            .clone()
-            .ok_or(BridgeError::Error(format!("Verifier index not set!")))?;
+            .ok_or(BridgeError::Error("Verifier index not set!".to_string()))?;
         let verifiers_public_keys = self.db.get_verifiers_public_keys(None).await?;
 
         let deposit_blockhash = self
@@ -962,7 +961,6 @@ where
             .idx
             .read()
             .await
-            .clone()
             .ok_or(BridgeError::Error("Verifier index not set".to_string()))?;
 
         let tx_metadata = Some(TxMetadata {
@@ -1021,7 +1019,6 @@ where
             .idx
             .read()
             .await
-            .clone()
             .ok_or(BridgeError::Error("Verifier index not set".to_string()))?;
 
         self.tx_sender
@@ -1151,7 +1148,6 @@ where
             .idx
             .read()
             .await
-            .clone()
             .ok_or(BridgeError::Error("Verifier index not set".to_string()))?;
 
         match duty {


### PR DESCRIPTION
# Description

- Removes public key fields in `BridgeConfig`.
- `aggregator::setup` returns verifiers' public keys

## Linked Issues

- Closes #537
