### PR TITLE
is kickoff malicious

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -148,7 +148,7 @@ impl Actor {
     }
 
     /// Returns derivied Winternitz secret key from given path.
-    fn get_derived_winternitz_sk(
+    pub fn get_derived_winternitz_sk(
         &self,
         path: WinternitzDerivationPath,
     ) -> Result<winternitz::SecretKey, BridgeError> {

--- a/core/src/builder/script.rs
+++ b/core/src/builder/script.rs
@@ -5,6 +5,8 @@
 // Currently generate_witness functions are not yet used.
 #![allow(dead_code)]
 
+use crate::actor::WinternitzDerivationPath;
+use crate::config::protocol::ProtocolParamset;
 use crate::EVMAddress;
 use bitcoin::hashes::{hash160, Hash};
 use bitcoin::opcodes::OP_TRUE;
@@ -16,6 +18,7 @@ use bitcoin::{
 };
 use bitcoin::{taproot, Amount, Txid, Witness};
 use bitvm::signatures::winternitz::{Parameters, PublicKey, SecretKey};
+use eyre::{Context, Result};
 use std::any::Any;
 use std::fmt::Debug;
 
@@ -24,6 +27,67 @@ pub enum SpendPath {
     ScriptSpend(usize),
     KeySpend,
     Unknown,
+}
+
+/// Converts a minimal serialized u32 (trailing zeros removed) to full 4 byte representation
+fn from_minimal_to_u32_le_bytes(minimal: &[u8]) -> Result<[u8; 4]> {
+    if minimal.len() > 4 {
+        return Err(eyre::eyre!("u32 bytes length is greater than 4"));
+    }
+    let mut bytes = [0u8; 4];
+    bytes[..minimal.len()].copy_from_slice(minimal);
+    Ok(bytes)
+}
+
+/// Extracts the committed data from the witness.
+/// Note: The function is hardcoded for winternitz_log_d = 4 currently, will not work for others.
+pub fn extract_winternitz_commits(
+    witness: Witness,
+    wt_derive_paths: &[WinternitzDerivationPath],
+    paramset: &'static ProtocolParamset,
+) -> Result<Vec<Vec<u8>>> {
+    if paramset.winternitz_log_d != 4 {
+        return Err(eyre::eyre!("Only winternitz_log_d = 4 is supported"));
+    }
+    let mut commits: Vec<Vec<u8>> = Vec::new();
+    let mut cur_witness_iter = witness.into_iter().skip(1);
+
+    for wt_path in wt_derive_paths.iter().rev() {
+        let wt_params = wt_path.get_params();
+        let message_digits =
+            (wt_params.byte_message_length() * 8).div_ceil(paramset.winternitz_log_d) as usize;
+        let checksum_digits = wt_params.total_length() as usize - message_digits;
+
+        let mut elements: Vec<&[u8]> = cur_witness_iter
+            .by_ref()
+            .skip(1)
+            .step_by(2)
+            .take(message_digits)
+            .collect();
+        elements.reverse();
+
+        // advance iterator to skip checksum digits at the end
+        cur_witness_iter.by_ref().nth(checksum_digits * 2 - 1);
+
+        commits.push(
+            elements
+                .chunks_exact(2)
+                .map(|digits| {
+                    let first_digit = u32::from_le_bytes(from_minimal_to_u32_le_bytes(digits[0])?);
+                    let second_digit = u32::from_le_bytes(from_minimal_to_u32_le_bytes(digits[1])?);
+
+                    let first_u8 = u8::try_from(first_digit)
+                        .wrap_err("Failed to convert first digit to u8")?;
+                    let second_u8 = u8::try_from(second_digit)
+                        .wrap_err("Failed to convert second digit to u8")?;
+
+                    Ok(second_u8 * (1 << paramset.winternitz_log_d) + first_u8)
+                })
+                .collect::<Result<Vec<_>>>()?,
+        );
+    }
+    commits.reverse();
+    Ok(commits)
 }
 
 /// A trait that marks all script types. Each script has a `generate_script_inputs` (eg. [`WinternitzCommit::generate_script_inputs`]) function that
@@ -933,5 +997,74 @@ mod tests {
             .send_raw_transaction(tx.get_cached_tx())
             .await
             .expect("bitcoin RPC did not accept transaction");
+    }
+
+    #[tokio::test]
+    async fn test_extract_commit_data() {
+        let config = create_test_config_with_thread_name().await;
+        let kp = bitcoin::secp256k1::Keypair::new(&SECP, &mut rand::thread_rng());
+
+        let signer = Actor::new(
+            kp.secret_key(),
+            Some(kp.secret_key()),
+            bitcoin::Network::Regtest,
+        );
+
+        let kickoff = WinternitzDerivationPath::Kickoff(0, 0, config.protocol_paramset());
+        let bitvm_assert = WinternitzDerivationPath::BitvmAssert(
+            64,
+            3,
+            0,
+            OutPoint {
+                txid: Txid::all_zeros(),
+                vout: 0,
+            },
+            config.protocol_paramset(),
+        );
+        let commit_script = WinternitzCommit::new(
+            vec![
+                (
+                    signer
+                        .derive_winternitz_pk(kickoff.clone())
+                        .expect("failed to derive Winternitz public key"),
+                    40,
+                ),
+                (
+                    signer
+                        .derive_winternitz_pk(bitvm_assert.clone())
+                        .expect("failed to derive Winternitz public key"),
+                    64,
+                ),
+            ],
+            signer.xonly_public_key,
+            4,
+        );
+        let signature = taproot::Signature::from_slice(&[1u8; 64]).expect("valid signature");
+        let kickoff_blockhash: Vec<u8> = (0..20u8).collect();
+        let assert_commit_data: Vec<u8> = (0..32u8).collect();
+        let witness = commit_script.generate_script_inputs(
+            &[
+                (
+                    kickoff_blockhash.clone(),
+                    signer.get_derived_winternitz_sk(kickoff.clone()).unwrap(),
+                ),
+                (
+                    assert_commit_data.clone(),
+                    signer
+                        .get_derived_winternitz_sk(bitvm_assert.clone())
+                        .unwrap(),
+                ),
+            ],
+            &signature,
+        );
+        let extracted = extract_winternitz_commits(
+            witness,
+            &[kickoff, bitvm_assert],
+            config.protocol_paramset(),
+        )
+        .unwrap();
+        tracing::info!("{:?}", extracted);
+        assert_eq!(extracted[0], kickoff_blockhash);
+        assert_eq!(extracted[1], assert_commit_data);
     }
 }

--- a/core/src/builder/transaction/creator.rs
+++ b/core/src/builder/transaction/creator.rs
@@ -120,13 +120,14 @@ impl ReimburseDbCache {
         }
     }
 
-    pub fn from_context(db: Database, context: ContractContext) -> Self {
+    pub fn from_context(db: Database, context: &ContractContext) -> Self {
         if context.deposit_data.is_some() {
             Self::new_for_deposit(
                 db,
                 context.operator_idx,
                 context
                     .deposit_data
+                    .as_ref()
                     .expect("checked in if statement")
                     .get_deposit_outpoint(),
                 context.paramset,

--- a/core/src/builder/transaction/deposit_signature_owner.rs
+++ b/core/src/builder/transaction/deposit_signature_owner.rs
@@ -65,7 +65,6 @@ impl SignatureId {
                     ChallengeTimeout2 => Ok(NofnSharedDeposit(SighashDefault)),
                     MiniAssert1 => Ok(Own(SighashDefault)),
                     OperatorChallengeAck1 => Ok(Own(SighashDefault)),
-                    WatchtowerChallenge1 => Ok(Own(SighashDefault)),
                     NotStored => Ok(NotOwned),
                     YieldKickoffTxid => Ok(NotOwned),
                 }

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -673,6 +673,7 @@ where
             deposit_data,
             kickoff_id,
         };
+
         let signed_txs = create_and_sign_txs(
             self.db.clone(),
             &self.signer,
@@ -1033,9 +1034,9 @@ where
                 );
                 let kickoff_data = self
                     .db
-                    .get_deposit_signatures_with_kickoff_txid(None, txid)
+                    .get_deposit_data_with_kickoff_txid(None, txid)
                     .await?;
-                if let Some((deposit_data, kickoff_id, _)) = kickoff_data {
+                if let Some((deposit_data, kickoff_id)) = kickoff_data {
                     // add kickoff machine if there is a new kickoff
                     let mut dbtx = self.db.begin_transaction().await?;
                     StateManager::<Self>::dispatch_new_kickoff_machine(
@@ -1059,8 +1060,7 @@ where
         tx_type: TransactionType,
         contract_context: ContractContext,
     ) -> Result<BTreeMap<TransactionType, TxHandler>, BridgeError> {
-        let mut db_cache =
-            ReimburseDbCache::from_context(self.db.clone(), contract_context.clone());
+        let mut db_cache = ReimburseDbCache::from_context(self.db.clone(), &contract_context);
         let txhandlers = create_txhandlers(
             tx_type,
             contract_context,

--- a/core/src/rpc/clementine.proto
+++ b/core/src/rpc/clementine.proto
@@ -30,8 +30,7 @@ enum NormalSignatureKind {
   MiniAssert1 = 11;
   OperatorChallengeAck1 = 12;
   NotStored = 13;
-  WatchtowerChallenge1 = 14;
-  YieldKickoffTxid = 15;
+  YieldKickoffTxid = 14;
 }
 
 // Signatures that are needed multiple times per an operators kickoff.

--- a/core/src/rpc/clementine.rs
+++ b/core/src/rpc/clementine.rs
@@ -406,8 +406,7 @@ pub enum NormalSignatureKind {
     MiniAssert1 = 11,
     OperatorChallengeAck1 = 12,
     NotStored = 13,
-    WatchtowerChallenge1 = 14,
-    YieldKickoffTxid = 15,
+    YieldKickoffTxid = 14,
 }
 impl NormalSignatureKind {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -430,7 +429,6 @@ impl NormalSignatureKind {
             Self::MiniAssert1 => "MiniAssert1",
             Self::OperatorChallengeAck1 => "OperatorChallengeAck1",
             Self::NotStored => "NotStored",
-            Self::WatchtowerChallenge1 => "WatchtowerChallenge1",
             Self::YieldKickoffTxid => "YieldKickoffTxid",
         }
     }
@@ -451,7 +449,6 @@ impl NormalSignatureKind {
             "MiniAssert1" => Some(Self::MiniAssert1),
             "OperatorChallengeAck1" => Some(Self::OperatorChallengeAck1),
             "NotStored" => Some(Self::NotStored),
-            "WatchtowerChallenge1" => Some(Self::WatchtowerChallenge1),
             "YieldKickoffTxid" => Some(Self::YieldKickoffTxid),
             _ => None,
         }

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -15,6 +15,7 @@ use crate::{
     rpc::parser::{self},
 };
 use bitcoin::secp256k1::PublicKey;
+use bitcoin::Witness;
 use clementine::verifier_deposit_finalize_params::Params;
 use secp256k1::musig::MusigAggNonce;
 use tokio::sync::mpsc::{self, error::SendError};
@@ -419,13 +420,20 @@ where
         request: Request<clementine::Txid>,
     ) -> Result<Response<Empty>, Status> {
         let txid = request.into_inner();
+        let txid = bitcoin::Txid::try_from(txid).expect("Should be able to convert");
         let mut dbtx = self.verifier.db.begin_transaction().await?;
-        self.verifier
-            .handle_kickoff(
-                &mut dbtx,
-                bitcoin::Txid::try_from(txid).expect("Should be able to convert"),
-            )
+        let kickoff_data = self
+            .verifier
+            .db
+            .get_deposit_data_with_kickoff_txid(None, txid)
             .await?;
+        if let Some((deposit_data, kickoff_id)) = kickoff_data {
+            self.verifier
+                .handle_kickoff(&mut dbtx, Witness::new(), deposit_data, kickoff_id)
+                .await?;
+        } else {
+            return Err(Status::not_found("Kickoff txid not found"));
+        }
         dbtx.commit().await.expect("Failed to commit transaction");
         Ok(Response::new(Empty {}))
     }

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -2,14 +2,17 @@ use std::time::Duration;
 
 use super::common::citrea::BRIDGE_PARAMS;
 use crate::bitvm_client::SECP;
+use crate::builder::transaction::DepositData;
 use crate::citrea::mock::MockCitreaClient;
 use crate::citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER};
 use crate::database::Database;
-use crate::rpc::clementine::{KickoffId, TransactionRequest, WithdrawParams};
+use crate::rpc::clementine::{
+    FinalizedPayoutParams, KickoffId, TransactionRequest, WithdrawParams,
+};
 use crate::test::common::citrea::SECRET_KEYS;
 use crate::test::common::tx_utils::{
     ensure_outpoint_spent, ensure_outpoint_spent_while_waiting_for_light_client_sync,
-    ensure_tx_onchain,
+    ensure_tx_onchain, get_txid_where_utxo_is_spent,
 };
 use crate::test::common::{
     create_regtest_rpc, generate_withdrawal_transaction_and_signature, mine_once_after_in_mempool,
@@ -383,7 +386,7 @@ async fn citrea_deposit_and_withdraw_e2e() -> Result<()> {
 }
 
 #[tokio::test]
-async fn mock_citrea_run() {
+async fn mock_citrea_run_truthful() {
     let mut config = create_test_config_with_thread_name().await;
     let regtest = create_regtest_rpc(&mut config).await;
     let rpc = regtest.rpc().clone();
@@ -669,4 +672,206 @@ async fn mock_citrea_run() {
     ensure_outpoint_spent(&rpc, reimburse_connector)
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn mock_citrea_run_malicious() {
+    let mut config = create_test_config_with_thread_name().await;
+    let regtest = create_regtest_rpc(&mut config).await;
+    let rpc = regtest.rpc().clone();
+    let mut citrea_client =
+        MockCitreaClient::new(config.citrea_rpc_url.clone(), "".to_string(), None)
+            .await
+            .unwrap();
+
+    tracing::info!("Running deposit");
+
+    tracing::info!(
+        "Deposit starting block_height: {:?}",
+        rpc.client.get_block_count().await.unwrap()
+    );
+    let (
+        _verifiers,
+        mut operators,
+        _aggregator,
+        _cleanup,
+        deposit_params,
+        move_txid,
+        _deposit_blockhash,
+    ) = run_single_deposit::<MockCitreaClient>(&mut config, rpc.clone(), None)
+        .await
+        .unwrap();
+
+    // sleep for 1 second
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    tracing::info!(
+        "Deposit ending block_height: {:?}",
+        rpc.client.get_block_count().await.unwrap()
+    );
+    // rpc.mine_blocks(DEFAULT_FINALITY_DEPTH).await.unwrap();
+
+    // Send deposit to Citrea
+    let tx = rpc
+        .client
+        .get_raw_transaction(&move_txid, None)
+        .await
+        .unwrap();
+    let tx_info = rpc
+        .client
+        .get_raw_transaction_info(&move_txid, None)
+        .await
+        .unwrap();
+    let block = rpc
+        .client
+        .get_block(&tx_info.blockhash.unwrap())
+        .await
+        .unwrap();
+    let _block_height = rpc
+        .client
+        .get_block_info(&block.block_hash())
+        .await
+        .unwrap()
+        .height as u64;
+
+    tracing::info!("Depositing to Citrea");
+    let current_block_height = rpc.client.get_block_count().await.unwrap();
+    citrea_client
+        .insert_deposit_move_txid(current_block_height + 1, tx.compute_txid())
+        .await;
+    rpc.mine_blocks(5).await.unwrap();
+
+    // rpc.mine_blocks(config.protocol_paramset().finality_depth as u64 + 2)
+    //     .await
+    //     .unwrap();
+
+    // Make a withdrawal
+    let user_sk = SecretKey::from_slice(&[13u8; 32]).unwrap();
+    let withdrawal_address = Address::p2tr(
+        &SECP,
+        user_sk.x_only_public_key(&SECP).0,
+        None,
+        config.protocol_paramset().network,
+    );
+    let (
+        UTXO {
+            outpoint: withdrawal_utxo,
+            ..
+        },
+        _payout_txout,
+        _sig,
+    ) = generate_withdrawal_transaction_and_signature(
+        &config,
+        &rpc,
+        &withdrawal_address,
+        config.protocol_paramset().bridge_amount
+            - config
+                .operator_withdrawal_fee_sats
+                .unwrap_or(Amount::from_sat(0)),
+    )
+    .await;
+
+    citrea_client
+        .insert_withdrawal_utxo(current_block_height + 1, withdrawal_utxo)
+        .await;
+    rpc.mine_blocks(5).await.unwrap();
+
+    // Mine some blocks so that block syncer counts it as finalzied
+    // rpc.mine_blocks(config.protocol_paramset().finality_depth as u64 + 2)
+    //     .await
+    //     .unwrap();
+
+    rpc.mine_blocks(DEFAULT_FINALITY_DEPTH + 2).await.unwrap();
+
+    // Setup tx_sender for sending transactions
+    let verifier_0_config = {
+        let mut config = config.clone();
+        config.db_name += "0";
+        config
+    };
+
+    let db = Database::new(&verifier_0_config)
+        .await
+        .expect("failed to create database");
+
+    let dep_data: DepositData = deposit_params.clone().try_into().unwrap();
+
+    let kickoff_txid: bitcoin::Txid = operators[0]
+        .internal_finalized_payout(FinalizedPayoutParams {
+            payout_blockhash: vec![0u8; 32],
+            deposit_outpoint: Some(dep_data.get_deposit_outpoint().into()),
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .try_into()
+        .unwrap();
+
+    // wait 3 seconds so fee payer txs are sent to mempool
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    // mine 1 block to make sure the fee payer txs are in the next block
+    rpc.mine_blocks(1).await.unwrap();
+
+    // Wait for the kickoff tx to be onchain
+    let _kickoff_block_height =
+        mine_once_after_in_mempool(&rpc, kickoff_txid, Some("Kickoff tx"), Some(1800))
+            .await
+            .unwrap();
+
+    rpc.mine_blocks(DEFAULT_FINALITY_DEPTH + 2).await.unwrap();
+
+    // wait until the light client prover is synced to the same height
+
+    //we need to check that challenge is sent
+    let mut used_utxo = 1000000000;
+    // get kickoff_idx that was used to sign the kickoff
+    for i in 0..config.protocol_paramset().num_kickoffs_per_round as u32 {
+        let kickoff_tx = db
+            .get_kickoff_txid_for_used_kickoff_connector(None, 0, i)
+            .await;
+        if let Ok(Some(used_kickoff_txid)) = kickoff_tx {
+            if used_kickoff_txid == kickoff_txid {
+                used_utxo = i;
+                break;
+            }
+        }
+    }
+
+    assert!(used_utxo != 1000000000);
+
+    tracing::warn!("Used utxo: {:?}", used_utxo);
+
+    let signed_txs = operators[0]
+        .internal_create_signed_txs(TransactionRequest {
+            deposit_params: Some(deposit_params),
+            kickoff_id: Some(KickoffId {
+                operator_idx: 0,
+                round_idx: 0,
+                kickoff_idx: used_utxo,
+            }),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    let challenge_timeout_txid = get_tx_from_signed_txs_with_type(
+        &signed_txs,
+        crate::builder::transaction::TransactionType::ChallengeTimeout,
+    )
+    .unwrap()
+    .compute_txid();
+
+    let challenge_outpoint = OutPoint {
+        txid: kickoff_txid,
+        vout: 0,
+    };
+
+    let challenge_spent_txid = get_txid_where_utxo_is_spent(&rpc, challenge_outpoint)
+        .await
+        .unwrap();
+
+    // check that challenge utxo was not spent on timeout -> meaning challenge was sent
+    assert!(challenge_spent_txid != challenge_timeout_txid);
+
+    // TODO: check that operators collateral got burned. It cant be checked right now as we dont have auto disprove implemented.
 }

--- a/core/src/test/full_flow.rs
+++ b/core/src/test/full_flow.rs
@@ -720,7 +720,7 @@ pub async fn run_bad_path_3(config: &mut BridgeConfig, rpc: ExtendedRpc) -> Resu
     Ok(())
 }
 
-fn get_tx_from_signed_txs_with_type(
+pub fn get_tx_from_signed_txs_with_type(
     txs: &SignedTxsWithType,
     tx_type: TxType,
 ) -> Result<bitcoin::Transaction> {

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -924,7 +924,15 @@ where
         let payout_info = self
             .db
             .get_payout_info_from_move_txid(None, move_txid)
-            .await?;
+            .await;
+        if let Err(e) = &payout_info {
+            tracing::warn!(
+                "Couldn't retrieve payout info from db {}, assuming malicious",
+                e
+            );
+            return Ok(true);
+        }
+        let payout_info = payout_info?;
         if let Some((operator_idx, payout_blockhash)) = payout_info {
             if operator_idx != kickoff_id.operator_idx {
                 return Ok(true);

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -1,7 +1,8 @@
-use crate::actor::Actor;
+use crate::actor::{Actor, WinternitzDerivationPath};
 use crate::bitcoin_syncer::BitcoinSyncer;
 use crate::bitvm_client::{self, ClementineBitVMPublicKeys, SECP};
 use crate::builder::address::taproot_builder_with_scripts;
+use crate::builder::script::extract_winternitz_commits;
 use crate::builder::sighash::{
     create_nofn_sighash_stream, create_operator_sighash_stream, PartialSignatureInfo, SignatureInfo,
 };
@@ -30,9 +31,9 @@ use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::schnorr::Signature;
 use bitcoin::secp256k1::Message;
 use bitcoin::{secp256k1::PublicKey, OutPoint};
-use bitcoin::{Address, ScriptBuf, TapTweakHash, XOnlyPublicKey};
+use bitcoin::{Address, ScriptBuf, TapTweakHash, Witness, XOnlyPublicKey};
 use bitvm::signatures::winternitz;
-use eyre::{Context, OptionExt};
+use eyre::{Context, OptionExt, Result};
 use secp256k1::musig::{MusigAggNonce, MusigPartialSignature, MusigPubNonce, MusigSecNonce};
 use std::collections::{BTreeMap, HashMap};
 use std::pin::pin;
@@ -908,29 +909,68 @@ where
         Ok(())
     }
 
-    // TODO: #402
+    /// Checks if the operator who sent the kickoff matches the payout data saved in our db
+    /// Payout data in db is updated during citrea sync.
     async fn is_kickoff_malicious(
         &self,
-        _kickoff_txid: bitcoin::Txid,
+        kickoff_witness: Witness,
+        deposit_data: &DepositData,
+        kickoff_id: KickoffId,
     ) -> Result<bool, BridgeError> {
+        let move_txid =
+            create_move_to_vault_txhandler(deposit_data.clone(), self.config.protocol_paramset())?
+                .get_cached_tx()
+                .compute_txid();
+        let payout_info = self
+            .db
+            .get_payout_info_from_move_txid(None, move_txid)
+            .await?;
+        if let Some((operator_idx, payout_blockhash)) = payout_info {
+            if operator_idx != kickoff_id.operator_idx {
+                return Ok(true);
+            }
+            let wt_derive_path = WinternitzDerivationPath::Kickoff(
+                kickoff_id.round_idx,
+                kickoff_id.kickoff_idx,
+                self.config.protocol_paramset(),
+            );
+            let commits = extract_winternitz_commits(
+                kickoff_witness,
+                &[wt_derive_path],
+                self.config.protocol_paramset(),
+            )?;
+            let blockhash_data = commits.first();
+            // only last 20 bytes of the blockhash is committed
+            let truncated_blockhash = &payout_blockhash[12..];
+            if let Some(committed_blockhash) = blockhash_data {
+                if committed_blockhash != truncated_blockhash {
+                    tracing::warn!("Payout blockhash does not match committed hash: committed: {:?}, truncated payout blockhash: {:?}",
+                        blockhash_data, truncated_blockhash);
+                    return Ok(true);
+                }
+            } else {
+                return Err(BridgeError::Error(
+                    "Couldn't retrieve committed data from witness".to_string(),
+                ));
+            }
+            return Ok(false);
+        }
         Ok(true)
     }
 
     pub async fn handle_kickoff<'a>(
         &'a self,
         dbtx: DatabaseTransaction<'a, '_>,
-        kickoff_txid: bitcoin::Txid,
+        kickoff_witness: Witness,
+        deposit_data: DepositData,
+        kickoff_id: KickoffId,
     ) -> Result<(), BridgeError> {
-        let is_malicious = self.is_kickoff_malicious(kickoff_txid).await?;
+        let is_malicious = self
+            .is_kickoff_malicious(kickoff_witness, &deposit_data, kickoff_id)
+            .await?;
         if !is_malicious {
             return Ok(());
         }
-
-        let (deposit_data, kickoff_id, _) = self
-            .db
-            .get_deposit_signatures_with_kickoff_txid(None, kickoff_txid)
-            .await?
-            .ok_or(eyre::eyre!("Kickoff txid not found"))?;
 
         let transaction_data = TransactionRequestData {
             deposit_data: deposit_data.clone(),
@@ -1171,9 +1211,9 @@ where
                 );
                 let kickoff_data = self
                     .db
-                    .get_deposit_signatures_with_kickoff_txid(None, txid)
+                    .get_deposit_data_with_kickoff_txid(None, txid)
                     .await?;
-                if let Some((deposit_data, kickoff_id, _)) = kickoff_data {
+                if let Some((deposit_data, kickoff_id)) = kickoff_data {
                     // add kickoff machine if there is a new kickoff
                     let mut dbtx = self.db.begin_transaction().await?;
                     StateManager::<Self>::dispatch_new_kickoff_machine(
@@ -1181,11 +1221,12 @@ where
                         &mut dbtx,
                         kickoff_id,
                         block_height,
-                        deposit_data,
-                        witness,
+                        deposit_data.clone(),
+                        witness.clone(),
                     )
                     .await?;
-                    self.handle_kickoff(&mut dbtx, txid).await?;
+                    self.handle_kickoff(&mut dbtx, witness, deposit_data, kickoff_id)
+                        .await?;
                     dbtx.commit().await?;
                 }
             }
@@ -1198,8 +1239,7 @@ where
         tx_type: TransactionType,
         contract_context: ContractContext,
     ) -> Result<BTreeMap<TransactionType, TxHandler>, BridgeError> {
-        let mut db_cache =
-            ReimburseDbCache::from_context(self.db.clone(), contract_context.clone());
+        let mut db_cache = ReimburseDbCache::from_context(self.db.clone(), &contract_context);
         let txhandlers = create_txhandlers(
             tx_type,
             contract_context,


### PR DESCRIPTION
Checks if a kickoff is malicious just by checking payout data in db. Data in db about current payouts should be updated during citrea sync. 
Implemented helper function to extract winternitz committed data from witness.


#402