### PR TITLE
Use bitcoin_syncer db in header chain prover

### DIFF
--- a/core/src/bitcoin_syncer.rs
+++ b/core/src/bitcoin_syncer.rs
@@ -76,12 +76,7 @@ pub(crate) async fn save_block(
     );
 
     let block_id = db
-        .add_block_info(
-            Some(dbtx),
-            &block_hash,
-            &block.header.prev_blockhash,
-            block_height,
-        )
+        .add_block_info(Some(dbtx), block.header, block_hash, block_height)
         .await?;
 
     db.store_full_block(Some(dbtx), block, block_height).await?;

--- a/core/src/database/bitcoin_syncer.rs
+++ b/core/src/database/bitcoin_syncer.rs
@@ -1,29 +1,38 @@
 use super::{
-    wrapper::{BlockHashDB, TxidDB},
+    wrapper::{BlockHashDB, BlockHeaderDB, TxidDB},
     Database, DatabaseTransaction,
 };
 use crate::{bitcoin_syncer::BitcoinSyncerEvent, errors::BridgeError, execute_query_with_tx};
-use bitcoin::{BlockHash, OutPoint, Txid};
+use bitcoin::{block::Header, BlockHash, OutPoint, Txid};
 use eyre::Context;
 use std::ops::DerefMut;
 
 impl Database {
-    /// # Returns
+    /// Add a block entry to the database.
     ///
-    /// - [`u32`]: Database entry id, later to be used while referring block
+    /// # Parameters
+    ///
+    /// - [`tx`]: Optional database transaction to use for the query
+    /// - [`block_header`]: Header of the block
+    /// - [`block_hash`]: Hash of the block
+    /// - [`block_height`]: Height of the block
+    ///
+    ///  # Returns
+    ///
+    /// - [`u32`]: Database entry id, later to be used while referring the block
     pub async fn add_block_info(
         &self,
         tx: Option<DatabaseTransaction<'_, '_>>,
-        block_hash: &BlockHash,
-        prev_block_hash: &BlockHash,
-        block_height: u32,
+        header: Header,
+        hash: BlockHash,
+        height: u32,
     ) -> Result<u32, BridgeError> {
         let query = sqlx::query_scalar(
-            "INSERT INTO bitcoin_syncer (blockhash, prev_blockhash, height) VALUES ($1, $2, $3) RETURNING id",
+            "INSERT INTO bitcoin_syncer (header, blockhash, height) VALUES ($1, $2, $3) RETURNING id",
         )
-        .bind(BlockHashDB(*block_hash))
-        .bind(BlockHashDB(*prev_block_hash))
-        .bind(i32::try_from(block_height).wrap_err(BridgeError::IntConversionError)?);
+        .bind(BlockHeaderDB(header))
+        .bind(BlockHashDB(hash))
+        .bind(i32::try_from(height).wrap_err(BridgeError::IntConversionError)?);
 
         let id: i32 = execute_query_with_tx!(self.connection, tx, query, fetch_one)?;
 
@@ -31,6 +40,7 @@ impl Database {
             .wrap_err(BridgeError::IntConversionError)
             .map_err(Into::into)
     }
+
     /// # Returns
     ///
     /// [`Some`] if the block exists in the database, [`None`] otherwise:
@@ -41,21 +51,19 @@ impl Database {
         &self,
         tx: Option<DatabaseTransaction<'_, '_>>,
         block_hash: BlockHash,
-    ) -> Result<Option<(BlockHash, u32)>, BridgeError> {
+    ) -> Result<Option<(Header, u32)>, BridgeError> {
         let query = sqlx::query_as(
-            "SELECT prev_blockhash, height FROM bitcoin_syncer WHERE blockhash = $1 AND is_canonical = true",
+            "SELECT header, height FROM bitcoin_syncer WHERE blockhash = $1 AND is_canonical = true",
         )
         .bind(BlockHashDB(block_hash));
 
-        let ret: Option<(BlockHashDB, i32)> =
+        let ret: Option<(BlockHeaderDB, i32)> =
             execute_query_with_tx!(self.connection, tx, query, fetch_optional)?;
 
-        ret.map(
-            |(prev_hash, height)| -> Result<(BlockHash, u32), BridgeError> {
-                let height = u32::try_from(height).wrap_err(BridgeError::IntConversionError)?;
-                Ok((prev_hash.0, height))
-            },
-        )
+        ret.map(|(header, height)| -> Result<(Header, u32), BridgeError> {
+            let height = u32::try_from(height).wrap_err(BridgeError::IntConversionError)?;
+            Ok((header.0, height))
+        })
         .transpose()
     }
 
@@ -343,12 +351,19 @@ mod tests {
         let mut dbtx = db.begin_transaction().await.unwrap();
 
         // Create a test block
-        let prev_block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32]));
+        let header = Header {
+            version: bitcoin::block::Version::TWO,
+            prev_blockhash: BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32])),
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: 1_000_000,
+            bits: CompactTarget::from_consensus(0),
+            nonce: 12345,
+        };
         let block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x45; 32]));
         let height = 0x45;
 
         let block_id = db
-            .add_block_info(Some(&mut dbtx), &block_hash, &prev_block_hash, height)
+            .add_block_info(Some(&mut dbtx), header, block_hash, height)
             .await
             .unwrap();
 
@@ -476,12 +491,19 @@ mod tests {
         let mut dbtx = db.begin_transaction().await.unwrap();
 
         // Create a test block
-        let prev_block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32]));
+        let header = Header {
+            version: bitcoin::block::Version::TWO,
+            prev_blockhash: BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32])),
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: 1_000_000,
+            bits: CompactTarget::from_consensus(0),
+            nonce: 12345,
+        };
         let block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x45; 32]));
         let height = 0x45;
 
         let block_id = db
-            .add_block_info(Some(&mut dbtx), &block_hash, &prev_block_hash, height)
+            .add_block_info(Some(&mut dbtx), header, block_hash, height)
             .await
             .unwrap();
 
@@ -532,15 +554,26 @@ mod tests {
         let mut dbtx = db.begin_transaction().await.unwrap();
 
         // Create a chain of blocks
-        let prev_block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32]));
+        let header = Header {
+            version: bitcoin::block::Version::TWO,
+            prev_blockhash: BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32])),
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: 1_000_000,
+            bits: CompactTarget::from_consensus(0),
+            nonce: 12345,
+        };
         let heights = [1, 2, 3, 4, 5];
-        let mut last_hash = prev_block_hash;
+        let mut last_hash = header.prev_blockhash;
 
         let mut block_ids = Vec::new();
         for height in heights {
+            let header = Header {
+                prev_blockhash: last_hash,
+                ..header
+            };
             let block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([height as u8; 32]));
             let block_id = db
-                .add_block_info(Some(&mut dbtx), &block_hash, &last_hash, height)
+                .add_block_info(Some(&mut dbtx), header, block_hash, height)
                 .await
                 .unwrap();
             block_ids.push(block_id);
@@ -581,7 +614,14 @@ mod tests {
         let config = create_test_config_with_thread_name().await;
         let db = Database::new(&config).await.unwrap();
 
-        let prev_block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32]));
+        let header = Header {
+            version: bitcoin::block::Version::TWO,
+            prev_blockhash: BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32])),
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: 1_000_000,
+            bits: CompactTarget::from_consensus(0),
+            nonce: 12345,
+        };
         let block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x45; 32]));
         let height = 0x45;
 
@@ -591,7 +631,7 @@ mod tests {
             .unwrap()
             .is_none());
 
-        db.add_block_info(None, &block_hash, &prev_block_hash, height)
+        db.add_block_info(None, header, block_hash, height)
             .await
             .unwrap();
         let block_info = db
@@ -600,29 +640,28 @@ mod tests {
             .unwrap()
             .unwrap();
         let max_height = db.get_max_height(None).await.unwrap().unwrap();
-        assert_eq!(block_info.0, prev_block_hash);
+        assert_eq!(block_info.0, header);
         assert_eq!(block_info.1, height);
         assert_eq!(max_height, height);
 
-        db.add_block_info(
-            None,
-            &BlockHash::from_raw_hash(Hash::from_byte_array([0x1; 32])),
-            &prev_block_hash,
-            height - 1,
-        )
-        .await
-        .unwrap();
+        let header = Header {
+            prev_blockhash: block_hash,
+            ..header
+        };
+        let block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x1; 32]));
+        db.add_block_info(None, header, block_hash, height - 1)
+            .await
+            .unwrap();
         let max_height = db.get_max_height(None).await.unwrap().unwrap();
         assert_eq!(max_height, height);
-
-        db.add_block_info(
-            None,
-            &BlockHash::from_raw_hash(Hash::from_byte_array([0x2; 32])),
-            &prev_block_hash,
-            height + 1,
-        )
-        .await
-        .unwrap();
+        let header = Header {
+            prev_blockhash: block_hash,
+            ..header
+        };
+        let block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x2; 32]));
+        db.add_block_info(None, header, block_hash, height + 1)
+            .await
+            .unwrap();
         let max_height = db.get_max_height(None).await.unwrap().unwrap();
         assert_ne!(max_height, height);
         assert_eq!(max_height, height + 1);
@@ -640,11 +679,18 @@ mod tests {
             .is_err());
         let mut dbtx = db.begin_transaction().await.unwrap();
 
-        let prev_block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32]));
+        let header = Header {
+            version: bitcoin::block::Version::TWO,
+            prev_blockhash: BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32])),
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: 1_000_000,
+            bits: CompactTarget::from_consensus(0),
+            nonce: 12345,
+        };
         let block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x45; 32]));
         let height = 0x45;
         let block_id = db
-            .add_block_info(Some(&mut dbtx), &block_hash, &prev_block_hash, height)
+            .add_block_info(Some(&mut dbtx), header, block_hash, height)
             .await
             .unwrap();
 
@@ -677,11 +723,18 @@ mod tests {
         let db = Database::new(&config).await.unwrap();
         let mut dbtx = db.begin_transaction().await.unwrap();
 
-        let prev_block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32]));
+        let header = Header {
+            version: bitcoin::block::Version::TWO,
+            prev_blockhash: BlockHash::from_raw_hash(Hash::from_byte_array([0x1F; 32])),
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: 1_000_000,
+            bits: CompactTarget::from_consensus(0),
+            nonce: 12345,
+        };
         let block_hash = BlockHash::from_raw_hash(Hash::from_byte_array([0x45; 32]));
         let height = 0x45;
         let block_id = db
-            .add_block_info(Some(&mut dbtx), &block_hash, &prev_block_hash, height)
+            .add_block_info(Some(&mut dbtx), header, block_hash, height)
             .await
             .unwrap();
 

--- a/core/src/database/bitcoin_syncer.rs
+++ b/core/src/database/bitcoin_syncer.rs
@@ -28,9 +28,10 @@ impl Database {
         height: u32,
     ) -> Result<u32, BridgeError> {
         let query = sqlx::query_scalar(
-            "INSERT INTO bitcoin_syncer (header, blockhash, height) VALUES ($1, $2, $3) RETURNING id",
+            "INSERT INTO bitcoin_syncer (header, prev_blockhash, blockhash, height) VALUES ($1, $2, $3, $4) RETURNING id",
         )
         .bind(BlockHeaderDB(header))
+        .bind(BlockHashDB(header.prev_blockhash))
         .bind(BlockHashDB(hash))
         .bind(i32::try_from(height).wrap_err(BridgeError::IntConversionError)?);
 

--- a/core/src/database/bitcoin_syncer.rs
+++ b/core/src/database/bitcoin_syncer.rs
@@ -28,7 +28,7 @@ impl Database {
         height: u32,
     ) -> Result<u32, BridgeError> {
         let query = sqlx::query_scalar(
-            "INSERT INTO bitcoin_syncer (header, prev_blockhash, blockhash, height) VALUES ($1, $2, $3, $4) RETURNING id",
+            "INSERT INTO bitcoin_syncer (block_header, prev_blockhash, blockhash, height) VALUES ($1, $2, $3, $4) RETURNING id",
         )
         .bind(BlockHeaderDB(header))
         .bind(BlockHashDB(header.prev_blockhash))
@@ -54,7 +54,7 @@ impl Database {
         block_hash: BlockHash,
     ) -> Result<Option<(Header, u32)>, BridgeError> {
         let query = sqlx::query_as(
-            "SELECT header, height FROM bitcoin_syncer WHERE blockhash = $1 AND is_canonical = true",
+            "SELECT block_header, height FROM bitcoin_syncer WHERE blockhash = $1 AND is_canonical = true",
         )
         .bind(BlockHashDB(block_hash));
 

--- a/core/src/database/verifier.rs
+++ b/core/src/database/verifier.rs
@@ -295,7 +295,11 @@ mod tests {
     use crate::{
         bitvm_client::SECP, database::Database, test::common::create_test_config_with_thread_name,
     };
-    use bitcoin::{hashes::Hash, BlockHash, Txid};
+    use bitcoin::{
+        block::{Header, Version},
+        hashes::Hash,
+        BlockHash, CompactTarget, TxMerkleNode, Txid,
+    };
 
     #[tokio::test]
     async fn set_get_verifiers_public_keys() {
@@ -339,8 +343,15 @@ mod tests {
         let block_id = db
             .add_block_info(
                 Some(&mut dbtx),
-                &BlockHash::all_zeros(),
-                &BlockHash::all_zeros(),
+                Header {
+                    version: Version::TWO,
+                    prev_blockhash: BlockHash::all_zeros(),
+                    merkle_root: TxMerkleNode::all_zeros(),
+                    time: 0,
+                    bits: CompactTarget::from_consensus(0),
+                    nonce: 0,
+                },
+                BlockHash::all_zeros(),
                 utxo.vout,
             )
             .await

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -1370,9 +1370,6 @@ where
         self.update_finalized_payouts(&mut dbtx, block_id, &block_cache)
             .await?;
 
-        self.header_chain_prover
-            .save_unproven_block_cache(Some(&mut dbtx), &block_cache)
-            .await?;
         self.header_chain_prover.prove_if_ready().await?;
 
         Ok(())

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -23,11 +23,6 @@ create table if not exists funding_utxos (
     funding_utxo jsonb not null,
     created_at timestamp not null default now()
 );
--- Watchtower header chain proofs
-create table if not exists header_chain_proofs (
-    block_hash text primary key not null references bitcoin_syncer (blockhash),
-    proof bytea
-);
 create table if not exists watchtower_xonly_public_keys (
     watchtower_id int not null,
     xonly_pk bytea not null,
@@ -88,7 +83,7 @@ create table if not exists operators_challenge_ack_hashes (
 -------- BITCOIN SYNCER --------
 create table if not exists bitcoin_syncer (
     id serial primary key,
-    header text not null,
+    block_header text not null,
     prev_blockhash text not null,
     blockhash text not null unique,
     height int not null,
@@ -126,6 +121,11 @@ create table if not exists bitcoin_syncer_event_handlers (
     last_processed_event_id int not null,
     created_at timestamp not null default now(),
     primary key (consumer_handle)
+);
+-- Watchtower header chain proofs
+create table if not exists header_chain_proofs (
+    block_hash text primary key not null references bitcoin_syncer (blockhash),
+    proof bytea
 );
 -------- TX SENDER --------
 DO $$ BEGIN IF NOT EXISTS (

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -25,10 +25,7 @@ create table if not exists funding_utxos (
 );
 -- Watchtower header chain proofs
 create table if not exists header_chain_proofs (
-    block_hash text primary key not null,
-    block_header text,
-    prev_block_hash text,
-    height bigint not null,
+    block_hash text primary key not null references bitcoin_syncer (blockhash),
     proof bytea
 );
 create table if not exists watchtower_xonly_public_keys (
@@ -92,6 +89,7 @@ create table if not exists operators_challenge_ack_hashes (
 create table if not exists bitcoin_syncer (
     id serial primary key,
     header text not null,
+    prev_blockhash text not null,
     blockhash text not null unique,
     height int not null,
     is_canonical boolean not null default true

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -91,8 +91,8 @@ create table if not exists operators_challenge_ack_hashes (
 -------- BITCOIN SYNCER --------
 create table if not exists bitcoin_syncer (
     id serial primary key,
+    header text not null,
     blockhash text not null unique,
-    prev_blockhash text not null,
     height int not null,
     is_canonical boolean not null default true
 );


### PR DESCRIPTION
# Description

Saves header data in bitcoin_syncer and uses it in header chain prover while removing block data from it.