### PR TITLE
Check nofn key

### DIFF
--- a/core/src/citrea/mock.rs
+++ b/core/src/citrea/mock.rs
@@ -180,8 +180,8 @@ impl CitreaClientT for MockCitreaClient {
     async fn check_nofn_correctness(
         &self,
         _nofn_xonly_pk: bitcoin::XOnlyPublicKey,
-    ) -> Result<bool, BridgeError> {
-        Ok(true)
+    ) -> Result<(), BridgeError> {
+        Ok(())
     }
 }
 

--- a/core/src/citrea/mock.rs
+++ b/core/src/citrea/mock.rs
@@ -176,6 +176,13 @@ impl CitreaClientT for MockCitreaClient {
     ) -> Result<(u64, u64), BridgeError> {
         Ok((block_height - 1, block_height))
     }
+
+    async fn check_nofn_correctness(
+        &self,
+        _nofn_xonly_pk: bitcoin::XOnlyPublicKey,
+    ) -> Result<bool, BridgeError> {
+        Ok(true)
+    }
 }
 
 impl MockCitreaClient {

--- a/core/src/citrea/mod.rs
+++ b/core/src/citrea/mod.rs
@@ -389,6 +389,9 @@ impl CitreaClientT for CitreaClient {
             .await
             .wrap_err("Failed to get script prefix")?
             ._0;
+        if script_prefix.len() < 34 {
+            return Err(eyre::eyre!("script_prefix is too short").into());
+        }
         let script_nofn_bytes = &script_prefix[2..2 + 32];
         let contract_nofn_xonly_pk = XOnlyPublicKey::from_slice(script_nofn_bytes)
             .wrap_err("Failed to convert citrea contract script nofn bytes to xonly pk")?;

--- a/core/src/citrea/mod.rs
+++ b/core/src/citrea/mod.rs
@@ -134,7 +134,7 @@ pub trait CitreaClientT: Send + Sync + Debug + Clone + 'static {
     async fn check_nofn_correctness(
         &self,
         nofn_xonly_pk: XOnlyPublicKey,
-    ) -> Result<bool, BridgeError>;
+    ) -> Result<(), BridgeError>;
 }
 
 /// Citrea client is responsible for interacting with the Citrea EVM and Citrea
@@ -381,7 +381,7 @@ impl CitreaClientT for CitreaClient {
     async fn check_nofn_correctness(
         &self,
         nofn_xonly_pk: XOnlyPublicKey,
-    ) -> Result<bool, BridgeError> {
+    ) -> Result<(), BridgeError> {
         let script_prefix = self
             .contract
             .scriptPrefix()
@@ -395,7 +395,10 @@ impl CitreaClientT for CitreaClient {
         let script_nofn_bytes = &script_prefix[2..2 + 32];
         let contract_nofn_xonly_pk = XOnlyPublicKey::from_slice(script_nofn_bytes)
             .wrap_err("Failed to convert citrea contract script nofn bytes to xonly pk")?;
-        Ok(contract_nofn_xonly_pk == nofn_xonly_pk)
+        if contract_nofn_xonly_pk != nofn_xonly_pk {
+            return Err(eyre::eyre!("Nofn of deposit does not match with citrea contract").into());
+        }
+        Ok(())
     }
 }
 

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -297,7 +297,10 @@ where
         &self,
         deposit_data: DepositData,
     ) -> Result<mpsc::Receiver<schnorr::Signature>, BridgeError> {
-        self.verify_deposit_nofn(&deposit_data).await?;
+        self.citrea_client
+            .check_nofn_correctness(deposit_data.get_nofn_xonly_pk())
+            .await?;
+
         let mut tweak_cache = TweakCache::default();
         let (sig_tx, sig_rx) = mpsc::channel(1280);
 
@@ -990,17 +993,6 @@ where
             collateral_funding_outpoint: self.collateral_funding_outpoint,
             reimburse_addr: self.reimburse_addr.clone(),
         }
-    }
-
-    async fn verify_deposit_nofn(&self, deposit_data: &DepositData) -> Result<(), BridgeError> {
-        if !self
-            .citrea_client
-            .check_nofn_correctness(deposit_data.get_nofn_xonly_pk())
-            .await?
-        {
-            return Err(eyre::eyre!("Nofn of deposit does not match with citrea contract").into());
-        }
-        Ok(())
     }
 }
 

--- a/core/src/rpc/clementine.proto
+++ b/core/src/rpc/clementine.proto
@@ -265,7 +265,7 @@ message FinalizedPayoutParams {
 // winternitz pubkeys.
 service ClementineOperator {
   // Returns an operator's deposit keys.
-  // Deposit keys inclued Assert BitVM winternitz keys, and challenge ACK hashes.
+  // Deposit keys include Assert BitVM winternitz keys, and challenge ACK hashes.
   rpc GetDepositKeys(DepositParams) returns (OperatorKeys) {}
   // Signs all tx's it can according to given transaction type (use it with AllNeededForDeposit to get almost all tx's)
   // Creates the transactions denoted by the deposit and operator_idx, round_idx, and kickoff_idx.

--- a/core/src/rpc/clementine.rs
+++ b/core/src/rpc/clementine.rs
@@ -765,7 +765,7 @@ pub mod clementine_operator_client {
             self
         }
         /// Returns an operator's deposit keys.
-        /// Deposit keys inclued Assert BitVM winternitz keys, and challenge ACK hashes.
+        /// Deposit keys include Assert BitVM winternitz keys, and challenge ACK hashes.
         pub async fn get_deposit_keys(
             &mut self,
             request: impl tonic::IntoRequest<super::DepositParams>,
@@ -1627,7 +1627,7 @@ pub mod clementine_operator_server {
     #[async_trait]
     pub trait ClementineOperator: std::marker::Send + std::marker::Sync + 'static {
         /// Returns an operator's deposit keys.
-        /// Deposit keys inclued Assert BitVM winternitz keys, and challenge ACK hashes.
+        /// Deposit keys include Assert BitVM winternitz keys, and challenge ACK hashes.
         async fn get_deposit_keys(
             &self,
             request: tonic::Request<super::DepositParams>,

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -4,7 +4,6 @@ use crate::builder::transaction::DepositData;
 use crate::citrea::mock::MockCitreaClient;
 use crate::citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER};
 use crate::database::Database;
-use crate::musig2::AggregateFromPublicKeys;
 use crate::rpc::clementine::{FinalizedPayoutParams, WithdrawParams};
 use crate::test::common::citrea::SECRET_KEYS;
 use crate::test::common::tx_utils::{
@@ -135,21 +134,6 @@ impl TestCase for CitreaDepositAndWithdrawE2E {
             _deposit_blockhash,
             _,
         ) = run_single_deposit::<CitreaClient>(&mut config, rpc.clone(), None).await?;
-
-        let nofn_xonly_pk =
-            bitcoin::XOnlyPublicKey::from_musig2_pks(verifiers_public_keys.clone(), None).unwrap();
-
-        let citrea_client = CitreaClient::new(
-            config.citrea_rpc_url.clone(),
-            config.citrea_light_client_prover_url.clone(),
-            None,
-        )
-        .await?;
-        let nofn_correctness = citrea_client
-            .check_nofn_correctness(nofn_xonly_pk)
-            .await
-            .unwrap();
-        tracing::warn!("Nofn correctness: {:?}", nofn_correctness);
 
         tracing::info!(
             "Deposit ending block_height: {:?}",

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -574,7 +574,7 @@ async fn mock_citrea_run_truthful() {
                 .await?
                 .is_some())
         },
-        Some(Duration::from_secs(180)),
+        Some(Duration::from_secs(300)),
         Some(Duration::from_millis(200)),
     )
     .await
@@ -590,7 +590,7 @@ async fn mock_citrea_run_truthful() {
                 .await?
                 .is_none())
         },
-        Some(Duration::from_secs(180)),
+        Some(Duration::from_secs(300)),
         Some(Duration::from_millis(200)),
     )
     .await

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -434,6 +434,8 @@ where
         session_id: u32,
         mut agg_nonce_rx: mpsc::Receiver<MusigAggNonce>,
     ) -> Result<mpsc::Receiver<MusigPartialSignature>, BridgeError> {
+        self.verify_deposit_nofn(&deposit_data).await?;
+
         let verifier = self.clone();
         let (partial_sig_tx, partial_sig_rx) = mpsc::channel(1280);
         let verifier_index = self
@@ -533,6 +535,8 @@ where
         mut agg_nonce_receiver: mpsc::Receiver<MusigAggNonce>,
         mut operator_sig_receiver: mpsc::Receiver<Signature>,
     ) -> Result<MusigPartialSignature, BridgeError> {
+        self.verify_deposit_nofn(&deposit_data).await?;
+
         let mut tweak_cache = TweakCache::default();
         let deposit_blockhash = self
             .rpc
@@ -1222,6 +1226,17 @@ where
             }
         }
         dbtx.commit().await?;
+        Ok(())
+    }
+
+    async fn verify_deposit_nofn(&self, deposit_data: &DepositData) -> Result<(), BridgeError> {
+        if !self
+            .citrea_client
+            .check_nofn_correctness(deposit_data.get_nofn_xonly_pk())
+            .await?
+        {
+            return Err(eyre::eyre!("Nofn of deposit does not match with citrea contract").into());
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
#660 

Adds a function to CitreaClientT to check if a xonly pk matches nofn_xonly_pk written in the citrea contract. 
Mock client always returns true, CitreaClient retrieves nofn key from contracts scriptPrefix variable and checks equality.

Also re-enables citrea e2e test that was ignored.

Note: As contract is getting updated we need to update check_nofn_correctness function and Bridge.json file later.