### PR TITLE
Block sync fix

### DIFF
--- a/core/src/bitcoin_syncer.rs
+++ b/core/src/bitcoin_syncer.rs
@@ -185,7 +185,7 @@ pub async fn set_initial_block_info_if_not_exists(
     let mut height = paramset.start_height;
     let mut dbtx = db.begin_transaction().await?;
     // first collect previous needed blocks according to paramset start height
-    while height < current_height {
+    while height <= current_height {
         let block_info = fetch_block_info_from_height(rpc, height).await?;
         let block = rpc
             .client
@@ -197,16 +197,6 @@ pub async fn set_initial_block_info_if_not_exists(
             .await?;
         height += 1;
     }
-    let block_info = fetch_block_info_from_height(rpc, current_height).await?;
-    let block = rpc
-        .client
-        .get_block(&block_info.hash)
-        .await
-        .wrap_err("Failed to get block")?;
-
-    let block_id = save_block(db, &mut dbtx, &block, current_height).await?;
-    db.add_event(Some(&mut dbtx), BitcoinSyncerEvent::NewBlock(block_id))
-        .await?;
 
     dbtx.commit().await?;
 

--- a/core/src/bitcoin_syncer.rs
+++ b/core/src/bitcoin_syncer.rs
@@ -111,7 +111,7 @@ async fn _get_block_info_from_hash(
     let block_height = db
         .get_block_info_from_hash(Some(dbtx), hash)
         .await?
-        .ok_or_else(|| eyre::eyre!("Block not found"))?
+        .ok_or_else(|| eyre::eyre!("Block not found in get_block_info_from_hash"))?
         .1;
 
     let mut block_utxos: Vec<Vec<OutPoint>> = Vec::new();
@@ -350,7 +350,7 @@ impl BitcoinSyncer {
         let current_height = db
             .get_max_height(None)
             .await?
-            .ok_or_else(|| eyre::eyre!("Block not found"))?;
+            .ok_or_else(|| eyre::eyre!("Block not found in BitcoinSyncer::new"))?;
 
         Ok(Self {
             db,

--- a/core/src/citrea/mock.rs
+++ b/core/src/citrea/mock.rs
@@ -174,7 +174,14 @@ impl CitreaClientT for MockCitreaClient {
         block_height: u64,
         _timeout: Duration,
     ) -> Result<(u64, u64), BridgeError> {
-        Ok((block_height - 1, block_height))
+        Ok((
+            if block_height == 0 {
+                0
+            } else {
+                block_height - 1
+            },
+            block_height,
+        ))
     }
 
     async fn check_nofn_correctness(

--- a/core/src/config/protocol.rs
+++ b/core/src/config/protocol.rs
@@ -190,7 +190,7 @@ pub const REGTEST_PARAMSET: ProtocolParamset = ProtocolParamset {
     time_to_send_watchtower_challenge: 4 * BLOCKS_PER_HOUR * 3 / 2,
     time_to_disprove: 4 * BLOCKS_PER_HOUR * 4 + 4 * BLOCKS_PER_HOUR / 2,
     finality_depth: 0,
-    start_height: 0,
+    start_height: 201,
 };
 
 pub const TESTNET4_PARAMSET: ProtocolParamset = ProtocolParamset {

--- a/core/src/config/protocol.rs
+++ b/core/src/config/protocol.rs
@@ -189,8 +189,8 @@ pub const REGTEST_PARAMSET: ProtocolParamset = ProtocolParamset {
     watchtower_challenge_timeout_timelock: 4 * BLOCKS_PER_HOUR * 2,
     time_to_send_watchtower_challenge: 4 * BLOCKS_PER_HOUR * 3 / 2,
     time_to_disprove: 4 * BLOCKS_PER_HOUR * 4 + 4 * BLOCKS_PER_HOUR / 2,
-    finality_depth: 1,
-    start_height: 201,
+    finality_depth: 0,
+    start_height: 0,
 };
 
 pub const TESTNET4_PARAMSET: ProtocolParamset = ProtocolParamset {

--- a/core/src/states/event.rs
+++ b/core/src/states/event.rs
@@ -138,7 +138,7 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
             }
         }
         // Save the state machines to the database with the current block height
-        self.save_state_to_db(self.last_processed_block_height, Some(dbtx))
+        self.save_state_to_db(self.next_height_to_process, Some(dbtx))
             .await?;
         Ok(())
     }

--- a/core/src/states/mod.rs
+++ b/core/src/states/mod.rs
@@ -146,8 +146,14 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
         // Start a transaction
         let mut tx = self.db.begin_transaction().await?;
 
+        // Get the owner type from the context
+        let owner_type = &self.context.owner_type;
+
         // First, check if we have any state saved
-        let status = self.db.get_next_height_to_process(Some(&mut tx)).await?;
+        let status = self
+            .db
+            .get_next_height_to_process(Some(&mut tx), owner_type)
+            .await?;
 
         // If no state is saved, return early
         let Some(block_height) = status else {
@@ -156,10 +162,7 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
             return Ok(());
         };
 
-        tracing::info!("Loading state machines from block height {}", block_height);
-
-        // Get the owner type from the context
-        let owner_type = &self.context.owner_type;
+        tracing::warn!("Loading state machines from block height {}", block_height);
 
         // Load kickoff machines
         let kickoff_machines = self
@@ -300,7 +303,7 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
                     })?;
 
                 // Use the machine's dirty flag to determine if it needs updating
-                Ok((state_json, (kickoff_id), owner_type.clone(), machine.dirty))
+                Ok((state_json, (kickoff_id), machine.dirty))
             })
             .collect();
 
@@ -315,12 +318,7 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
                 let operator_xonly_pk = machine.operator_data.xonly_pk;
 
                 // Use the machine's dirty flag to determine if it needs updating
-                Ok((
-                    state_json,
-                    (operator_xonly_pk),
-                    owner_type.clone(),
-                    machine.dirty,
-                ))
+                Ok((state_json, (operator_xonly_pk), machine.dirty))
             })
             .collect();
 
@@ -331,6 +329,7 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
                 kickoff_machines?,
                 round_machines?,
                 block_height as i32,
+                owner_type,
             )
             .await?;
 
@@ -420,7 +419,10 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
                 self.update_block_cache(&block, block_height);
                 self.process_block_parallel(block_height).await?;
             } else {
-                return Err(eyre::eyre!("Block at height {} not found", block_height));
+                return Err(eyre::eyre!(
+                    "Block at height {} not found in process_and_add_new_states_from_height",
+                    block_height
+                ));
             }
         }
 

--- a/core/src/states/mod.rs
+++ b/core/src/states/mod.rs
@@ -147,10 +147,7 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
         let mut tx = self.db.begin_transaction().await?;
 
         // First, check if we have any state saved
-        let status = self
-            .db
-            .get_last_processed_block_height(Some(&mut tx))
-            .await?;
+        let status = self.db.get_next_height_to_process(Some(&mut tx)).await?;
 
         // If no state is saved, return early
         let Some(block_height) = status else {
@@ -256,7 +253,7 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
 
         tx.commit().await?;
         self.next_height_to_process =
-            u32::try_from(block_height).wrap_err(BridgeError::IntConversionError)? + 1;
+            u32::try_from(block_height).wrap_err(BridgeError::IntConversionError)?;
         Ok(())
     }
     #[cfg(test)]

--- a/core/src/states/task.rs
+++ b/core/src/states/task.rs
@@ -98,7 +98,9 @@ impl<T: Owner + std::fmt::Debug + 'static> Task for BlockFetcherTask<T> {
                 let mut new_tip = false;
 
                 // Update states to catch up to finalized chain
-                while self.next_height <= current_tip_height - self.paramset.finality_depth {
+                while current_tip_height >= self.paramset.finality_depth
+                    && self.next_height <= current_tip_height - self.paramset.finality_depth
+                {
                     new_tip = true;
 
                     let block = self
@@ -106,8 +108,8 @@ impl<T: Owner + std::fmt::Debug + 'static> Task for BlockFetcherTask<T> {
                         .get_full_block(Some(&mut dbtx), self.next_height)
                         .await?
                         .ok_or(BridgeError::Error(format!(
-                            "Block at height {} not found",
-                            self.next_height
+                            "Block at height {} not found in BlockFetcherTask, current tip height is {}",
+                            self.next_height, current_tip_height
                         )))?;
 
                     let event = SystemEvent::NewBlock {

--- a/core/src/states/task.rs
+++ b/core/src/states/task.rs
@@ -32,8 +32,8 @@ pub struct BlockFetcherTask<T: Owner + std::fmt::Debug + 'static> {
     queue: PGMQueueExt,
     /// Queue name for this owner type
     queue_name: String,
-    /// The last height that was processed
-    last_sent_height: u32,
+    /// The next height to process
+    next_height: u32,
     /// Protocol parameters
     paramset: &'static ProtocolParamset,
     /// Owner type marker
@@ -43,7 +43,7 @@ pub struct BlockFetcherTask<T: Owner + std::fmt::Debug + 'static> {
 impl<T: Owner + std::fmt::Debug + 'static> BlockFetcherTask<T> {
     /// Creates a new block fetcher task
     pub async fn new(
-        last_processed_block_height: u32,
+        next_height: u32,
         db: Database,
         paramset: &'static ProtocolParamset,
     ) -> Result<Self, BridgeError> {
@@ -53,14 +53,14 @@ impl<T: Owner + std::fmt::Debug + 'static> BlockFetcherTask<T> {
         tracing::info!(
             "Creating block fetcher task for owner type {} starting from height {}",
             T::OWNER_TYPE,
-            last_processed_block_height
+            next_height
         );
 
         Ok(Self {
             db,
             queue,
             queue_name,
-            last_sent_height: last_processed_block_height,
+            next_height,
             paramset,
             _phantom: std::marker::PhantomData,
         })
@@ -98,25 +98,22 @@ impl<T: Owner + std::fmt::Debug + 'static> Task for BlockFetcherTask<T> {
                 let mut new_tip = false;
 
                 // Update states to catch up to finalized chain
-                while self.last_sent_height < current_tip_height - self.paramset.finality_depth + 1
-                {
+                while self.next_height <= current_tip_height - self.paramset.finality_depth {
                     new_tip = true;
-
-                    let next_height = self.last_sent_height + 1;
 
                     let block = self
                         .db
-                        .get_full_block(Some(&mut dbtx), next_height)
+                        .get_full_block(Some(&mut dbtx), self.next_height)
                         .await?
                         .ok_or(BridgeError::Error(format!(
                             "Block at height {} not found",
-                            next_height
+                            self.next_height
                         )))?;
 
                     let event = SystemEvent::NewBlock {
                         block_id,
                         block,
-                        height: next_height,
+                        height: self.next_height,
                     };
 
                     self.queue
@@ -129,7 +126,7 @@ impl<T: Owner + std::fmt::Debug + 'static> Task for BlockFetcherTask<T> {
                             ))
                         })?;
 
-                    self.last_sent_height += 1;
+                    self.next_height += 1;
                 }
 
                 new_tip
@@ -209,13 +206,11 @@ impl<T: Owner + std::fmt::Debug + 'static> IntoTask for StateManager<T> {
 
 impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
     pub async fn block_fetcher_task(&self) -> Result<WithDelay<BlockFetcherTask<T>>, BridgeError> {
-        Ok(BlockFetcherTask::<T>::new(
-            self.last_processed_block_height,
-            self.db.clone(),
-            self.paramset,
+        Ok(
+            BlockFetcherTask::<T>::new(self.next_height_to_process, self.db.clone(), self.paramset)
+                .await?
+                .with_delay(POLL_DELAY),
         )
-        .await?
-        .with_delay(POLL_DELAY))
     }
 }
 

--- a/core/src/states/task.rs
+++ b/core/src/states/task.rs
@@ -92,9 +92,10 @@ impl<T: Owner + std::fmt::Debug + 'static> Task for BlockFetcherTask<T> {
                     .db
                     .get_block_info_from_id(Some(&mut dbtx), block_id)
                     .await?
-                    .ok_or(BridgeError::Error("Block not found".to_string()))?
+                    .ok_or(BridgeError::Error(
+                        "Block not found in BlockFetcherTask".to_string(),
+                    ))?
                     .1;
-
                 let mut new_tip = false;
 
                 // Update states to catch up to finalized chain

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -95,11 +95,10 @@ impl TestCase for CitreaDepositAndWithdrawE2E {
             citrea::start_citrea(Self::sequencer_config(), f)
                 .await
                 .unwrap();
-        let block_count = da.get_block_count().await?;
-        println!("Block count before deposit: {:?}", block_count);
-        let lc_prover = lc_prover.unwrap();
 
         let mut config = create_test_config_with_thread_name().await;
+        let lc_prover = lc_prover.unwrap();
+
         citrea::update_config_with_citrea_e2e_values(
             &mut config,
             da,
@@ -117,6 +116,10 @@ impl TestCase for CitreaDepositAndWithdrawE2E {
         )
         .await?;
 
+        rpc.mine_blocks(5).await.unwrap();
+
+        let block_count = da.get_block_count().await?;
+        println!("Block count before deposit: {:?}", block_count);
         tracing::info!("Running deposit");
 
         tracing::info!(

--- a/core/src/tx_sender.rs
+++ b/core/src/tx_sender.rs
@@ -121,7 +121,9 @@ impl Task for TxSenderTask {
                             .db
                             .get_block_info_from_id(Some(&mut dbtx), block_id)
                             .await?
-                            .ok_or(BridgeError::Error("Block not found".to_string()))?
+                            .ok_or(BridgeError::Error(
+                                "Block not found in TxSenderTask".to_string(),
+                            ))?
                             .1;
 
                         tracing::info!("TXSENDER: Confirmed transactions for block {}", block_id);

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -236,13 +236,10 @@ CREATE TABLE IF NOT EXISTS state_machines (
 );
 -- Status table to track the last processed block
 CREATE TABLE IF NOT EXISTS state_manager_status (
-    id SERIAL PRIMARY KEY,
+    owner_type VARCHAR(100) PRIMARY KEY,
     next_height_to_process INT NOT NULL,
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
--- Insert a default record in the status table
-INSERT INTO state_manager_status (id, next_height_to_process, updated_at)
-VALUES (1, 0, NOW()) ON CONFLICT (id) DO NOTHING;
 -- Create indexes for better query performance
 CREATE INDEX IF NOT EXISTS state_machines_block_height_idx ON state_machines(block_height);
 CREATE INDEX IF NOT EXISTS state_machines_machine_type_idx ON state_machines(machine_type);

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -237,11 +237,11 @@ CREATE TABLE IF NOT EXISTS state_machines (
 -- Status table to track the last processed block
 CREATE TABLE IF NOT EXISTS state_manager_status (
     id SERIAL PRIMARY KEY,
-    last_processed_block_height INT NOT NULL,
+    next_height_to_process INT NOT NULL,
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 -- Insert a default record in the status table
-INSERT INTO state_manager_status (id, last_processed_block_height, updated_at)
+INSERT INTO state_manager_status (id, next_height_to_process, updated_at)
 VALUES (1, 0, NOW()) ON CONFLICT (id) DO NOTHING;
 -- Create indexes for better query performance
 CREATE INDEX IF NOT EXISTS state_machines_block_height_idx ON state_machines(block_height);


### PR DESCRIPTION
Several fixes for state manager:

- State manager actually started syncing from start_height + 1 before, not start_height. This also caused a panic somewhere when block with start_height was not added in the db.
- Refactor a bit so that state manager holds next block height to process, not last processed height, this is mainly so that state manager can start from genesis block, otherwise there are annoying unsigned int -1 overflows.
- Also load next height to process from db. Differentiate between owner types in state_manager_status table as operators and verifiers currently processed blocks might be different.