### PR TITLE
Remove unnecessary +100s in citrea_deposit_and_withdraw_e2e test

### DIFF
--- a/core/src/test/common/citrea/parameters.rs
+++ b/core/src/test/common/citrea/parameters.rs
@@ -138,15 +138,12 @@ pub fn get_transaction_params(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::extended_rpc::ExtendedRpc;
+    use bitcoincore_rpc::RpcApi;
     use std::str::FromStr;
 
-    use bitcoincore_rpc::RpcApi;
-
-    use crate::extended_rpc::ExtendedRpc;
-
-    use super::*;
-
-    #[ignore]
+    #[ignore = "Manual testing utility"]
     #[tokio::test]
     async fn test_get_transaction_params() {
         let rpc = ExtendedRpc::connect(

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -280,7 +280,7 @@ impl TestCase for CitreaDepositAndWithdrawE2E {
         da.wait_mempool_len(2, None).await?;
 
         // 6. generate FINALITY_DEPTH da blocks
-        rpc.mine_blocks(DEFAULT_FINALITY_DEPTH + 100).await.unwrap();
+        rpc.mine_blocks(DEFAULT_FINALITY_DEPTH).await.unwrap();
 
         let finalized_height = da.get_finalized_height(None).await.unwrap();
 
@@ -288,7 +288,7 @@ impl TestCase for CitreaDepositAndWithdrawE2E {
         lc_prover.wait_for_l1_height(finalized_height, None).await?;
         tracing::info!("Waited for L1 height {}", finalized_height);
 
-        rpc.mine_blocks(DEFAULT_FINALITY_DEPTH + 100).await.unwrap();
+        rpc.mine_blocks(DEFAULT_FINALITY_DEPTH).await.unwrap();
 
         let payout_txid = loop {
             let withdrawal_response = operators[0]
@@ -321,7 +321,7 @@ impl TestCase for CitreaDepositAndWithdrawE2E {
 
         mine_once_after_in_mempool(&rpc, payout_txid, Some("Payout tx"), None).await?;
 
-        rpc.mine_blocks(DEFAULT_FINALITY_DEPTH + 100).await.unwrap();
+        rpc.mine_blocks(DEFAULT_FINALITY_DEPTH).await.unwrap();
 
         // Setup tx_sender for sending transactions
         let verifier_0_config = {
@@ -375,7 +375,7 @@ impl TestCase for CitreaDepositAndWithdrawE2E {
         let kickoff_block_height =
             mine_once_after_in_mempool(&rpc, kickoff_txid, Some("Kickoff tx"), Some(1800)).await?;
 
-        rpc.mine_blocks(DEFAULT_FINALITY_DEPTH + 100).await.unwrap();
+        rpc.mine_blocks(DEFAULT_FINALITY_DEPTH).await.unwrap();
 
         // wait until the light client prover is synced to the same height
         lc_prover


### PR DESCRIPTION
# Description

Decreases unnecessarily large mine block requests in citrea_deposit_and_withdraw_e2e test