### PR TITLE
Change unspendable internal key

### DIFF
--- a/core/src/bitvm_client.rs
+++ b/core/src/bitvm_client.rs
@@ -5,7 +5,6 @@ use crate::builder::script::{SpendableScript, WinternitzCommit};
 use crate::config::protocol::ProtocolParamset;
 use crate::errors::BridgeError;
 use ark_bn254::Bn254;
-use bitcoin::key::Parity;
 use bitcoin::{self};
 use bitcoin::{ScriptBuf, XOnlyPublicKey};
 

--- a/core/src/bitvm_client.rs
+++ b/core/src/bitvm_client.rs
@@ -32,6 +32,15 @@ lazy_static::lazy_static! {
     /// This is an unspendable pubkey.
     ///
     /// See https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
+    ///
+    /// It is used to create a taproot address where the internal key is not spendable.
+    /// Here are the other protocols that use this key:
+    /// - Babylon:https://github.com/babylonlabs-io/btc-staking-ts/blob/v0.4.0-rc.2/src/constants/internalPubkey.ts
+    /// - Ark: https://github.com/ark-network/ark/blob/cba48925bcc836cc55f9bb482f2cd1b76d78953e/common/tree/validation.go#L47
+    /// - BitVM: https://github.com/BitVM/BitVM/blob/2dd2e0e799d2b9236dd894da3fee8c4c4893dcf1/bridge/src/scripts.rs#L16
+    /// - Best in Slot: https://github.com/bestinslot-xyz/brc20-programmable-module/blob/2113bdd73430a8c3757e537cb63124a6cb33dfab/src/evm/precompiles/get_locked_pkscript_precompile.rs#L53
+    /// - https://github.com/BlockstreamResearch/options/blob/36a77175919101393b49f1211732db762cc7dfc1/src/options_lib/src/contract.rs#L132
+    ///
     pub static ref UNSPENDABLE_XONLY_PUBKEY: bitcoin::secp256k1::XOnlyPublicKey =
         XOnlyPublicKey::from_str("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0").expect("this key is valid");
 }

--- a/core/src/bitvm_client.rs
+++ b/core/src/bitvm_client.rs
@@ -34,7 +34,7 @@ lazy_static::lazy_static! {
     ///
     /// See https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
     pub static ref UNSPENDABLE_PUBKEY: bitcoin::secp256k1::PublicKey =
-        "93c7378d96518a75448821c4f7c8f4bae7ce60f804d03d1f0628dd5dd0f5de51".parse::<bitcoin::secp256k1::XOnlyPublicKey>().expect("this key is valid").public_key(Parity::Even);
+        "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0".parse::<bitcoin::secp256k1::XOnlyPublicKey>().expect("this key is valid").public_key(Parity::Even);
 }
 
 lazy_static::lazy_static! {
@@ -42,7 +42,7 @@ lazy_static::lazy_static! {
     ///
     /// See https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
     pub static ref UNSPENDABLE_XONLY_PUBKEY: bitcoin::secp256k1::XOnlyPublicKey =
-        XOnlyPublicKey::from_str("93c7378d96518a75448821c4f7c8f4bae7ce60f804d03d1f0628dd5dd0f5de51").expect("this key is valid");
+        XOnlyPublicKey::from_str("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0").expect("this key is valid");
 }
 
 // lazy_static::lazy_static! {

--- a/core/src/bitvm_client.rs
+++ b/core/src/bitvm_client.rs
@@ -33,14 +33,6 @@ lazy_static::lazy_static! {
     /// This is an unspendable pubkey.
     ///
     /// See https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
-    pub static ref UNSPENDABLE_PUBKEY: bitcoin::secp256k1::PublicKey =
-        "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0".parse::<bitcoin::secp256k1::XOnlyPublicKey>().expect("this key is valid").public_key(Parity::Even);
-}
-
-lazy_static::lazy_static! {
-    /// This is an unspendable pubkey.
-    ///
-    /// See https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
     pub static ref UNSPENDABLE_XONLY_PUBKEY: bitcoin::secp256k1::XOnlyPublicKey =
         XOnlyPublicKey::from_str("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0").expect("this key is valid");
 }

--- a/core/src/builder/script.rs
+++ b/core/src/builder/script.rs
@@ -517,7 +517,7 @@ mod tests {
     }
 
     fn dummy_pubkey() -> PublicKey {
-        *bitvm_client::UNSPENDABLE_PUBKEY
+        bitvm_client::UNSPENDABLE_XONLY_PUBKEY.public_key(bitcoin::secp256k1::Parity::Even)
     }
 
     fn dummy_params() -> Parameters {


### PR DESCRIPTION
The new key is widely used compared to our old one.

Some usages:
BitVM: https://github.com/BitVM/BitVM/blob/2dd2e0e799d2b9236dd894da3fee8c4c4893dcf1/bridge/src/scripts.rs#L16
CATProtocol: https://github.com/CATProtocol/cat-token-box/blob/f276adc376aaecb8bd292237d87866416f4e2c29/packages/sdk/src/lib/constants.ts#L2
BIS: https://github.com/bestinslot-xyz/brc20-programmable-module/blob/2113bdd73430a8c3757e537cb63124a6cb33dfab/src/evm/precompiles/get_locked_pkscript_precompile.rs#L53
And many others

https://github.com/search?q=50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0&type=repositories

https://github.com/search?q=93c7378d96518a75448821c4f7c8f4bae7ce60f804d03d1f0628dd5dd0f5de51&type=repositories