### PR TITLE
fix: deadlock in new_deposit for num_round_tx>15

### DIFF
--- a/core/src/rpc/operator.rs
+++ b/core/src/rpc/operator.rs
@@ -15,7 +15,7 @@ use crate::rpc::parser;
 use crate::rpc::parser::parse_transaction_request;
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, OutPoint};
-use futures::{FutureExt, TryFutureExt};
+use futures::TryFutureExt;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{async_trait, Request, Response, Status};


### PR DESCRIPTION
# Description

As the title says. Just added tokio::spawn to operator's deposit_sign stream.