### PR TITLE
Read Citrea chain id from config

### DIFF
--- a/core/src/citrea/mock.rs
+++ b/core/src/citrea/mock.rs
@@ -72,6 +72,7 @@ impl CitreaClientT for MockCitreaClient {
     async fn new(
         citrea_rpc_url: String,
         _light_client_prover_url: String,
+        _chain_id: u32,
         _secret_key: Option<PrivateKeySigner>,
     ) -> Result<Self, BridgeError> {
         tracing::info!(
@@ -230,9 +231,14 @@ mod tests {
     #[tokio::test]
     async fn deposit_move_txid() {
         let config = create_test_config_with_thread_name().await;
-        let mut client = super::MockCitreaClient::new(config.citrea_rpc_url, "".to_string(), None)
-            .await
-            .unwrap();
+        let mut client = super::MockCitreaClient::new(
+            config.citrea_rpc_url,
+            "".to_string(),
+            config.citrea_chain_id,
+            None,
+        )
+        .await
+        .unwrap();
 
         assert!(client
             .collect_deposit_move_txids(None, 2)
@@ -266,9 +272,14 @@ mod tests {
     #[tokio::test]
     async fn withdrawal_utxos() {
         let config = create_test_config_with_thread_name().await;
-        let mut client = super::MockCitreaClient::new(config.citrea_rpc_url, "".to_string(), None)
-            .await
-            .unwrap();
+        let mut client = super::MockCitreaClient::new(
+            config.citrea_rpc_url,
+            "".to_string(),
+            config.citrea_chain_id,
+            None,
+        )
+        .await
+        .unwrap();
 
         assert!(client
             .collect_withdrawal_utxos(None, 2)

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -374,6 +374,7 @@ mod tests {
         env::set_var("DB_NAME", "clementine");
         env::set_var("CITREA_RPC_URL", "");
         env::set_var("CITREA_LIGHT_CLIENT_PROVER_URL", "");
+        env::set_var("CITREA_CHAIN_ID", "5655");
         env::set_var(
             "BRIDGE_CONTRACT_ADDRESS",
             "3100000000000000000000000000000000000002",

--- a/core/src/config/env.rs
+++ b/core/src/config/env.rs
@@ -138,6 +138,7 @@ impl BridgeConfig {
             db_name: read_string_from_env("DB_NAME")?,
             citrea_rpc_url: read_string_from_env("CITREA_RPC_URL")?,
             citrea_light_client_prover_url: read_string_from_env("CITREA_LIGHT_CLIENT_PROVER_URL")?,
+            citrea_chain_id: read_string_from_env_then_parse::<u32>("CITREA_CHAIN_ID")?,
             bridge_contract_address: read_string_from_env("BRIDGE_CONTRACT_ADDRESS")?,
             header_chain_proof_path,
             verifier_endpoints,
@@ -206,6 +207,10 @@ mod tests {
         std::env::set_var(
             "CITREA_LIGHT_CLIENT_PROVER_URL",
             &default_config.citrea_light_client_prover_url,
+        );
+        std::env::set_var(
+            "CITREA_CHAIN_ID",
+            default_config.citrea_chain_id.to_string(),
         );
         std::env::set_var(
             "BRIDGE_CONTRACT_ADDRESS",

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -76,6 +76,8 @@ pub struct BridgeConfig {
     pub citrea_rpc_url: String,
     /// Citrea light client prover RPC URL.
     pub citrea_light_client_prover_url: String,
+    /// Citrea's EVM Chain ID.
+    pub citrea_chain_id: u32,
     /// Bridge contract address.
     pub bridge_contract_address: String,
     // Initial header chain proof receipt's file path.
@@ -124,8 +126,6 @@ pub struct BridgeConfig {
     /// Aggregator's client cert should be equal to the this certificate.
     pub aggregator_cert_path: PathBuf,
 
-    // /// Directory containing unix sockets
-    // pub socket_path: String,
     /// All Secret keys. Just for testing purposes.
     pub all_verifiers_secret_keys: Option<Vec<SecretKey>>,
     /// All Secret keys. Just for testing purposes.
@@ -203,6 +203,7 @@ impl Default for BridgeConfig {
 
             citrea_rpc_url: "".to_string(),
             citrea_light_client_prover_url: "".to_string(),
+            citrea_chain_id: 5655,
             bridge_contract_address: "3100000000000000000000000000000000000002".to_string(),
 
             header_chain_proof_path: Some(
@@ -249,7 +250,6 @@ impl Default for BridgeConfig {
                 )
                 .expect("known valid input"),
             ),
-            // socket_path: "/".to_string(),
             verifier_endpoints: None,
             operator_endpoints: None,
 

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -178,6 +178,7 @@ where
         let citrea_client = C::new(
             config.citrea_rpc_url.clone(),
             config.citrea_light_client_prover_url.clone(),
+            config.citrea_chain_id,
             None,
         )
         .await?;

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -243,6 +243,7 @@ impl TestCase for CitreaDepositAndWithdrawE2E {
         let citrea_client = CitreaClient::new(
             config.citrea_rpc_url.clone(),
             config.citrea_light_client_prover_url.clone(),
+            config.citrea_chain_id,
             Some(SECRET_KEYS[0].to_string().parse().unwrap()),
         )
         .await
@@ -416,10 +417,14 @@ async fn mock_citrea_run_truthful() {
     let mut config = create_test_config_with_thread_name().await;
     let regtest = create_regtest_rpc(&mut config).await;
     let rpc = regtest.rpc().clone();
-    let mut citrea_client =
-        MockCitreaClient::new(config.citrea_rpc_url.clone(), "".to_string(), None)
-            .await
-            .unwrap();
+    let mut citrea_client = MockCitreaClient::new(
+        config.citrea_rpc_url.clone(),
+        "".to_string(),
+        config.citrea_chain_id,
+        None,
+    )
+    .await
+    .unwrap();
 
     tracing::info!("Running deposit");
 
@@ -686,10 +691,14 @@ async fn mock_citrea_run_malicious() {
     let mut config = create_test_config_with_thread_name().await;
     let regtest = create_regtest_rpc(&mut config).await;
     let rpc = regtest.rpc().clone();
-    let mut citrea_client =
-        MockCitreaClient::new(config.citrea_rpc_url.clone(), "".to_string(), None)
-            .await
-            .unwrap();
+    let mut citrea_client = MockCitreaClient::new(
+        config.citrea_rpc_url.clone(),
+        "".to_string(),
+        config.citrea_chain_id,
+        None,
+    )
+    .await
+    .unwrap();
 
     tracing::info!("Running deposit");
 
@@ -879,10 +888,14 @@ async fn mock_citrea_run_malicious_after_exit() {
     let mut config = create_test_config_with_thread_name().await;
     let regtest = create_regtest_rpc(&mut config).await;
     let rpc = regtest.rpc().clone();
-    let mut citrea_client =
-        MockCitreaClient::new(config.citrea_rpc_url.clone(), "".to_string(), None)
-            .await
-            .unwrap();
+    let mut citrea_client = MockCitreaClient::new(
+        config.citrea_rpc_url.clone(),
+        "".to_string(),
+        config.citrea_chain_id,
+        None,
+    )
+    .await
+    .unwrap();
 
     tracing::info!("Running deposit");
 

--- a/core/src/test/withdraw.rs
+++ b/core/src/test/withdraw.rs
@@ -93,6 +93,7 @@ impl TestCase for CitreaWithdrawAndGetUTXO {
         let citrea_client = CitreaClient::new(
             config.citrea_rpc_url.clone(),
             config.citrea_light_client_prover_url.clone(),
+            config.citrea_chain_id,
             Some(SECRET_KEYS[0].to_string().parse().unwrap()),
         )
         .await

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -162,6 +162,7 @@ where
         let citrea_client = C::new(
             config.citrea_rpc_url.clone(),
             config.citrea_light_client_prover_url.clone(),
+            config.citrea_chain_id,
             None,
         )
         .await?;

--- a/core/tests/data/test_config.toml
+++ b/core/tests/data/test_config.toml
@@ -42,6 +42,7 @@ db_name = "clementine"
 # Citrea RPC URL.
 citrea_rpc_url = "http://127.0.0.1:12345"
 citrea_light_client_prover_url = ""
+citrea_chain_id = 5655
 bridge_contract_address = "3100000000000000000000000000000000000002"
 
 # Header chain prover's assumption to start with.

--- a/scripts/docker/docker_config.toml
+++ b/scripts/docker/docker_config.toml
@@ -61,6 +61,7 @@ confirmation_threshold = 1
 
 citrea_rpc_url = ""
 citrea_light_client_prover_url = ""
+citrea_chain_id = 5655
 bridge_contract_address = "3100000000000000000000000000000000000002"
 
 # Header chain prover's assumption to start with.


### PR DESCRIPTION
# Description

Adds `citrea_chain_id` to `BridgeConfig` and deletes the const in Citrea module.