### PR TITLE
Run hcp only if ENABLE_HEADER_CHAIN_PROVER is given

### DIFF
--- a/core/src/header_chain_prover.rs
+++ b/core/src/header_chain_prover.rs
@@ -111,13 +111,19 @@ impl HeaderChainProver {
                 .client
                 .get_block_header(&block_hash)
                 .await
-                .wrap_err("Failed to get block header")?;
+                .wrap_err(format!(
+                "Failed to get block header with block hash {} (retrieved from assumption file)",
+                block_hash
+            ))?;
             let block_height = rpc
                 .client
                 .get_block_info(&block_hash)
                 .await
                 .map(|info| info.height)
-                .wrap_err("Failed to get block info")?;
+                .wrap_err(format!(
+                    "Failed to get block info with block hash {} (retrieved from assumption file)",
+                    block_hash
+                ))?;
             tracing::info!(
                 "Adding proof assumption for a block with hash of {:?}, header of {:?} and height of {}",
                 block_hash,

--- a/core/src/header_chain_prover.rs
+++ b/core/src/header_chain_prover.rs
@@ -767,6 +767,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "Header chain prover is ignored"]
     async fn verifier_new_check_header_chain_proof() {
         let mut config = create_test_config_with_thread_name().await;
         let regtest = create_regtest_rpc(&mut config).await;
@@ -802,6 +803,8 @@ mod tests {
                 Ok(verifier
                     .verifier
                     .header_chain_prover
+                    .as_ref()
+                    .unwrap()
                     .db
                     .get_block_proof_by_hash(None, hash)
                     .await

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -136,7 +136,7 @@ pub struct Verifier<C: CitreaClientT> {
     pub(crate) config: BridgeConfig,
     pub(crate) nonces: Arc<tokio::sync::Mutex<AllSessions>>,
     pub tx_sender: TxSenderClient,
-    pub header_chain_prover: HeaderChainProver,
+    pub header_chain_prover: Option<HeaderChainProver>,
     pub citrea_client: C,
 }
 
@@ -176,7 +176,11 @@ where
         // TODO: Removing index causes to remove the index from the tx_sender handle as well
         let tx_sender = TxSenderClient::new(db.clone(), "verifier_".to_string());
 
-        let header_chain_prover = HeaderChainProver::new(&config, rpc.clone()).await?;
+        let header_chain_prover = if std::env::var("ENABLE_HEADER_CHAIN_PROVER").is_ok() {
+            Some(HeaderChainProver::new(&config, rpc.clone()).await?)
+        } else {
+            None
+        };
 
         let verifier = Verifier {
             rpc,
@@ -1458,10 +1462,12 @@ where
         self.update_finalized_payouts(&mut dbtx, block_id, &block_cache)
             .await?;
 
-        self.header_chain_prover
-            .save_unproven_block_cache(Some(&mut dbtx), &block_cache)
-            .await?;
-        self.header_chain_prover.prove_if_ready().await?;
+        if let Some(header_chain_prover) = &self.header_chain_prover {
+            header_chain_prover
+                .save_unproven_block_cache(Some(&mut dbtx), &block_cache)
+                .await?;
+            header_chain_prover.prove_if_ready().await?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
# Description

Runs hpc only if ENABLE_HEADER_CHAIN_PROVER is given. This is a temporary change before hcp and deployment has a stable ground.