### PR TITLE
Fix clippy because new lints

### DIFF
--- a/core/src/builder/transaction/creator.rs
+++ b/core/src/builder/transaction/creator.rs
@@ -448,10 +448,10 @@ pub async fn create_txhandlers(
     // get the next round txhandler (because reimburse connectors will be in it)
     let next_round_txhandler = create_round_txhandler(
         operator_data.xonly_pk,
-        RoundTxInput::Prevout(
+        RoundTxInput::Prevout(Box::new(
             get_txhandler(&txhandlers, TransactionType::ReadyToReimburse)?
                 .get_spendable_output(UtxoVout::BurnConnector)?,
-        ),
+        )),
         kickoff_winternitz_keys.get_keys_for_round(round_idx as usize + 1),
         paramset,
     )?;
@@ -705,10 +705,10 @@ pub fn create_round_txhandlers(
             }
             let round_txhandler = builder::transaction::create_round_txhandler(
                 operator_data.xonly_pk,
-                RoundTxInput::Prevout(
+                RoundTxInput::Prevout(Box::new(
                     prev_ready_to_reimburse_txhandler
                         .get_spendable_output(UtxoVout::BurnConnector)?,
-                ),
+                )),
                 kickoff_winternitz_keys.get_keys_for_round(round_idx),
                 paramset,
             )?;

--- a/core/src/builder/transaction/operator_collateral.rs
+++ b/core/src/builder/transaction/operator_collateral.rs
@@ -29,7 +29,7 @@ use bitcoin::{Amount, OutPoint, TxOut, XOnlyPublicKey};
 use std::sync::Arc;
 
 pub enum RoundTxInput {
-    Prevout(SpendableTxIn),
+    Prevout(Box<SpendableTxIn>),
     Collateral(OutPoint, Amount),
 }
 
@@ -59,7 +59,7 @@ pub fn create_round_txhandler(
             input_amount = prevout.get_prevout().value;
             builder = builder.add_input(
                 NormalSignatureKind::OperatorSighashDefault,
-                prevout,
+                *prevout,
                 SpendPath::KeySpend,
                 Sequence::from_height(paramset.operator_reimburse_timelock),
             );
@@ -193,9 +193,9 @@ pub fn create_round_nth_txhandler(
     for idx in 1..=index {
         round_txhandler = create_round_txhandler(
             operator_xonly_pk,
-            RoundTxInput::Prevout(
+            RoundTxInput::Prevout(Box::new(
                 ready_to_reimburse_txhandler.get_spendable_output(UtxoVout::BurnConnector)?,
-            ),
+            )),
             pubkeys.get_keys_for_round(idx),
             paramset,
         )?;

--- a/core/src/database/operator.rs
+++ b/core/src/database/operator.rs
@@ -487,7 +487,10 @@ impl Database {
 
         match result {
             Some((deposit_params, operator_xonly_pk, round_idx, kickoff_idx)) => Ok(Some((
-                deposit_params.0.try_into()?,
+                deposit_params
+                    .0
+                    .try_into()
+                    .wrap_err("Can't convert deposit params")?,
                 KickoffData {
                     operator_xonly_pk: operator_xonly_pk.0,
                     round_idx: u32::try_from(round_idx)

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -143,9 +143,6 @@ pub enum BridgeError {
     #[error("{0}")]
     CLIDisplayAndExit(StyledStr),
 
-    #[error("Tonic status: {0}")]
-    TonicStatus(#[from] tonic::Status),
-
     // Base wrapper for eyre
     #[error(transparent)]
     Eyre(#[from] eyre::Report),

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -173,7 +173,7 @@ pub trait ResultExt: Sized {
     type Output;
 
     fn map_to_eyre(self) -> Result<Self::Output, eyre::Report>;
-    fn map_to_status(self) -> Result<Self::Output, tonic::Status>;
+    fn map_to_status(self) -> Result<Self::Output, Box<tonic::Status>>;
 }
 
 impl<T: Into<BridgeError>> ErrorExt for T {
@@ -195,8 +195,8 @@ impl<U: Sized, T: Into<BridgeError>> ResultExt for Result<U, T> {
         self.map_err(ErrorExt::into_eyre)
     }
 
-    fn map_to_status(self) -> Result<Self::Output, tonic::Status> {
-        self.map_err(ErrorExt::into_status)
+    fn map_to_status(self) -> Result<Self::Output, Box<tonic::Status>> {
+        Ok(self.map_err(ErrorExt::into_status)?)
     }
 }
 

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -1041,7 +1041,8 @@ impl ClementineAggregator for Aggregator {
             .rpc
             .get_blockhash_of_tx(&deposit_data.get_deposit_outpoint().txid)
             .await
-            .map_to_status()?;
+            .map_to_status()
+            .map_err(|e| *e)?;
 
         let verifiers_public_keys = deposit_data.get_verifiers();
 

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -511,7 +511,8 @@ impl Aggregator {
             .deposit_params
             .clone()
             .ok_or_else(|| eyre::eyre!("No deposit params found in deposit sign session"))?
-            .try_into()?;
+            .try_into()
+            .wrap_err("Failed to convert deposit params to deposit data")?;
 
         // calculate number of signatures needed from each operator
         let needed_sigs = config.get_num_required_operator_sigs(&deposit_data);
@@ -623,9 +624,11 @@ impl Aggregator {
         emergency_stop_agg_nonce: MusigAggNonce,
         deposit_params: DepositParams,
     ) -> Result<(), BridgeError> {
-        let mut deposit_data: crate::builder::transaction::DepositData =
-            deposit_params.try_into()?;
-        let musig_partial_sigs = parser::verifier::parse_partial_sigs(emergency_stop_sigs)?;
+        let mut deposit_data: crate::builder::transaction::DepositData = deposit_params
+            .try_into()
+            .wrap_err("Failed to convert deposit params to deposit data")?;
+        let musig_partial_sigs = parser::verifier::parse_partial_sigs(emergency_stop_sigs)
+            .wrap_err("Failed to parse emergency stop signatures")?;
 
         // create move tx and calculate sighash
         let move_txhandler =

--- a/core/src/rpc/interceptors.rs
+++ b/core/src/rpc/interceptors.rs
@@ -21,6 +21,7 @@ fn is_internal(req: &Request<()>) -> bool {
 }
 
 impl Interceptor for Interceptors {
+    #[allow(clippy::result_large_err)]
     fn call(&mut self, req: Request<()>) -> Result<Request<()>, Status> {
         match self {
             Interceptors::OnlyAggregatorAndSelf {
@@ -32,6 +33,7 @@ impl Interceptor for Interceptors {
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn only_aggregator_and_self(
     req: Request<()>,
     our_cert: &CertificateDer<'static>,

--- a/core/src/rpc/parser/mod.rs
+++ b/core/src/rpc/parser/mod.rs
@@ -45,6 +45,7 @@ impl From<ParserError> for tonic::Status {
 }
 
 #[allow(dead_code)]
+#[allow(clippy::result_large_err)]
 /// Converts an integer type in to another integer type. This is needed because
 /// tonic defaults to wrong integer types for some parameters.
 pub fn convert_int_to_another<SOURCE, TARGET>(
@@ -450,6 +451,7 @@ impl TryFrom<clementine::Txid> for Txid {
     }
 }
 
+#[allow(clippy::result_large_err)]
 pub fn parse_transaction_request(
     request: TransactionRequest,
 ) -> Result<TransactionRequestData, Status> {

--- a/core/src/rpc/parser/verifier.rs
+++ b/core/src/rpc/parser/verifier.rs
@@ -124,6 +124,7 @@ impl From<MusigPartialSignature> for PartialSig {
     }
 }
 
+#[allow(clippy::result_large_err)]
 pub fn parse_deposit_sign_session(
     deposit_sign_session: clementine::DepositSignSession,
     verifier_pk: &PublicKey,
@@ -143,6 +144,7 @@ pub fn parse_deposit_sign_session(
     Ok((deposit_data, session_id))
 }
 
+#[allow(clippy::result_large_err)]
 pub fn parse_partial_sigs(
     partial_sigs: Vec<Vec<u8>>,
 ) -> Result<Vec<MusigPartialSignature>, Status> {
@@ -160,6 +162,7 @@ pub fn parse_partial_sigs(
         .collect::<Result<Vec<_>, _>>()
 }
 
+#[allow(clippy::result_large_err)]
 pub fn parse_op_keys_with_deposit(
     data: OperatorKeysWithDeposit,
 ) -> Result<(DepositData, OperatorKeys, XOnlyPublicKey), Status> {

--- a/core/src/test/common/mod.rs
+++ b/core/src/test/common/mod.rs
@@ -226,7 +226,7 @@ pub async fn run_multiple_deposits<C: CitreaClientT>(
     let verifiers_public_keys: Vec<PublicKey> = aggregator
         .setup(Request::new(Empty {}))
         .await
-        .unwrap()
+        .wrap_err("Can't setup aggregator")?
         .into_inner()
         .try_into()?;
 
@@ -254,7 +254,7 @@ pub async fn run_multiple_deposits<C: CitreaClientT>(
         let move_txid: Txid = aggregator
             .new_deposit(deposit)
             .await
-            .unwrap()
+            .wrap_err("Error while making a deposit")?
             .into_inner()
             .try_into()?;
         rpc.mine_blocks(1).await?;
@@ -348,7 +348,7 @@ pub async fn run_single_deposit<C: CitreaClientT>(
     let move_txid: Txid = aggregator
         .new_deposit(deposit)
         .await
-        .unwrap()
+        .wrap_err("Error while making a deposit")?
         .into_inner()
         .try_into()?;
 
@@ -601,7 +601,7 @@ pub async fn run_replacement_deposit(
             fee_type: FeeType::Cpfp as i32,
         })
         .await
-        .unwrap();
+        .wrap_err("Error while sending replacement deposit tx")?;
 
     // sleep 3 seconds so that tx_sender can send the fee_payer_tx to the mempool
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
@@ -636,7 +636,7 @@ pub async fn run_replacement_deposit(
     let move_txid: Txid = aggregator
         .new_deposit(deposit)
         .await
-        .unwrap()
+        .wrap_err("Error while making a deposit")?
         .into_inner()
         .try_into()?;
 

--- a/core/src/test/common/mod.rs
+++ b/core/src/test/common/mod.rs
@@ -716,10 +716,10 @@ pub fn ensure_test_certificates() -> Result<(), std::io::Error> {
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 eprintln!("Failed to generate certificates: {}", stderr);
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("Certificate generation failed: {}", stderr),
-                ));
+                return Err(std::io::Error::other(format!(
+                    "Certificate generation failed: {}",
+                    stderr
+                )));
             }
 
             println!("TLS certificates generated successfully");

--- a/core/src/test/common/mod.rs
+++ b/core/src/test/common/mod.rs
@@ -225,7 +225,8 @@ pub async fn run_multiple_deposits<C: CitreaClientT>(
 
     let verifiers_public_keys: Vec<PublicKey> = aggregator
         .setup(Request::new(Empty {}))
-        .await?
+        .await
+        .unwrap()
         .into_inner()
         .try_into()?;
 
@@ -252,7 +253,8 @@ pub async fn run_multiple_deposits<C: CitreaClientT>(
 
         let move_txid: Txid = aggregator
             .new_deposit(deposit)
-            .await?
+            .await
+            .unwrap()
             .into_inner()
             .try_into()?;
         rpc.mine_blocks(1).await?;
@@ -345,7 +347,8 @@ pub async fn run_single_deposit<C: CitreaClientT>(
 
     let move_txid: Txid = aggregator
         .new_deposit(deposit)
-        .await?
+        .await
+        .unwrap()
         .into_inner()
         .try_into()?;
 
@@ -597,7 +600,8 @@ pub async fn run_replacement_deposit(
             raw_tx: Some(RawSignedTx::from(&replacement_deposit_tx)),
             fee_type: FeeType::Cpfp as i32,
         })
-        .await?;
+        .await
+        .unwrap();
 
     // sleep 3 seconds so that tx_sender can send the fee_payer_tx to the mempool
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
@@ -631,7 +635,8 @@ pub async fn run_replacement_deposit(
 
     let move_txid: Txid = aggregator
         .new_deposit(deposit)
-        .await?
+        .await
+        .unwrap()
         .into_inner()
         .try_into()?;
 


### PR DESCRIPTION
# Description

- Wraps some of the `Status` errors with `Box`
- Allows some of the `clippy::result_large_err`
- Converts some of the ?s to `unwrap`s in tests because no need to add additional conversion logic