### PR TITLE
Add host.docker.internal to SAN list in dev TLS certificate generator

### DIFF
--- a/scripts/generate_certs.sh
+++ b/scripts/generate_certs.sh
@@ -35,6 +35,7 @@ basicConstraints = CA:true
 
 [alt_names]
 DNS.1 = localhost
+DNS.2 = host.docker.internal
 IP.1 = 127.0.0.1
 EOF
 


### PR DESCRIPTION
# Description

This PR updates the certificate-generation helper script to include host.docker.internal in the Subject-Alternative-Name (SAN) list that OpenSSL writes to every dev certificate.
By adding
`DNS.2 = host.docker.internal`
to the openssl_x509.cnf template, the server certificate presented by the Aggregator is now valid both when clients connect via https://localhost:17000 and when containers connect via https://host.docker.internal:17000.
Without this entry, gRPC clients running inside Docker failed with:
`ERR_TLS_CERT_ALTNAME_INVALID: Host: host.docker.internal is not in the cert's altnames`

## Linked Issues

## Testing

## Docs
