### PR TITLE
Use ubuntu-latest instead of ubicloud when it is logical to do so

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -127,7 +127,7 @@ jobs:
 
   bridge_circuit_release_build_test:
     name: Test bridge circuit host code with release build
-    runs-on: ubicloud-standard-30
+    runs-on: ubicloud
     needs: release_build
 
     env:
@@ -149,7 +149,7 @@ jobs:
 
   bridge_additional_disprove_tests_matrix:
     name: Test additional disprove script ${{ matrix.description_suffix }} with release build
-    runs-on: ubicloud-standard-30
+    runs-on: ubicloud
     needs: release_build
     strategy:
       fail-fast: false
@@ -201,7 +201,7 @@ jobs:
     name: Coverage checks with Codecov
     runs-on: ubicloud-standard-30
     needs: debug_build_test
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
 
     services:
       postgres:

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -34,7 +34,7 @@ jobs:
 
   udeps:
     name: Check unused dependencies
-    runs-on: ubicloud-standard-30
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
 
   docs:
     name: Check documentation build
-    runs-on: ubicloud-standard-30
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
 
   codespell:
     name: codespell
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     name: Build and deploy documentation
-    runs-on: ubicloud-standard-30
+    runs-on: ubuntu-latest
     permissions:
       contents: write
 

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -18,7 +18,7 @@ jobs:
   docker:
     timeout-minutes: 120
     name: Build and publish Docker image
-    runs-on: ubicloud-standard-30
+    runs-on: ubicloud-standard-2
     steps:
       - uses: actions/checkout@v4
       - name: Docker Setup Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   linux_amd64_binary_extraction:
-    runs-on: ubicloud-standard-30
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
           path: target/release/clementine-cli
 
   release:
-    needs:  linux_amd64_binary_extraction
+    needs: linux_amd64_binary_extraction
     runs-on: ubuntu-latest
     steps:
       - name: Download linux-amd64 Binary
@@ -81,5 +81,3 @@ jobs:
             It includes:
             - clementine-core-${{ github.ref_name }}-linux-amd64
             - clementine-cli-${{ github.ref_name }}-linux-amd64
-
-


### PR DESCRIPTION
# Description

Converts some of the `runs-on`s to `ubuntu-latest` from `ubicloud-*`.