### PR TITLE
Format imports with `Crate` granularity

### DIFF
--- a/bridge-circuit-host/src/bridge_circuit_host.rs
+++ b/bridge-circuit-host/src/bridge_circuit_host.rs
@@ -1,22 +1,25 @@
-use crate::docker::{stark_to_bitvm2_g16, stark_to_bitvm2_g16_dev_mode};
-use crate::structs::{
-    BridgeCircuitBitvmInputs, BridgeCircuitHostParams, SuccinctBridgeCircuitPublicInputs,
+use crate::{
+    docker::{stark_to_bitvm2_g16, stark_to_bitvm2_g16_dev_mode},
+    structs::{
+        BridgeCircuitBitvmInputs, BridgeCircuitHostParams, SuccinctBridgeCircuitPublicInputs,
+    },
+    utils::calculate_succinct_output_prefix,
 };
-use crate::utils::calculate_succinct_output_prefix;
 use ark_bn254::Bn254;
 use bitcoin::Transaction;
 use borsh;
-use circuits_lib::bridge_circuit::groth16::CircuitGroth16Proof;
-use circuits_lib::bridge_circuit::merkle_tree::BitcoinMerkleTree;
-use circuits_lib::bridge_circuit::spv::SPV;
-use circuits_lib::bridge_circuit::structs::WorkOnlyCircuitInput;
-use circuits_lib::bridge_circuit::transaction::CircuitTransaction;
-
-use circuits_lib::common::constants::{
-    MAINNET_HEADER_CHAIN_METHOD_ID, REGTEST_HEADER_CHAIN_METHOD_ID, SIGNET_HEADER_CHAIN_METHOD_ID,
-    TESTNET4_HEADER_CHAIN_METHOD_ID,
+use circuits_lib::bridge_circuit::{
+    groth16::CircuitGroth16Proof, merkle_tree::BitcoinMerkleTree, spv::SPV,
+    structs::WorkOnlyCircuitInput, transaction::CircuitTransaction,
 };
-use circuits_lib::header_chain::mmr_native::MMRNative;
+
+use circuits_lib::{
+    common::constants::{
+        MAINNET_HEADER_CHAIN_METHOD_ID, REGTEST_HEADER_CHAIN_METHOD_ID,
+        SIGNET_HEADER_CHAIN_METHOD_ID, TESTNET4_HEADER_CHAIN_METHOD_ID,
+    },
+    header_chain::mmr_native::MMRNative,
+};
 use risc0_zkvm::{compute_image_id, default_prover, is_dev_mode, ExecutorEnv, ProverOpts, Receipt};
 
 pub const REGTEST_BRIDGE_CIRCUIT_ELF: &[u8] =

--- a/bridge-circuit-host/src/docker.rs
+++ b/bridge-circuit-host/src/docker.rs
@@ -2,11 +2,11 @@ use hex::ToHex;
 use num_bigint::BigUint;
 use num_traits::Num;
 use risc0_groth16::{to_json, ProofJson, Seal};
-use risc0_zkvm::sha::Digestible;
 use risc0_zkvm::{
-    sha::Digest, ReceiptClaim, SuccinctReceipt, SuccinctReceiptVerifierParameters, SystemState,
+    sha::{Digest, Digestible},
+    Groth16Receipt, Groth16ReceiptVerifierParameters, InnerReceipt, Receipt, ReceiptClaim,
+    SuccinctReceipt, SuccinctReceiptVerifierParameters, SystemState,
 };
-use risc0_zkvm::{Groth16Receipt, Groth16ReceiptVerifierParameters, InnerReceipt, Receipt};
 use serde_json::Value;
 use std::{
     env::consts::ARCH,

--- a/circuits-lib/src/bridge_circuit/groth16_verifier.rs
+++ b/circuits-lib/src/bridge_circuit/groth16_verifier.rs
@@ -1,16 +1,17 @@
 use ark_bn254::{Bn254, Fr};
-use ark_groth16::PreparedVerifyingKey;
-use ark_groth16::Proof;
+use ark_groth16::{PreparedVerifyingKey, Proof};
 use ark_serialize::CanonicalDeserialize;
 use num_bigint::BigUint;
 use num_traits::Num;
 
-use super::constants::{
-    A0_ARK, A1_ARK, ASSUMPTIONS, BN_254_CONTROL_ID_ARK, CLAIM_TAG, INPUT, OUTPUT_TAG, POST_STATE,
-    PREPARED_VK,
+use super::{
+    constants::{
+        A0_ARK, A1_ARK, ASSUMPTIONS, BN_254_CONTROL_ID_ARK, CLAIM_TAG, INPUT, OUTPUT_TAG,
+        POST_STATE, PREPARED_VK,
+    },
+    groth16::CircuitGroth16Proof,
+    structs::WorkOnlyCircuitOutput,
 };
-use super::groth16::CircuitGroth16Proof;
-use super::structs::WorkOnlyCircuitOutput;
 use hex::ToHex;
 use sha2::{Digest, Sha256};
 use std::str::FromStr;

--- a/circuits-lib/src/bridge_circuit/merkle_tree.rs
+++ b/circuits-lib/src/bridge_circuit/merkle_tree.rs
@@ -287,8 +287,7 @@ pub fn verify_merkle_proof(
 #[cfg(test)]
 mod tests {
 
-    use bitcoin::hashes::Hash;
-    use bitcoin::Block;
+    use bitcoin::{hashes::Hash, Block};
 
     use crate::bridge_circuit::transaction::CircuitTransaction;
 

--- a/circuits-lib/src/bridge_circuit/storage_proof.rs
+++ b/circuits-lib/src/bridge_circuit/storage_proof.rs
@@ -1,5 +1,4 @@
-use alloy_primitives::Bytes;
-use alloy_primitives::{Keccak256, U256};
+use alloy_primitives::{Bytes, Keccak256, U256};
 use alloy_rpc_types::EIP1186StorageProof;
 use jmt::KeyHash;
 use sha2::{Digest, Sha256};

--- a/circuits-lib/src/bridge_circuit/transaction.rs
+++ b/circuits-lib/src/bridge_circuit/transaction.rs
@@ -3,11 +3,10 @@
 ///
 use core::ops::{Deref, DerefMut};
 
-use bitcoin::absolute::LockTime;
-use bitcoin::consensus::Encodable;
-use bitcoin::hashes::Hash;
-use bitcoin::transaction::Version;
-use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness};
+use bitcoin::{
+    absolute::LockTime, consensus::Encodable, hashes::Hash, transaction::Version, Amount, OutPoint,
+    ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+};
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::common::hashes::calculate_sha256;

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -1,25 +1,23 @@
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 
-use crate::bitvm_client::{self, ClementineBitVMPublicKeys, SECP};
-use crate::builder::script::SpendPath;
-use crate::builder::sighash::TapTweakData;
-use crate::builder::transaction::input::SpentTxIn;
-use crate::builder::transaction::{SighashCalculator, TransactionType, TxHandler};
-use crate::config::protocol::ProtocolParamset;
-use crate::errors::{BridgeError, TxError};
-use crate::operator::{PublicHash, RoundIndex};
-use crate::rpc::clementine::tagged_signature::SignatureId;
-use crate::rpc::clementine::TaggedSignature;
-use bitcoin::hashes::hash160;
-use bitcoin::secp256k1::PublicKey;
-use bitcoin::taproot::{self, LeafVersion, TaprootSpendInfo};
-use bitcoin::{
-    hashes::Hash,
-    secp256k1::{schnorr, Keypair, Message, SecretKey, XOnlyPublicKey},
-    Address, ScriptBuf, TapSighash, TapTweakHash,
+use crate::{
+    bitvm_client::{self, ClementineBitVMPublicKeys, SECP},
+    builder::{
+        script::SpendPath,
+        sighash::TapTweakData,
+        transaction::{input::SpentTxIn, SighashCalculator, TransactionType, TxHandler},
+    },
+    config::protocol::ProtocolParamset,
+    errors::{BridgeError, TxError},
+    operator::{PublicHash, RoundIndex},
+    rpc::clementine::{tagged_signature::SignatureId, TaggedSignature},
 };
-use bitcoin::{OutPoint, TapNodeHash, TapSighashType, Witness};
+use bitcoin::{
+    hashes::{hash160, Hash},
+    secp256k1::{schnorr, Keypair, Message, PublicKey, SecretKey, XOnlyPublicKey},
+    taproot::{self, LeafVersion, TaprootSpendInfo},
+    Address, OutPoint, ScriptBuf, TapNodeHash, TapSighash, TapSighashType, TapTweakHash, Witness,
+};
 use bitvm::signatures::winternitz::{self, BinarysearchVerifier, ToBytesConverter, Winternitz};
 use eyre::{Context, OptionExt};
 
@@ -744,25 +742,26 @@ impl Actor {
 #[cfg(test)]
 mod tests {
     use super::Actor;
-    use crate::builder::address::create_taproot_address;
-    use crate::config::protocol::ProtocolParamsetName;
+    use crate::{builder::address::create_taproot_address, config::protocol::ProtocolParamsetName};
 
     use super::*;
-    use crate::builder::script::{CheckSig, SpendPath, SpendableScript};
-    use crate::builder::transaction::input::SpendableTxIn;
-    use crate::builder::transaction::output::UnspentTxOut;
-    use crate::builder::transaction::{TransactionType, TxHandler, TxHandlerBuilder};
+    use crate::builder::{
+        script::{CheckSig, SpendPath, SpendableScript},
+        transaction::{
+            input::SpendableTxIn, output::UnspentTxOut, TransactionType, TxHandler,
+            TxHandlerBuilder,
+        },
+    };
 
-    use crate::bitvm_client::SECP;
-    use crate::rpc::clementine::NormalSignatureKind;
-    use crate::{actor::WinternitzDerivationPath, test::common::*};
+    use crate::{
+        actor::WinternitzDerivationPath, bitvm_client::SECP, rpc::clementine::NormalSignatureKind,
+        test::common::*,
+    };
     use bitcoin::secp256k1::{schnorr, Message, SecretKey};
 
-    use bitcoin::sighash::TapSighashType;
-    use bitcoin::transaction::Transaction;
+    use bitcoin::{sighash::TapSighashType, transaction::Transaction};
 
-    use bitcoin::secp256k1::rand;
-    use bitcoin::{Amount, Network, OutPoint, Txid};
+    use bitcoin::{secp256k1::rand, Amount, Network, OutPoint, Txid};
     use bitcoincore_rpc::RpcApi;
     use bitvm::{
         execute_script,
@@ -770,8 +769,7 @@ mod tests {
         treepp::script,
     };
     use rand::thread_rng;
-    use std::str::FromStr;
-    use std::sync::Arc;
+    use std::{str::FromStr, sync::Arc};
 
     // Helper: create a TxHandler with a single key spend input.
     fn create_key_spend_tx_handler(actor: &Actor) -> (bitcoin::TxOut, TxHandler) {

--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -1,25 +1,27 @@
-use crate::deposit::DepositData;
-use crate::extended_rpc::ExtendedRpc;
-use crate::rpc::clementine::{DepositParams, OperatorKeysWithDeposit};
 #[cfg(feature = "automation")]
 use crate::tx_sender::TxSenderClient;
 use crate::{
     builder::{self},
     config::BridgeConfig,
     database::Database,
+    deposit::DepositData,
     errors::BridgeError,
+    extended_rpc::ExtendedRpc,
     musig2::aggregate_partial_signatures,
     rpc::{
         self,
         clementine::{
             clementine_operator_client::ClementineOperatorClient,
-            clementine_verifier_client::ClementineVerifierClient,
+            clementine_verifier_client::ClementineVerifierClient, DepositParams,
+            OperatorKeysWithDeposit,
         },
     },
 };
-use bitcoin::hashes::Hash;
-use bitcoin::secp256k1::{schnorr, Message, PublicKey};
-use bitcoin::XOnlyPublicKey;
+use bitcoin::{
+    hashes::Hash,
+    secp256k1::{schnorr, Message, PublicKey},
+    XOnlyPublicKey,
+};
 use futures_util::future::try_join_all;
 use secp256k1::musig::{AggregatedNonce, PartialSignature};
 use tonic::Status;

--- a/core/src/bin/cli.rs
+++ b/core/src/bin/cli.rs
@@ -1,7 +1,6 @@
 //! This module defines a command line interface for the RPC client.
 
-use std::path::PathBuf;
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 use bitcoin::{hashes::Hash, Block, ScriptBuf, Txid};
 use clap::{Parser, Subcommand};

--- a/core/src/bitcoin_syncer.rs
+++ b/core/src/bitcoin_syncer.rs
@@ -561,15 +561,17 @@ impl<H: BlockHandler> Task for FinalizedBlockFetcherTask<H> {
 
 #[cfg(test)]
 mod tests {
-    use crate::bitcoin_syncer::BitcoinSyncer;
-    use crate::builder::transaction::DEFAULT_SEQUENCE;
+    use crate::{bitcoin_syncer::BitcoinSyncer, builder::transaction::DEFAULT_SEQUENCE};
 
-    use crate::task::{IntoTask, TaskExt};
-    use crate::{database::Database, test::common::*};
-    use bitcoin::absolute::Height;
-    use bitcoin::hashes::Hash;
-    use bitcoin::transaction::Version;
-    use bitcoin::{OutPoint, ScriptBuf, Transaction, TxIn, Witness};
+    use crate::{
+        database::Database,
+        task::{IntoTask, TaskExt},
+        test::common::*,
+    };
+    use bitcoin::{
+        absolute::Height, hashes::Hash, transaction::Version, OutPoint, ScriptBuf, Transaction,
+        TxIn, Witness,
+    };
     use bitcoincore_rpc::RpcApi;
 
     #[tokio::test]

--- a/core/src/bitvm_client.rs
+++ b/core/src/bitvm_client.rs
@@ -1,26 +1,28 @@
-use crate::actor::WinternitzDerivationPath;
-use crate::builder::address::taproot_builder_with_scripts;
-use crate::builder::script::{SpendableScript, WinternitzCommit};
-
-use crate::config::protocol::ProtocolParamset;
-use crate::errors::BridgeError;
-use bitcoin::{self};
-use bitcoin::{ScriptBuf, XOnlyPublicKey};
-
-use bitvm::chunk::api::{
-    api_generate_full_tapscripts, api_generate_partial_script, Assertions, NUM_HASH, NUM_PUBS,
-    NUM_U256,
+use crate::{
+    actor::WinternitzDerivationPath,
+    builder::{
+        address::taproot_builder_with_scripts,
+        script::{SpendableScript, WinternitzCommit},
+    },
 };
-use bitvm::signatures::wots_api::wots160;
+
+use crate::{config::protocol::ProtocolParamset, errors::BridgeError};
+use bitcoin::{self, ScriptBuf, XOnlyPublicKey};
+
+use bitvm::{
+    chunk::api::{
+        api_generate_full_tapscripts, api_generate_partial_script, Assertions, NUM_HASH, NUM_PUBS,
+        NUM_U256,
+    },
+    signatures::wots_api::wots160,
+};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use bridge_circuit_host::utils::{get_ark_verifying_key, get_ark_verifying_key_dev_mode_bridge};
 use risc0_zkvm::is_dev_mode;
 use std::fs;
 
-use std::str::FromStr;
-use std::sync::Arc;
-use std::time::Instant;
+use std::{str::FromStr, sync::Arc, time::Instant};
 
 lazy_static::lazy_static! {
     /// Global secp context.
@@ -650,8 +652,7 @@ pub fn replace_disprove_scripts(pks: &ClementineBitVMPublicKeys) -> Vec<ScriptBu
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::secp256k1::rand::thread_rng;
-    use bitcoin::{hashes::Hash, Txid};
+    use bitcoin::{hashes::Hash, secp256k1::rand::thread_rng, Txid};
 
     use super::*;
     use crate::{actor::Actor, test::common::create_test_config_with_thread_name};

--- a/core/src/builder/address.rs
+++ b/core/src/builder/address.rs
@@ -8,12 +8,11 @@ use super::script::{
     BaseDepositScript, CheckSig, Multisig, ReplacementDepositScript, SpendableScript,
     TimelockScript,
 };
-use crate::bitvm_client::SECP;
-use crate::deposit::SecurityCouncil;
-use crate::errors::BridgeError;
-use crate::{bitvm_client, EVMAddress};
-use bitcoin::address::NetworkUnchecked;
+use crate::{
+    bitvm_client, bitvm_client::SECP, deposit::SecurityCouncil, errors::BridgeError, EVMAddress,
+};
 use bitcoin::{
+    address::NetworkUnchecked,
     secp256k1::XOnlyPublicKey,
     taproot::{TaprootBuilder, TaprootSpendInfo},
     Address, ScriptBuf,
@@ -229,10 +228,9 @@ mod tests {
         builder::{self, address::calculate_taproot_leaf_depths},
         musig2::AggregateFromPublicKeys,
     };
-    use bitcoin::secp256k1::rand;
     use bitcoin::{
         key::{Keypair, TapTweak},
-        secp256k1::{PublicKey, SecretKey},
+        secp256k1::{rand, PublicKey, SecretKey},
         Address, AddressType, ScriptBuf, XOnlyPublicKey,
     };
     use std::str::FromStr;

--- a/core/src/builder/script.rs
+++ b/core/src/builder/script.rs
@@ -19,22 +19,19 @@
 
 #![allow(dead_code)]
 
-use crate::actor::WinternitzDerivationPath;
-use crate::config::protocol::ProtocolParamset;
-use crate::deposit::SecurityCouncil;
-use crate::EVMAddress;
-use bitcoin::hashes::Hash;
-use bitcoin::opcodes::OP_TRUE;
-use bitcoin::{
-    opcodes::{all::*, OP_FALSE},
-    script::Builder,
-    ScriptBuf, XOnlyPublicKey,
+use crate::{
+    actor::WinternitzDerivationPath, config::protocol::ProtocolParamset, deposit::SecurityCouncil,
+    EVMAddress,
 };
-use bitcoin::{taproot, Txid, Witness};
+use bitcoin::{
+    hashes::Hash,
+    opcodes::{all::*, OP_FALSE, OP_TRUE},
+    script::Builder,
+    taproot, ScriptBuf, Txid, Witness, XOnlyPublicKey,
+};
 use bitvm::signatures::winternitz::{Parameters, PublicKey, SecretKey};
 use eyre::{Context, Result};
-use std::any::Any;
-use std::fmt::Debug;
+use std::{any::Any, fmt::Debug};
 
 #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
 pub enum SpendPath {
@@ -553,15 +550,21 @@ fn get_script_from_arr<T: SpendableScript>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::actor::{Actor, WinternitzDerivationPath};
-    use crate::bitvm_client::{self, UNSPENDABLE_XONLY_PUBKEY};
-    use crate::builder::address::create_taproot_address;
-    use crate::config::protocol::ProtocolParamsetName;
-    use crate::extended_rpc::ExtendedRpc;
-    use crate::operator::RoundIndex;
-    use bitcoin::hashes::Hash;
-    use bitcoin::secp256k1::rand::{self, Rng};
-    use bitcoin::secp256k1::{PublicKey, SecretKey};
+    use crate::{
+        actor::{Actor, WinternitzDerivationPath},
+        bitvm_client::{self, UNSPENDABLE_XONLY_PUBKEY},
+        builder::address::create_taproot_address,
+        config::protocol::ProtocolParamsetName,
+        extended_rpc::ExtendedRpc,
+        operator::RoundIndex,
+    };
+    use bitcoin::{
+        hashes::Hash,
+        secp256k1::{
+            rand::{self, Rng},
+            PublicKey, SecretKey,
+        },
+    };
     use bitcoincore_rpc::RpcApi;
     use std::sync::Arc;
 
@@ -698,11 +701,14 @@ mod tests {
         }
     }
     // Tests for the spendability of all scripts
-    use crate::bitvm_client::SECP;
-    use crate::builder;
-    use crate::builder::transaction::input::SpendableTxIn;
-    use crate::builder::transaction::output::UnspentTxOut;
-    use crate::builder::transaction::{TransactionType, TxHandlerBuilder, DEFAULT_SEQUENCE};
+    use crate::{
+        bitvm_client::SECP,
+        builder,
+        builder::transaction::{
+            input::SpendableTxIn, output::UnspentTxOut, TransactionType, TxHandlerBuilder,
+            DEFAULT_SEQUENCE,
+        },
+    };
     use bitcoin::{Amount, OutPoint, Sequence, TxOut, Txid};
 
     async fn create_taproot_test_tx(

--- a/core/src/builder/sighash.rs
+++ b/core/src/builder/sighash.rs
@@ -20,22 +20,21 @@
 //!
 //! For more on sighash types, see: <https://developer.bitcoin.org/devguide/transactions.html?highlight=sighash#signature-hash-types>
 
-use crate::bitvm_client;
-use crate::builder::transaction::deposit_signature_owner::EntityType;
-use crate::builder::transaction::sign::get_kickoff_utxos_to_sign;
-use crate::builder::transaction::{
-    create_txhandlers, ContractContext, ReimburseDbCache, TransactionType, TxHandlerCache,
+use crate::{
+    bitvm_client,
+    builder::transaction::{
+        create_txhandlers, deposit_signature_owner::EntityType, sign::get_kickoff_utxos_to_sign,
+        ContractContext, ReimburseDbCache, TransactionType, TxHandlerCache,
+    },
+    config::BridgeConfig,
+    database::Database,
+    deposit::{DepositData, KickoffData},
+    errors::BridgeError,
+    operator::RoundIndex,
+    rpc::clementine::{tagged_signature::SignatureId, NormalSignatureKind},
 };
-use crate::config::BridgeConfig;
-use crate::database::Database;
-use crate::deposit::{DepositData, KickoffData};
-use crate::errors::BridgeError;
-use crate::operator::RoundIndex;
-use crate::rpc::clementine::tagged_signature::SignatureId;
-use crate::rpc::clementine::NormalSignatureKind;
 use async_stream::try_stream;
-use bitcoin::hashes::Hash;
-use bitcoin::{TapNodeHash, TapSighash, XOnlyPublicKey};
+use bitcoin::{hashes::Hash, TapNodeHash, TapSighash, XOnlyPublicKey};
 use futures_core::stream::Stream;
 
 impl BridgeConfig {

--- a/core/src/builder/transaction/challenge.rs
+++ b/core/src/builder/transaction/challenge.rs
@@ -3,17 +3,22 @@
 //! This module provides functions for constructing and challenge related transactions in the protocol.
 //! The transactions are: Challenge, ChallengeTimeout, OperatorChallengeNack, OperatorChallengeAck, Disprove.
 
-use crate::builder;
-use crate::builder::script::SpendPath;
-use crate::builder::transaction::output::UnspentTxOut;
-use crate::builder::transaction::txhandler::{TxHandler, DEFAULT_SEQUENCE};
-use crate::builder::transaction::*;
-use crate::config::protocol::ProtocolParamset;
-use crate::constants::MIN_TAPROOT_AMOUNT;
-use crate::errors::BridgeError;
-use crate::rpc::clementine::{NormalSignatureKind, NumberedSignatureKind};
-use bitcoin::script::PushBytesBuf;
-use bitcoin::{Sequence, TxOut, WitnessVersion};
+use crate::{
+    builder,
+    builder::{
+        script::SpendPath,
+        transaction::{
+            output::UnspentTxOut,
+            txhandler::{TxHandler, DEFAULT_SEQUENCE},
+            *,
+        },
+    },
+    config::protocol::ProtocolParamset,
+    constants::MIN_TAPROOT_AMOUNT,
+    errors::BridgeError,
+    rpc::clementine::{NormalSignatureKind, NumberedSignatureKind},
+};
+use bitcoin::{script::PushBytesBuf, Sequence, TxOut, WitnessVersion};
 use eyre::Context;
 
 use self::input::UtxoVout;

--- a/core/src/builder/transaction/deposit_signature_owner.rs
+++ b/core/src/builder/transaction/deposit_signature_owner.rs
@@ -5,9 +5,10 @@
 //! and what sighash type is required for that signature. Additionally it encodes when this signature is given to other entities.
 //!
 
-use crate::errors::BridgeError;
-use crate::rpc::clementine::tagged_signature::SignatureId;
-use crate::rpc::clementine::{NormalSignatureKind, NumberedSignatureKind};
+use crate::{
+    errors::BridgeError,
+    rpc::clementine::{tagged_signature::SignatureId, NormalSignatureKind, NumberedSignatureKind},
+};
 use bitcoin::TapSighashType;
 use eyre::Context;
 

--- a/core/src/builder/transaction/input.rs
+++ b/core/src/builder/transaction/input.rs
@@ -4,12 +4,16 @@
 //! It provides abstractions for spendable inputs, input errors, correctness checks, supporting Taproot and script path spends.
 //!
 
-use crate::bitvm_client;
-use crate::builder::script::SpendableScript;
-use crate::builder::sighash::TapTweakData;
-use crate::builder::{address::create_taproot_address, script::SpendPath};
-use crate::config::protocol::ProtocolParamset;
-use crate::rpc::clementine::tagged_signature::SignatureId;
+use crate::{
+    bitvm_client,
+    builder::{
+        address::create_taproot_address,
+        script::{SpendPath, SpendableScript},
+        sighash::TapTweakData,
+    },
+    config::protocol::ProtocolParamset,
+    rpc::clementine::tagged_signature::SignatureId,
+};
 use bitcoin::{
     taproot::{LeafVersion, TaprootSpendInfo},
     Amount, OutPoint, ScriptBuf, Sequence, TxIn, TxOut, Witness, WitnessProgram, XOnlyPublicKey,

--- a/core/src/builder/transaction/mod.rs
+++ b/core/src/builder/transaction/mod.rs
@@ -29,32 +29,29 @@
 //! - [`deposit_signature_owner.rs`] - Maps which TxIn signatures are signed by which protocol entities, additionally supporting different Sighash types.
 //!
 
-use super::script::{CheckSig, Multisig, SpendableScript};
-use super::script::{ReplacementDepositScript, SpendPath};
-use crate::builder::address::calculate_taproot_leaf_depths;
-use crate::builder::script::OtherSpendable;
-use crate::builder::transaction::challenge::*;
-use crate::builder::transaction::input::SpendableTxIn;
-use crate::builder::transaction::operator_assert::*;
-use crate::builder::transaction::operator_collateral::*;
-use crate::builder::transaction::operator_reimburse::*;
-use crate::builder::transaction::output::UnspentTxOut;
-use crate::config::protocol::ProtocolParamset;
-use crate::constants::NON_EPHEMERAL_ANCHOR_AMOUNT;
-use crate::deposit::{DepositData, SecurityCouncil};
-use crate::errors::BridgeError;
-use crate::operator::RoundIndex;
-use crate::rpc::clementine::grpc_transaction_id;
-use crate::rpc::clementine::GrpcTransactionId;
-use crate::rpc::clementine::{
-    NormalSignatureKind, NormalTransactionId, NumberedTransactionId, NumberedTransactionType,
+use super::script::{CheckSig, Multisig, ReplacementDepositScript, SpendPath, SpendableScript};
+use crate::{
+    builder::{
+        address::calculate_taproot_leaf_depths,
+        script::OtherSpendable,
+        transaction::{
+            challenge::*, input::SpendableTxIn, operator_assert::*, operator_collateral::*,
+            operator_reimburse::*, output::UnspentTxOut,
+        },
+    },
+    config::protocol::ProtocolParamset,
+    constants::NON_EPHEMERAL_ANCHOR_AMOUNT,
+    deposit::{DepositData, SecurityCouncil},
+    errors::BridgeError,
+    operator::RoundIndex,
+    rpc::clementine::{
+        grpc_transaction_id, GrpcTransactionId, NormalSignatureKind, NormalTransactionId,
+        NumberedTransactionId, NumberedTransactionType,
+    },
 };
-use bitcoin::hashes::Hash;
-use bitcoin::opcodes::all::OP_RETURN;
-use bitcoin::script::Builder;
-use bitcoin::transaction::Version;
 use bitcoin::{
-    Address, Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid, XOnlyPublicKey,
+    hashes::Hash, opcodes::all::OP_RETURN, script::Builder, transaction::Version, Address, Amount,
+    OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid, XOnlyPublicKey,
 };
 use hex;
 use input::UtxoVout;

--- a/core/src/builder/transaction/operator_assert.rs
+++ b/core/src/builder/transaction/operator_assert.rs
@@ -2,12 +2,11 @@
 
 use self::output::UnspentTxOut;
 use super::input::UtxoVout;
-use crate::builder;
-pub use crate::builder::transaction::txhandler::TxHandler;
-pub use crate::builder::transaction::*;
-use crate::config::protocol::ProtocolParamset;
-use crate::errors::BridgeError;
-use crate::rpc::clementine::NormalSignatureKind;
+pub use crate::builder::transaction::{txhandler::TxHandler, *};
+use crate::{
+    builder, config::protocol::ProtocolParamset, errors::BridgeError,
+    rpc::clementine::NormalSignatureKind,
+};
 use bitcoin::Sequence;
 
 /// Creates a [`TxHandler`] for the `disprove_timeout_tx`.

--- a/core/src/builder/transaction/operator_collateral.rs
+++ b/core/src/builder/transaction/operator_collateral.rs
@@ -10,22 +10,23 @@
 //! The `round_tx` is used to create a collateral for the withdrawal, kickoff utxos for the current
 //! round and the reimburse connectors for the previous round.
 
-use super::input::UtxoVout;
-use super::txhandler::DEFAULT_SEQUENCE;
-use crate::builder;
-use crate::builder::address::create_taproot_address;
-use crate::builder::script::{TimelockScript, WinternitzCommit};
-use crate::builder::transaction::creator::KickoffWinternitzKeys;
-use crate::builder::transaction::input::SpendableTxIn;
-use crate::builder::transaction::output::UnspentTxOut;
-use crate::builder::transaction::txhandler::TxHandler;
-use crate::builder::transaction::*;
-use crate::config::protocol::ProtocolParamset;
-use crate::constants::MIN_TAPROOT_AMOUNT;
-use crate::errors::BridgeError;
-use crate::rpc::clementine::NumberedSignatureKind;
-use bitcoin::Sequence;
-use bitcoin::{Amount, OutPoint, TxOut, XOnlyPublicKey};
+use super::{input::UtxoVout, txhandler::DEFAULT_SEQUENCE};
+use crate::{
+    builder,
+    builder::{
+        address::create_taproot_address,
+        script::{TimelockScript, WinternitzCommit},
+        transaction::{
+            creator::KickoffWinternitzKeys, input::SpendableTxIn, output::UnspentTxOut,
+            txhandler::TxHandler, *,
+        },
+    },
+    config::protocol::ProtocolParamset,
+    constants::MIN_TAPROOT_AMOUNT,
+    errors::BridgeError,
+    rpc::clementine::NumberedSignatureKind,
+};
+use bitcoin::{Amount, OutPoint, Sequence, TxOut, XOnlyPublicKey};
 use std::sync::Arc;
 
 pub enum RoundTxInput {

--- a/core/src/builder/transaction/operator_reimburse.rs
+++ b/core/src/builder/transaction/operator_reimburse.rs
@@ -9,31 +9,32 @@
 //! - Handling payout transactions for user withdrawals, including both standard (with BitVM) and optimistic payout flows.
 //!
 
-use super::create_move_to_vault_txhandler;
-use super::input::SpendableTxIn;
-use super::input::UtxoVout;
-use super::op_return_txout;
-use super::txhandler::DEFAULT_SEQUENCE;
-use super::HiddenNode;
-use super::Signed;
-use super::TransactionType;
-use super::TxError;
-use crate::builder::script::{CheckSig, SpendableScript, TimelockScript};
-use crate::builder::script::{PreimageRevealScript, SpendPath};
-use crate::builder::transaction::output::UnspentTxOut;
-use crate::builder::transaction::txhandler::{TxHandler, TxHandlerBuilder};
-use crate::config::protocol::ProtocolParamset;
-use crate::deposit::{DepositData, KickoffData};
-use crate::errors::BridgeError;
-use crate::rpc::clementine::NormalSignatureKind;
-use crate::{builder, UTXO};
-use bitcoin::hashes::Hash;
-use bitcoin::script::PushBytesBuf;
-use bitcoin::secp256k1::schnorr::Signature;
-use bitcoin::transaction::Version;
-use bitcoin::ScriptBuf;
-use bitcoin::XOnlyPublicKey;
-use bitcoin::{TxOut, Txid};
+use super::{
+    create_move_to_vault_txhandler,
+    input::{SpendableTxIn, UtxoVout},
+    op_return_txout,
+    txhandler::DEFAULT_SEQUENCE,
+    HiddenNode, Signed, TransactionType, TxError,
+};
+use crate::{
+    builder,
+    builder::{
+        script::{CheckSig, PreimageRevealScript, SpendPath, SpendableScript, TimelockScript},
+        transaction::{
+            output::UnspentTxOut,
+            txhandler::{TxHandler, TxHandlerBuilder},
+        },
+    },
+    config::protocol::ProtocolParamset,
+    deposit::{DepositData, KickoffData},
+    errors::BridgeError,
+    rpc::clementine::NormalSignatureKind,
+    UTXO,
+};
+use bitcoin::{
+    hashes::Hash, script::PushBytesBuf, secp256k1::schnorr::Signature, transaction::Version,
+    ScriptBuf, TxOut, Txid, XOnlyPublicKey,
+};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]

--- a/core/src/builder/transaction/output.rs
+++ b/core/src/builder/transaction/output.rs
@@ -4,8 +4,7 @@
 //! Main purpose of it is to store the scripts used in the taproot outputs.
 //!
 
-use crate::builder::address::create_taproot_address;
-use crate::builder::script::SpendableScript;
+use crate::builder::{address::create_taproot_address, script::SpendableScript};
 use bitcoin::{taproot::TaprootSpendInfo, Amount, ScriptBuf, TxOut, XOnlyPublicKey};
 use std::sync::Arc;
 

--- a/core/src/builder/transaction/sign.rs
+++ b/core/src/builder/transaction/sign.rs
@@ -2,26 +2,23 @@
 //!
 //! This module provides logic signing the transactions used in the Clementine bridge.
 
-use super::challenge::create_watchtower_challenge_txhandler;
-use super::{ContractContext, TxHandlerCache};
-use crate::actor::{Actor, TweakCache, WinternitzDerivationPath};
-use crate::bitvm_client::ClementineBitVMPublicKeys;
-use crate::builder;
-use crate::builder::transaction::creator::ReimburseDbCache;
-use crate::builder::transaction::TransactionType;
-use crate::citrea::CitreaClientT;
-use crate::config::protocol::ProtocolParamset;
-use crate::config::BridgeConfig;
-use crate::database::Database;
-use crate::deposit::KickoffData;
-use crate::errors::{BridgeError, TxError};
-use crate::operator::{Operator, RoundIndex};
-use crate::utils::RbfSigningInfo;
-use crate::verifier::Verifier;
-use bitcoin::hashes::Hash;
-use bitcoin::{BlockHash, OutPoint, Transaction, XOnlyPublicKey};
-use rand_chacha::rand_core::SeedableRng;
-use rand_chacha::ChaCha12Rng;
+use super::{challenge::create_watchtower_challenge_txhandler, ContractContext, TxHandlerCache};
+use crate::{
+    actor::{Actor, TweakCache, WinternitzDerivationPath},
+    bitvm_client::ClementineBitVMPublicKeys,
+    builder,
+    builder::transaction::{creator::ReimburseDbCache, TransactionType},
+    citrea::CitreaClientT,
+    config::{protocol::ProtocolParamset, BridgeConfig},
+    database::Database,
+    deposit::KickoffData,
+    errors::{BridgeError, TxError},
+    operator::{Operator, RoundIndex},
+    utils::RbfSigningInfo,
+    verifier::Verifier,
+};
+use bitcoin::{hashes::Hash, BlockHash, OutPoint, Transaction, XOnlyPublicKey};
+use rand_chacha::{rand_core::SeedableRng, ChaCha12Rng};
 use secp256k1::rand::seq::SliceRandom;
 
 /// Data to identify the deposit and kickoff.

--- a/core/src/builder/transaction/txhandler.rs
+++ b/core/src/builder/transaction/txhandler.rs
@@ -5,23 +5,32 @@
 //! [`TxHandlerBuilder`] is used to create [`TxHandler`]s.
 //!
 
-use super::input::{SpendableTxIn, SpentTxIn, UtxoVout};
-use super::output::UnspentTxOut;
-use crate::builder::script::SpendPath;
-use crate::builder::sighash::{PartialSignatureInfo, SignatureInfo};
-use crate::builder::transaction::deposit_signature_owner::{DepositSigKeyOwner, EntityType};
-use crate::builder::transaction::TransactionType;
-use crate::errors::{BridgeError, TxError};
-use crate::rpc::clementine::tagged_signature::SignatureId;
-use crate::rpc::clementine::{NormalSignatureKind, RawSignedTx};
-use bitcoin::sighash::SighashCache;
-use bitcoin::taproot::{self, LeafVersion};
-use bitcoin::transaction::Version;
-use bitcoin::{absolute, OutPoint, Script, Sequence, TapNodeHash, Transaction, Witness};
-use bitcoin::{TapLeafHash, TapSighash, TapSighashType, TxOut, Txid};
+use super::{
+    input::{SpendableTxIn, SpentTxIn, UtxoVout},
+    output::UnspentTxOut,
+};
+use crate::{
+    builder::{
+        script::SpendPath,
+        sighash::{PartialSignatureInfo, SignatureInfo},
+        transaction::{
+            deposit_signature_owner::{DepositSigKeyOwner, EntityType},
+            TransactionType,
+        },
+    },
+    errors::{BridgeError, TxError},
+    rpc::clementine::{tagged_signature::SignatureId, NormalSignatureKind, RawSignedTx},
+};
+use bitcoin::{
+    absolute,
+    sighash::SighashCache,
+    taproot::{self, LeafVersion},
+    transaction::Version,
+    OutPoint, Script, Sequence, TapLeafHash, TapNodeHash, TapSighash, TapSighashType, Transaction,
+    TxOut, Txid, Witness,
+};
 use eyre::{Context, OptionExt};
-use std::collections::BTreeMap;
-use std::marker::PhantomData;
+use std::{collections::BTreeMap, marker::PhantomData};
 
 pub const DEFAULT_SEQUENCE: Sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
 

--- a/core/src/citrea.rs
+++ b/core/src/citrea.rs
@@ -1,7 +1,6 @@
 //! # Citrea Related Utilities
 
-use crate::citrea::BRIDGE_CONTRACT::DepositReplaced;
-use crate::errors::BridgeError;
+use crate::{citrea::BRIDGE_CONTRACT::DepositReplaced, errors::BridgeError};
 use alloy::{
     eips::{BlockId, BlockNumberOrTag},
     network::EthereumWallet,
@@ -23,8 +22,10 @@ use bitcoin::{hashes::Hash, OutPoint, Txid, XOnlyPublicKey};
 use bridge_circuit_host::receipt_from_inner;
 use circuits_lib::bridge_circuit::structs::{LightClientProof, StorageProof};
 use eyre::Context;
-use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
-use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::{
+    http_client::{HttpClient, HttpClientBuilder},
+    proc_macros::rpc,
+};
 use risc0_zkvm::{InnerReceipt, Receipt};
 use std::{fmt::Debug, time::Duration};
 use tonic::async_trait;

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -3,22 +3,16 @@
 //! This module defines command line interface for server binaries. `Clap` is used
 //! for easy generation of help messages and handling arguments.
 
-use crate::config::protocol::ProtocolParamset;
-use crate::config::BridgeConfig;
-use crate::errors::BridgeError;
-use crate::errors::ErrorExt;
-use crate::utils;
-use crate::utils::delayed_panic;
-use clap::Parser;
-use clap::ValueEnum;
+use crate::{
+    config::{protocol::ProtocolParamset, BridgeConfig},
+    errors::{BridgeError, ErrorExt},
+    utils,
+    utils::delayed_panic,
+};
+use clap::{Parser, ValueEnum};
 use eyre::Context;
-use std::env;
-use std::ffi::OsString;
-use std::path::PathBuf;
-use std::process;
-use std::str::FromStr;
-use tracing::level_filters::LevelFilter;
-use tracing::Level;
+use std::{env, ffi::OsString, path::PathBuf, process, str::FromStr};
+use tracing::{level_filters::LevelFilter, Level};
 
 #[derive(Debug, Clone, Copy, ValueEnum, Eq, PartialEq)]
 pub enum Actors {
@@ -226,12 +220,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{get_cli_config_from_args, get_config_source, parse_from, ConfigSource};
-    use crate::cli::Actors;
-    use crate::errors::BridgeError;
-    use std::env;
-    use std::fs::File;
-    use std::io::Write;
-    use std::path::PathBuf;
+    use crate::{cli::Actors, errors::BridgeError};
+    use std::{env, fs::File, io::Write, path::PathBuf};
 
     /// With help message flag, we should see the help message. Shocking.
     #[test]

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -10,17 +10,14 @@
 //! Configuration options can be read from a TOML file. File contents are
 //! described in `BridgeConfig` struct.
 
-use crate::bitvm_client::UNSPENDABLE_XONLY_PUBKEY;
-use crate::deposit::SecurityCouncil;
-use crate::errors::BridgeError;
-use bitcoin::address::NetworkUnchecked;
-use bitcoin::secp256k1::SecretKey;
-use bitcoin::{Address, Amount, OutPoint};
+use crate::{
+    bitvm_client::UNSPENDABLE_XONLY_PUBKEY, deposit::SecurityCouncil, errors::BridgeError,
+};
+use bitcoin::{address::NetworkUnchecked, secp256k1::SecretKey, Address, Amount, OutPoint};
 use protocol::ProtocolParamset;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
-use std::{fs::File, io::Read, path::PathBuf};
+use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
 
 pub mod env;
 pub mod protocol;

--- a/core/src/config/protocol.rs
+++ b/core/src/config/protocol.rs
@@ -1,13 +1,12 @@
-use crate::config::env::read_string_from_env_then_parse;
-use crate::constants::{MIN_TAPROOT_AMOUNT, NON_EPHEMERAL_ANCHOR_AMOUNT};
-use crate::errors::BridgeError;
+use crate::{
+    config::env::read_string_from_env_then_parse,
+    constants::{MIN_TAPROOT_AMOUNT, NON_EPHEMERAL_ANCHOR_AMOUNT},
+    errors::BridgeError,
+};
 use bitcoin::{Amount, Network};
 use eyre::Context;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
-use std::fs;
-use std::path::Path;
-use std::str::FromStr;
+use std::{fmt::Display, fs, path::Path, str::FromStr};
 
 pub const BLOCKS_PER_HOUR: u16 = 6;
 

--- a/core/src/database/bitcoin_syncer.rs
+++ b/core/src/database/bitcoin_syncer.rs
@@ -386,10 +386,8 @@ impl Database {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database::Database;
-    use crate::test::common::*;
-    use bitcoin::hashes::Hash;
-    use bitcoin::{BlockHash, CompactTarget};
+    use crate::{database::Database, test::common::*};
+    use bitcoin::{hashes::Hash, BlockHash, CompactTarget};
 
     async fn setup_test_db() -> Database {
         let config = create_test_config_with_thread_name().await;

--- a/core/src/database/header_chain_prover.rs
+++ b/core/src/database/header_chain_prover.rs
@@ -402,11 +402,12 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
-    use crate::database::Database;
-    use crate::test::common::*;
-    use bitcoin::block::{self, Header, Version};
-    use bitcoin::hashes::Hash;
-    use bitcoin::{BlockHash, CompactTarget, TxMerkleNode};
+    use crate::{database::Database, test::common::*};
+    use bitcoin::{
+        block::{self, Header, Version},
+        hashes::Hash,
+        BlockHash, CompactTarget, TxMerkleNode,
+    };
     use borsh::BorshDeserialize;
     use risc0_zkvm::Receipt;
 

--- a/core/src/database/mod.rs
+++ b/core/src/database/mod.rs
@@ -12,9 +12,7 @@ use crate::{config::BridgeConfig, errors::BridgeError};
 use alloy::transports::http::reqwest::Url;
 use eyre::Context;
 use secrecy::ExposeSecret;
-use sqlx::postgres::PgConnectOptions;
-use sqlx::ConnectOptions;
-use sqlx::{Pool, Postgres};
+use sqlx::{postgres::PgConnectOptions, ConnectOptions, Pool, Postgres};
 
 mod aggregator;
 mod bitcoin_syncer;
@@ -165,8 +163,7 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::common::*;
-    use crate::{config::BridgeConfig, database::Database};
+    use crate::{config::BridgeConfig, database::Database, test::common::*};
 
     #[tokio::test]
     async fn valid_database_connection() {

--- a/core/src/database/operator.rs
+++ b/core/src/database/operator.rs
@@ -13,18 +13,14 @@ use crate::{
     builder::transaction::create_move_to_vault_txhandler,
     config::protocol::ProtocolParamset,
     deposit::{DepositData, KickoffData, OperatorData},
-    operator::RoundIndex,
-};
-use crate::{
     errors::BridgeError,
     execute_query_with_tx,
-    operator::PublicHash,
+    operator::{PublicHash, RoundIndex},
     rpc::clementine::{DepositSignatures, TaggedSignature},
     UTXO,
 };
 use bitcoin::{OutPoint, Txid, XOnlyPublicKey};
-use bitvm::signatures::winternitz;
-use bitvm::signatures::winternitz::PublicKey as WinternitzPublicKey;
+use bitvm::signatures::{winternitz, winternitz::PublicKey as WinternitzPublicKey};
 use eyre::{eyre, Context};
 use std::str::FromStr;
 
@@ -894,18 +890,21 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
-    use crate::bitvm_client::{SECP, UNSPENDABLE_XONLY_PUBKEY};
-    use crate::operator::{Operator, RoundIndex};
-    use crate::rpc::clementine::{
-        DepositSignatures, NormalSignatureKind, NumberedSignatureKind, TaggedSignature,
+    use crate::{
+        bitvm_client::{SECP, UNSPENDABLE_XONLY_PUBKEY},
+        database::Database,
+        operator::{Operator, RoundIndex},
+        rpc::clementine::{
+            DepositSignatures, NormalSignatureKind, NumberedSignatureKind, TaggedSignature,
+        },
+        test::common::{citrea::MockCitreaClient, *},
+        UTXO,
     };
-    use crate::test::common::citrea::MockCitreaClient;
-    use crate::UTXO;
-    use crate::{database::Database, test::common::*};
-    use bitcoin::hashes::Hash;
-    use bitcoin::key::constants::SCHNORR_SIGNATURE_SIZE;
-    use bitcoin::key::Keypair;
-    use bitcoin::{Address, Amount, OutPoint, ScriptBuf, TxOut, Txid, XOnlyPublicKey};
+    use bitcoin::{
+        hashes::Hash,
+        key::{constants::SCHNORR_SIGNATURE_SIZE, Keypair},
+        Address, Amount, OutPoint, ScriptBuf, TxOut, Txid, XOnlyPublicKey,
+    };
     use std::str::FromStr;
 
     #[tokio::test]

--- a/core/src/database/state_machine.rs
+++ b/core/src/database/state_machine.rs
@@ -5,8 +5,7 @@
 use bitcoin::XOnlyPublicKey;
 
 use super::{wrapper::XOnlyPublicKeyDB, Database, DatabaseTransaction};
-use crate::errors::BridgeError;
-use crate::execute_query_with_tx;
+use crate::{errors::BridgeError, execute_query_with_tx};
 
 impl Database {
     /// Saves state machines to the database with the current block height

--- a/core/src/database/tx_sender.rs
+++ b/core/src/database/tx_sender.rs
@@ -1078,10 +1078,9 @@ mod tests {
 
     use super::*;
     use crate::database::Database;
-    use bitcoin::absolute::Height;
-    use bitcoin::hashes::Hash;
-    use bitcoin::transaction::Version;
-    use bitcoin::{Block, OutPoint, TapNodeHash, Txid};
+    use bitcoin::{
+        absolute::Height, hashes::Hash, transaction::Version, Block, OutPoint, TapNodeHash, Txid,
+    };
 
     async fn setup_test_db() -> Database {
         let config = create_test_config_with_thread_name().await;

--- a/core/src/deposit.rs
+++ b/core/src/deposit.rs
@@ -6,17 +6,19 @@
 
 use std::sync::Arc;
 
-use crate::builder::script::{
-    BaseDepositScript, Multisig, ReplacementDepositScript, SpendableScript, TimelockScript,
+use crate::{
+    builder::script::{
+        BaseDepositScript, Multisig, ReplacementDepositScript, SpendableScript, TimelockScript,
+    },
+    config::protocol::ProtocolParamset,
+    errors::BridgeError,
+    musig2::AggregateFromPublicKeys,
+    operator::RoundIndex,
+    EVMAddress,
 };
-use crate::config::protocol::ProtocolParamset;
-use crate::errors::BridgeError;
-use crate::musig2::AggregateFromPublicKeys;
-use crate::operator::RoundIndex;
-use crate::EVMAddress;
-use bitcoin::address::NetworkUnchecked;
-use bitcoin::secp256k1::PublicKey;
-use bitcoin::{Address, OutPoint, Txid, XOnlyPublicKey};
+use bitcoin::{
+    address::NetworkUnchecked, secp256k1::PublicKey, Address, OutPoint, Txid, XOnlyPublicKey,
+};
 use eyre::Context;
 
 /// Data structure to represent a single kickoff utxo in an operators round tx.

--- a/core/src/extended_rpc.rs
+++ b/core/src/extended_rpc.rs
@@ -10,34 +10,21 @@
 //! [`crate::test::common::create_regtest_rpc`]. Please refer to
 //! [`crate::test::common`] for using [`ExtendedRpc`] in tests.
 
-use bitcoin::Address;
-use bitcoin::Amount;
-use bitcoin::BlockHash;
-use bitcoin::FeeRate;
-use bitcoin::OutPoint;
-use bitcoin::ScriptBuf;
-use bitcoin::TxOut;
-use bitcoin::Txid;
-use bitcoincore_rpc::Auth;
-use bitcoincore_rpc::Client;
-use bitcoincore_rpc::RpcApi;
-use eyre::eyre;
-use eyre::Context;
-use eyre::OptionExt;
-use secrecy::ExposeSecret;
-use secrecy::SecretString;
-use std::str::FromStr;
-use std::sync::Arc;
+use bitcoin::{Address, Amount, BlockHash, FeeRate, OutPoint, ScriptBuf, TxOut, Txid};
+use bitcoincore_rpc::{Auth, Client, RpcApi};
+use eyre::{eyre, Context, OptionExt};
+use secrecy::{ExposeSecret, SecretString};
+use std::{str::FromStr, sync::Arc};
 
-use crate::builder::transaction::create_round_txhandlers;
-use crate::builder::transaction::input::UtxoVout;
-use crate::builder::transaction::KickoffWinternitzKeys;
-use crate::builder::transaction::TransactionType;
-use crate::builder::transaction::TxHandler;
-use crate::config::protocol::ProtocolParamset;
-use crate::deposit::OperatorData;
-use crate::errors::BridgeError;
-use crate::operator::RoundIndex;
+use crate::{
+    builder::transaction::{
+        create_round_txhandlers, input::UtxoVout, KickoffWinternitzKeys, TransactionType, TxHandler,
+    },
+    config::protocol::ProtocolParamset,
+    deposit::OperatorData,
+    errors::BridgeError,
+    operator::RoundIndex,
+};
 use secrecy::SecretBox;
 
 type Result<T> = std::result::Result<T, BitcoinRPCError>;
@@ -714,21 +701,22 @@ impl ExtendedRpc {
 
 #[cfg(test)]
 mod tests {
-    use crate::actor::Actor;
-    use crate::config::protocol::{ProtocolParamset, REGTEST_PARAMSET};
-    use crate::extended_rpc::ExtendedRpc;
-    use crate::test::common::{citrea, create_test_config_with_thread_name};
     use crate::{
-        bitvm_client::SECP, extended_rpc::BitcoinRPCError, test::common::create_regtest_rpc,
+        actor::Actor,
+        bitvm_client::SECP,
+        config::protocol::{ProtocolParamset, REGTEST_PARAMSET},
+        extended_rpc::{BitcoinRPCError, ExtendedRpc},
+        test::common::{citrea, create_regtest_rpc, create_test_config_with_thread_name},
     };
-    use bitcoin::Amount;
-    use bitcoin::{amount, key::Keypair, Address, FeeRate, XOnlyPublicKey};
+    use bitcoin::{amount, key::Keypair, Address, Amount, FeeRate, XOnlyPublicKey};
     use bitcoincore_rpc::RpcApi;
-    use citrea_e2e::bitcoin::DEFAULT_FINALITY_DEPTH;
-    use citrea_e2e::config::{BitcoinConfig, TestCaseDockerConfig};
-    use citrea_e2e::test_case::TestCaseRunner;
-    use citrea_e2e::Result;
-    use citrea_e2e::{config::TestCaseConfig, framework::TestFramework, test_case::TestCase};
+    use citrea_e2e::{
+        bitcoin::DEFAULT_FINALITY_DEPTH,
+        config::{BitcoinConfig, TestCaseConfig, TestCaseDockerConfig},
+        framework::TestFramework,
+        test_case::{TestCase, TestCaseRunner},
+        Result,
+    };
     use tonic::async_trait;
 
     #[tokio::test]

--- a/core/src/header_chain_prover.rs
+++ b/core/src/header_chain_prover.rs
@@ -4,29 +4,26 @@
 //! module must be fed with new blocks via the database. Later, it can check if
 //! proving should be triggered by verifying if the batch size is sufficient.
 
-use crate::builder::block_cache::BlockCache;
-use crate::database::DatabaseTransaction;
-use crate::errors::ResultExt;
 use crate::{
+    builder::block_cache::BlockCache,
     config::BridgeConfig,
-    database::Database,
-    errors::{BridgeError, ErrorExt},
+    database::{Database, DatabaseTransaction},
+    errors::{BridgeError, ErrorExt, ResultExt},
     extended_rpc::ExtendedRpc,
 };
-use bitcoin::block::Header;
-use bitcoin::{hashes::Hash, BlockHash, Network};
+use bitcoin::{block::Header, hashes::Hash, BlockHash, Network};
 use bitcoincore_rpc::RpcApi;
 use bridge_circuit_host::docker::dev_stark_to_risc0_g16;
-use circuits_lib::bridge_circuit::structs::{WorkOnlyCircuitInput, WorkOnlyCircuitOutput};
-use circuits_lib::header_chain::mmr_guest::MMRGuest;
-use circuits_lib::header_chain::{
-    BlockHeaderCircuitOutput, ChainState, CircuitBlockHeader, HeaderChainCircuitInput,
-    HeaderChainPrevProofType,
+use circuits_lib::{
+    bridge_circuit::structs::{WorkOnlyCircuitInput, WorkOnlyCircuitOutput},
+    header_chain::{
+        mmr_guest::MMRGuest, BlockHeaderCircuitOutput, ChainState, CircuitBlockHeader,
+        HeaderChainCircuitInput, HeaderChainPrevProofType,
+    },
 };
 use eyre::{eyre, Context, OptionExt};
 use lazy_static::lazy_static;
-use risc0_zkvm::is_dev_mode;
-use risc0_zkvm::{compute_image_id, ExecutorEnv, ProverOpts, Receipt};
+use risc0_zkvm::{compute_image_id, is_dev_mode, ExecutorEnv, ProverOpts, Receipt};
 use std::{
     fs::File,
     io::{BufReader, Read},
@@ -706,11 +703,13 @@ impl HeaderChainProver {
 
 #[cfg(test)]
 mod tests {
-    use crate::extended_rpc::ExtendedRpc;
-    use crate::header_chain_prover::HeaderChainProver;
-    use crate::test::common::*;
-    use crate::verifier::VerifierServer;
-    use crate::{database::Database, test::common::citrea::MockCitreaClient};
+    use crate::{
+        database::Database,
+        extended_rpc::ExtendedRpc,
+        header_chain_prover::HeaderChainProver,
+        test::common::{citrea::MockCitreaClient, *},
+        verifier::VerifierServer,
+    };
     use bitcoin::{block::Header, hashes::Hash, BlockHash, Network};
     use bitcoincore_rpc::RpcApi;
     use circuits_lib::header_chain::{

--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -240,20 +240,22 @@ pub fn partial_sign(
 #[cfg(test)]
 mod tests {
     use super::{nonce_pair, MuSigNoncePair, Musig2Mode};
-    use crate::builder::script::{CheckSig, OtherSpendable, SpendableScript};
-    use crate::builder::transaction::{TransactionType, DEFAULT_SEQUENCE};
-    use crate::rpc::clementine::NormalSignatureKind;
     use crate::{
         bitvm_client::{self, SECP},
         builder::{
             self,
-            transaction::{input::SpendableTxIn, output::UnspentTxOut, TxHandlerBuilder},
+            script::{CheckSig, OtherSpendable, SpendableScript},
+            transaction::{
+                input::SpendableTxIn, output::UnspentTxOut, TransactionType, TxHandlerBuilder,
+                DEFAULT_SEQUENCE,
+            },
         },
         errors::BridgeError,
         musig2::{
             aggregate_nonces, aggregate_partial_signatures, create_key_agg_cache, from_secp_xonly,
             partial_sign, AggregateFromPublicKeys,
         },
+        rpc::clementine::NormalSignatureKind,
     };
     use bitcoin::{
         hashes::Hash,
@@ -263,8 +265,7 @@ mod tests {
         Amount, OutPoint, TapNodeHash, TapSighashType, TxOut, Txid, XOnlyPublicKey,
     };
     use secp256k1::{musig::PartialSignature, rand::Rng};
-    use std::sync::Arc;
-    use std::vec;
+    use std::{sync::Arc, vec};
 
     /// Generates random key and nonce pairs for a given number of signers.
     fn create_key_and_nonce_pairs(num_signers: usize) -> (Vec<Keypair>, Vec<MuSigNoncePair>) {

--- a/core/src/rpc/operator.rs
+++ b/core/src/rpc/operator.rs
@@ -1,22 +1,23 @@
-use super::clementine::clementine_operator_server::ClementineOperator;
-use super::clementine::{
-    self, ChallengeAckDigest, DepositParams, DepositSignSession, Empty, FinalizedPayoutParams,
-    OperatorKeys, OperatorParams, SchnorrSig, SignedTxWithType, SignedTxsWithType,
-    TransactionRequest, VergenResponse, WithdrawParams, WithdrawResponse,
-    WithdrawalFinalizedParams, XOnlyPublicKeyRpc,
+use super::{
+    clementine::{
+        self, clementine_operator_server::ClementineOperator, ChallengeAckDigest, DepositParams,
+        DepositSignSession, Empty, FinalizedPayoutParams, OperatorKeys, OperatorParams, SchnorrSig,
+        SignedTxWithType, SignedTxsWithType, TransactionRequest, VergenResponse, WithdrawParams,
+        WithdrawResponse, WithdrawalFinalizedParams, XOnlyPublicKeyRpc,
+    },
+    error::*,
+    parser::ParserError,
 };
-use super::error::*;
-use super::parser::ParserError;
-use crate::bitvm_client::ClementineBitVMPublicKeys;
-use crate::builder::transaction::sign::create_and_sign_txs;
-use crate::citrea::CitreaClientT;
-use crate::deposit::DepositData;
-use crate::operator::OperatorServer;
-use crate::rpc::parser;
-use crate::rpc::parser::parse_transaction_request;
-use crate::utils::get_vergen_response;
-use bitcoin::hashes::Hash;
-use bitcoin::{BlockHash, OutPoint};
+use crate::{
+    bitvm_client::ClementineBitVMPublicKeys,
+    builder::transaction::sign::create_and_sign_txs,
+    citrea::CitreaClientT,
+    deposit::DepositData,
+    operator::OperatorServer,
+    rpc::{parser, parser::parse_transaction_request},
+    utils::get_vergen_response,
+};
+use bitcoin::{hashes::Hash, BlockHash, OutPoint};
 use bitvm::chunk::api::{NUM_HASH, NUM_PUBS, NUM_U256};
 use futures::TryFutureExt;
 use tokio::sync::mpsc;

--- a/core/src/rpc/parser/mod.rs
+++ b/core/src/rpc/parser/mod.rs
@@ -1,23 +1,31 @@
-use super::clementine::{
-    self, DepositParams, FeeType, Outpoint, RawSignedTx, RbfSigningInfoRpc, SchnorrSig,
-    TransactionRequest, WinternitzPubkey,
+use super::{
+    clementine::{
+        self, DepositParams, FeeType, Outpoint, RawSignedTx, RbfSigningInfoRpc, SchnorrSig,
+        TransactionRequest, WinternitzPubkey,
+    },
+    error,
 };
-use super::error;
-use crate::builder::transaction::sign::TransactionRequestData;
-use crate::deposit::{
-    Actors, BaseDepositData, DepositData, DepositInfo, DepositType, ReplacementDepositData,
-    SecurityCouncil,
+use crate::{
+    builder::transaction::sign::TransactionRequestData,
+    deposit::{
+        Actors, BaseDepositData, DepositData, DepositInfo, DepositType, ReplacementDepositData,
+        SecurityCouncil,
+    },
+    errors::BridgeError,
+    operator::RoundIndex,
+    utils::{FeePayingType, RbfSigningInfo},
 };
-use crate::errors::BridgeError;
-use crate::operator::RoundIndex;
-use crate::utils::{FeePayingType, RbfSigningInfo};
-use bitcoin::hashes::{sha256d, FromSliceError, Hash};
-use bitcoin::secp256k1::schnorr::Signature;
-use bitcoin::{OutPoint, TapNodeHash, Txid, XOnlyPublicKey};
+use bitcoin::{
+    hashes::{sha256d, FromSliceError, Hash},
+    secp256k1::schnorr::Signature,
+    OutPoint, TapNodeHash, Txid, XOnlyPublicKey,
+};
 use bitvm::signatures::winternitz;
 use eyre::Context;
-use std::fmt::{Debug, Display};
-use std::num::TryFromIntError;
+use std::{
+    fmt::{Debug, Display},
+    num::TryFromIntError,
+};
 use tonic::Status;
 
 pub mod operator;

--- a/core/src/rpc/parser/verifier.rs
+++ b/core/src/rpc/parser/verifier.rs
@@ -1,27 +1,25 @@
 use super::ParserError;
-use crate::citrea::CitreaClientT;
-use crate::deposit::DepositData;
-use crate::errors::BridgeError;
-use crate::fetch_next_optional_message_from_stream;
-use crate::rpc::clementine::{
-    nonce_gen_response, verifier_deposit_sign_params, DepositSignSession, NonceGenFirstResponse,
-    OperatorKeys, OperatorKeysWithDeposit, PartialSig, VerifierDepositSignParams, VerifierParams,
-};
-use crate::verifier::Verifier;
 use crate::{
-    fetch_next_message_from_stream,
+    citrea::CitreaClientT,
+    deposit::DepositData,
+    errors::BridgeError,
+    fetch_next_message_from_stream, fetch_next_optional_message_from_stream,
     rpc::{
         clementine::{
-            self, verifier_deposit_finalize_params, NonceGenResponse,
-            VerifierDepositFinalizeParams, VerifierPublicKeys,
+            self, nonce_gen_response, verifier_deposit_finalize_params,
+            verifier_deposit_sign_params, DepositSignSession, NonceGenFirstResponse,
+            NonceGenResponse, OperatorKeys, OperatorKeysWithDeposit, PartialSig,
+            VerifierDepositFinalizeParams, VerifierDepositSignParams, VerifierParams,
+            VerifierPublicKeys,
         },
         error::{self, invalid_argument},
     },
+    verifier::Verifier,
 };
-use bitcoin::secp256k1::schnorr;
-use bitcoin::secp256k1::schnorr::Signature;
-use bitcoin::secp256k1::PublicKey;
-use bitcoin::XOnlyPublicKey;
+use bitcoin::{
+    secp256k1::{schnorr, schnorr::Signature, PublicKey},
+    XOnlyPublicKey,
+};
 use eyre::Context;
 use secp256k1::musig::{AggregatedNonce, PartialSignature, PublicNonce};
 use tonic::Status;

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -1,21 +1,25 @@
-use super::clementine::{
-    self, clementine_verifier_server::ClementineVerifier, Empty, NonceGenRequest, NonceGenResponse,
-    OperatorParams, OptimisticPayoutParams, PartialSig, RawTxWithRbfInfo, SignedTxWithType,
-    SignedTxsWithType, VergenResponse, VerifierDepositFinalizeParams, VerifierDepositSignParams,
-    VerifierParams,
+use super::{
+    clementine::{
+        self, clementine_verifier_server::ClementineVerifier, Empty, NonceGenRequest,
+        NonceGenResponse, OperatorParams, OptimisticPayoutParams, PartialSig, RawTxWithRbfInfo,
+        SignedTxWithType, SignedTxsWithType, VergenResponse, VerifierDepositFinalizeParams,
+        VerifierDepositSignParams, VerifierParams,
+    },
+    error,
+    parser::ParserError,
 };
-use super::error;
-use super::parser::ParserError;
-use crate::builder::transaction::sign::create_and_sign_txs;
-use crate::citrea::CitreaClientT;
-use crate::fetch_next_optional_message_from_stream;
-use crate::rpc::clementine::VerifierDepositFinalizeResponse;
-use crate::rpc::parser::parse_transaction_request;
-use crate::utils::get_vergen_response;
-use crate::verifier::VerifierServer;
 use crate::{
-    fetch_next_message_from_stream,
-    rpc::parser::{self},
+    builder::transaction::sign::create_and_sign_txs,
+    citrea::CitreaClientT,
+    fetch_next_message_from_stream, fetch_next_optional_message_from_stream,
+    rpc::{
+        clementine::VerifierDepositFinalizeResponse,
+        parser::{
+            parse_transaction_request, {self},
+        },
+    },
+    utils::get_vergen_response,
+    verifier::VerifierServer,
 };
 use bitcoin::Witness;
 use clementine::verifier_deposit_finalize_params::Params;

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -1,25 +1,34 @@
 //! # Servers
 //!
 //! Utilities for operator and verifier servers.
-use crate::aggregator::Aggregator;
-use crate::citrea::CitreaClientT;
-use crate::extended_rpc::ExtendedRpc;
-use crate::operator::OperatorServer;
-use crate::rpc::clementine::clementine_aggregator_server::ClementineAggregatorServer;
-use crate::rpc::clementine::clementine_operator_server::ClementineOperatorServer;
-use crate::rpc::clementine::clementine_verifier_server::ClementineVerifierServer;
-use crate::rpc::interceptors::Interceptors::{Noop, OnlyAggregatorAndSelf};
-use crate::utils::AddMethodMiddlewareLayer;
-use crate::verifier::VerifierServer;
-use crate::{config::BridgeConfig, errors};
+use crate::{
+    aggregator::Aggregator,
+    citrea::CitreaClientT,
+    config::BridgeConfig,
+    errors,
+    extended_rpc::ExtendedRpc,
+    operator::OperatorServer,
+    rpc::{
+        clementine::{
+            clementine_aggregator_server::ClementineAggregatorServer,
+            clementine_operator_server::ClementineOperatorServer,
+            clementine_verifier_server::ClementineVerifierServer,
+        },
+        interceptors::Interceptors::{Noop, OnlyAggregatorAndSelf},
+    },
+    utils::AddMethodMiddlewareLayer,
+    verifier::VerifierServer,
+};
 use errors::BridgeError;
 use eyre::Context;
 use rustls_pki_types::pem::PemObject;
 use std::thread;
 use tokio::sync::oneshot;
-use tonic::server::NamedService;
-use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Certificate, CertificateDer, Identity, ServerTlsConfig};
+use tonic::{
+    server::NamedService,
+    service::interceptor::InterceptedService,
+    transport::{Certificate, CertificateDer, Identity, ServerTlsConfig},
+};
 
 #[cfg(test)]
 use crate::test::common::ensure_test_certificates;

--- a/core/src/states/context.rs
+++ b/core/src/states/context.rs
@@ -1,19 +1,16 @@
-use crate::config::protocol::ProtocolParamset;
-use crate::database::DatabaseTransaction;
-use crate::deposit::{DepositData, KickoffData};
-use crate::operator::RoundIndex;
-use crate::utils::NamedEntity;
+use crate::{
+    config::protocol::ProtocolParamset,
+    database::DatabaseTransaction,
+    deposit::{DepositData, KickoffData},
+    operator::RoundIndex,
+    utils::NamedEntity,
+};
 
-use bitcoin::BlockHash;
-use bitcoin::Transaction;
-use bitcoin::Txid;
-use bitcoin::Witness;
-use bitcoin::XOnlyPublicKey;
+use bitcoin::{BlockHash, Transaction, Txid, Witness, XOnlyPublicKey};
 use statig::awaitable::InitializedStateMachine;
 use tonic::async_trait;
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::database::Database;
 
@@ -29,9 +26,7 @@ use crate::errors::BridgeError;
 
 use std::collections::HashSet;
 
-use super::block_cache;
-use super::kickoff;
-use super::round;
+use super::{block_cache, kickoff, round};
 
 #[derive(Debug, Clone)]
 /// Duties are notifications that are sent to the owner (verifier or operator) of the state machine to notify them on changes to the current

--- a/core/src/states/mod.rs
+++ b/core/src/states/mod.rs
@@ -1,18 +1,20 @@
 pub use crate::builder::block_cache;
-use crate::config::protocol::ProtocolParamset;
-use crate::database::{Database, DatabaseTransaction};
-use crate::errors::BridgeError;
+use crate::{
+    config::protocol::ProtocolParamset,
+    database::{Database, DatabaseTransaction},
+    errors::BridgeError,
+};
 use eyre::Context;
 use futures::future::{join, join_all};
 use kickoff::KickoffEvent;
 use matcher::BlockMatcher;
 use pgmq::PGMQueueExt;
 use round::RoundEvent;
-use statig::awaitable::{InitializedStateMachine, UninitializedStateMachine};
-use statig::prelude::*;
-use std::cmp::max;
-use std::future::Future;
-use std::sync::Arc;
+use statig::{
+    awaitable::{InitializedStateMachine, UninitializedStateMachine},
+    prelude::*,
+};
+use std::{cmp::max, future::Future, sync::Arc};
 use thiserror::Error;
 
 pub mod context;

--- a/core/src/states/round.rs
+++ b/core/src/states/round.rs
@@ -1,11 +1,11 @@
 use statig::prelude::*;
 use std::collections::{HashMap, HashSet};
 
-use crate::deposit::OperatorData;
-use crate::operator::RoundIndex;
 use crate::{
     builder::transaction::{input::UtxoVout, ContractContext, TransactionType},
+    deposit::OperatorData,
     errors::{BridgeError, TxError},
+    operator::RoundIndex,
 };
 use bitcoin::OutPoint;
 use serde_with::serde_as;

--- a/core/src/task/manager.rs
+++ b/core/src/task/manager.rs
@@ -1,12 +1,12 @@
 use super::{IntoTask, Task, TaskExt};
-use crate::errors::BridgeError;
-use crate::utils::NamedEntity;
+use crate::{errors::BridgeError, utils::NamedEntity};
 use futures::future::join_all;
-use std::marker::PhantomData;
-use std::time::Duration;
-use tokio::sync::oneshot;
-use tokio::task::{AbortHandle, JoinHandle};
-use tokio::time::sleep;
+use std::{marker::PhantomData, time::Duration};
+use tokio::{
+    sync::oneshot,
+    task::{AbortHandle, JoinHandle},
+    time::sleep,
+};
 
 /// A background task manager that can hold and manage multiple tasks When
 /// dropped, it will abort all tasks. Graceful shutdown can be performed with

--- a/core/src/task/mod.rs
+++ b/core/src/task/mod.rs
@@ -1,8 +1,9 @@
 use std::time::Duration;
-use tokio::sync::oneshot;
-use tokio::sync::oneshot::error::TryRecvError;
-use tokio::task::JoinHandle;
-use tokio::time::sleep;
+use tokio::{
+    sync::{oneshot, oneshot::error::TryRecvError},
+    task::JoinHandle,
+    time::sleep,
+};
 use tonic::async_trait;
 
 use crate::errors::BridgeError;

--- a/core/src/task/tests.rs
+++ b/core/src/task/tests.rs
@@ -1,14 +1,14 @@
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio::sync::Mutex;
 
 use tokio::time::sleep;
 
-use crate::errors::BridgeError;
-use crate::utils::NamedEntity;
+use crate::{errors::BridgeError, utils::NamedEntity};
 
-use super::manager::BackgroundTaskManager;
-use super::{CancelableResult, Task, TaskExt};
+use super::{manager::BackgroundTaskManager, CancelableResult, Task, TaskExt};
 
 // A simple counter task that increments a counter each time it runs
 #[derive(Debug, Clone)]

--- a/core/src/test/additional_disprove_scripts.rs
+++ b/core/src/test/additional_disprove_scripts.rs
@@ -1,47 +1,45 @@
-use super::common::citrea::get_bridge_params;
-use super::common::ActorsCleanup;
-use crate::bitvm_client::SECP;
-use crate::builder::transaction::input::UtxoVout;
-use crate::builder::transaction::TransactionType;
-use crate::citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER};
-use crate::config::BridgeConfig;
-use crate::database::Database;
-use crate::deposit::KickoffData;
-use crate::operator::RoundIndex;
-use crate::rpc::clementine::clementine_aggregator_client::ClementineAggregatorClient;
-use crate::rpc::clementine::clementine_operator_client::ClementineOperatorClient;
-use crate::rpc::clementine::clementine_verifier_client::ClementineVerifierClient;
-use crate::rpc::clementine::{TransactionRequest, WithdrawParams};
-use crate::test::common::citrea::{get_citrea_safe_withdraw_params, SECRET_KEYS};
-use crate::test::common::tx_utils::{
-    create_tx_sender, ensure_outpoint_spent_while_waiting_for_light_client_sync,
-    get_tx_from_signed_txs_with_type,
-    get_txid_where_utxo_is_spent_while_waiting_for_light_client_sync,
-    mine_once_after_outpoint_spent_in_mempool,
-};
-use crate::test::common::{
-    generate_withdrawal_transaction_and_signature, mine_once_after_in_mempool, run_single_deposit,
-};
-use crate::utils::{FeePayingType, TxMetadata};
+use super::common::{citrea::get_bridge_params, ActorsCleanup};
 use crate::{
+    bitvm_client::SECP,
+    builder::transaction::{input::UtxoVout, TransactionType},
+    citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER},
+    config::BridgeConfig,
+    database::Database,
+    deposit::KickoffData,
     extended_rpc::ExtendedRpc,
-    test::common::{
-        citrea::{self},
-        create_test_config_with_thread_name,
+    operator::RoundIndex,
+    rpc::clementine::{
+        clementine_aggregator_client::ClementineAggregatorClient,
+        clementine_operator_client::ClementineOperatorClient,
+        clementine_verifier_client::ClementineVerifierClient, TransactionRequest, WithdrawParams,
     },
+    test::common::{
+        citrea::{
+            get_citrea_safe_withdraw_params, SECRET_KEYS, {self},
+        },
+        create_test_config_with_thread_name, generate_withdrawal_transaction_and_signature,
+        mine_once_after_in_mempool, run_single_deposit,
+        tx_utils::{
+            create_tx_sender, ensure_outpoint_spent_while_waiting_for_light_client_sync,
+            get_tx_from_signed_txs_with_type,
+            get_txid_where_utxo_is_spent_while_waiting_for_light_client_sync,
+            mine_once_after_outpoint_spent_in_mempool,
+        },
+    },
+    utils::{FeePayingType, TxMetadata},
 };
 use alloy::primitives::U256;
 use async_trait::async_trait;
-use bitcoin::hashes::Hash;
-use bitcoin::{secp256k1::SecretKey, Address, Amount};
-use bitcoin::{OutPoint, Transaction, Txid};
+use bitcoin::{hashes::Hash, secp256k1::SecretKey, Address, Amount, OutPoint, Transaction, Txid};
 use bitcoincore_rpc::RpcApi;
-use citrea_e2e::bitcoin::{BitcoinNode, DEFAULT_FINALITY_DEPTH};
-use citrea_e2e::config::{BatchProverConfig, LightClientProverConfig};
-use citrea_e2e::node::Node;
 use citrea_e2e::{
-    config::{BitcoinConfig, SequencerConfig, TestCaseConfig, TestCaseDockerConfig},
+    bitcoin::{BitcoinNode, DEFAULT_FINALITY_DEPTH},
+    config::{
+        BatchProverConfig, BitcoinConfig, LightClientProverConfig, SequencerConfig, TestCaseConfig,
+        TestCaseDockerConfig,
+    },
     framework::TestFramework,
+    node::Node,
     test_case::{TestCase, TestCaseRunner},
     Result,
 };

--- a/core/src/test/bitvm_disprove_scripts.rs
+++ b/core/src/test/bitvm_disprove_scripts.rs
@@ -1,48 +1,44 @@
-use super::common::citrea::get_bridge_params;
-use super::common::ActorsCleanup;
-use crate::bitvm_client::SECP;
-use crate::builder::transaction::input::UtxoVout;
-use crate::config::BridgeConfig;
-use crate::database::Database;
-use crate::deposit::KickoffData;
-use crate::rpc::clementine::clementine_aggregator_client::ClementineAggregatorClient;
-use crate::rpc::clementine::clementine_operator_client::ClementineOperatorClient;
-use crate::rpc::clementine::clementine_verifier_client::ClementineVerifierClient;
-use crate::rpc::clementine::{TransactionRequest, WithdrawParams};
-use crate::test::common::citrea::{get_citrea_safe_withdraw_params, SECRET_KEYS};
-use crate::test::common::tx_utils::{
-    create_tx_sender, ensure_outpoint_spent_while_waiting_for_light_client_sync,
-    get_tx_from_signed_txs_with_type,
-    get_txid_where_utxo_is_spent_while_waiting_for_light_client_sync,
-    mine_once_after_outpoint_spent_in_mempool,
-};
-use crate::test::common::{
-    generate_withdrawal_transaction_and_signature, mine_once_after_in_mempool, run_single_deposit,
-};
-use crate::utils::{FeePayingType, TxMetadata};
+use super::common::{citrea::get_bridge_params, ActorsCleanup};
 use crate::{
-    builder::transaction::TransactionType,
+    bitvm_client::SECP,
+    builder::transaction::{input::UtxoVout, TransactionType},
     citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER},
-};
-use crate::{
+    config::BridgeConfig,
+    database::Database,
+    deposit::KickoffData,
     extended_rpc::ExtendedRpc,
-    test::common::{
-        citrea::{self},
-        create_test_config_with_thread_name,
+    rpc::clementine::{
+        clementine_aggregator_client::ClementineAggregatorClient,
+        clementine_operator_client::ClementineOperatorClient,
+        clementine_verifier_client::ClementineVerifierClient, TransactionRequest, WithdrawParams,
     },
+    test::common::{
+        citrea::{
+            get_citrea_safe_withdraw_params, SECRET_KEYS, {self},
+        },
+        create_test_config_with_thread_name, generate_withdrawal_transaction_and_signature,
+        mine_once_after_in_mempool, run_single_deposit,
+        tx_utils::{
+            create_tx_sender, ensure_outpoint_spent_while_waiting_for_light_client_sync,
+            get_tx_from_signed_txs_with_type,
+            get_txid_where_utxo_is_spent_while_waiting_for_light_client_sync,
+            mine_once_after_outpoint_spent_in_mempool,
+        },
+    },
+    utils::{FeePayingType, TxMetadata},
 };
 use alloy::primitives::U256;
 use async_trait::async_trait;
-use bitcoin::hashes::Hash;
-use bitcoin::{secp256k1::SecretKey, Address, Amount};
-use bitcoin::{OutPoint, Transaction, Txid};
+use bitcoin::{hashes::Hash, secp256k1::SecretKey, Address, Amount, OutPoint, Transaction, Txid};
 use bitcoincore_rpc::RpcApi;
-use citrea_e2e::bitcoin::{BitcoinNode, DEFAULT_FINALITY_DEPTH};
-use citrea_e2e::config::{BatchProverConfig, LightClientProverConfig};
-use citrea_e2e::node::Node;
 use citrea_e2e::{
-    config::{BitcoinConfig, SequencerConfig, TestCaseConfig, TestCaseDockerConfig},
+    bitcoin::{BitcoinNode, DEFAULT_FINALITY_DEPTH},
+    config::{
+        BatchProverConfig, BitcoinConfig, LightClientProverConfig, SequencerConfig, TestCaseConfig,
+        TestCaseDockerConfig,
+    },
     framework::TestFramework,
+    node::Node,
     test_case::{TestCase, TestCaseRunner},
     Result,
 };

--- a/core/src/test/bitvm_script.rs
+++ b/core/src/test/bitvm_script.rs
@@ -1,6 +1,5 @@
 mod tests {
-    use bitcoin::hashes::hash160;
-    use bitcoin::hashes::Hash;
+    use bitcoin::hashes::{hash160, Hash};
     use bitvm::{
         clementine::additional_disprove::{
             create_additional_replacable_disprove_script, validate_assertions_for_additional_script,

--- a/core/src/test/common/citrea/mod.rs
+++ b/core/src/test/common/citrea/mod.rs
@@ -1,7 +1,6 @@
 //! # Citrea Related Utilities
 
-use crate::musig2::AggregateFromPublicKeys;
-use crate::{config::BridgeConfig, errors::BridgeError};
+use crate::{config::BridgeConfig, errors::BridgeError, musig2::AggregateFromPublicKeys};
 use bitcoin::secp256k1::PublicKey;
 use citrea_e2e::{
     bitcoin::BitcoinNode,

--- a/core/src/test/common/citrea/parameters.rs
+++ b/core/src/test/common/citrea/parameters.rs
@@ -1,21 +1,22 @@
 //! # Parameter Builder For Citrea Requests
 
-use crate::builder;
-use crate::builder::script::SpendPath;
-use crate::builder::transaction::TransactionType;
-use crate::citrea::Bridge::MerkleProof as CitreaMerkleProof;
-use crate::citrea::Bridge::Transaction as CitreaTransaction;
-use crate::errors::BridgeError;
-use crate::extended_rpc::ExtendedRpc;
-use crate::rpc::clementine::NormalSignatureKind;
-use crate::test::common::citrea::bitcoin_merkle::BitcoinMerkleTree;
-use crate::UTXO;
+use crate::{
+    builder,
+    builder::{script::SpendPath, transaction::TransactionType},
+    citrea::Bridge::{MerkleProof as CitreaMerkleProof, Transaction as CitreaTransaction},
+    errors::BridgeError,
+    extended_rpc::ExtendedRpc,
+    rpc::clementine::NormalSignatureKind,
+    test::common::citrea::bitcoin_merkle::BitcoinMerkleTree,
+    UTXO,
+};
 use alloy::primitives::{Bytes, FixedBytes, Uint};
-use bitcoin::consensus::Encodable;
-use bitcoin::hashes::sha256;
-use bitcoin::hashes::Hash;
-use bitcoin::secp256k1::schnorr;
-use bitcoin::{Block, Transaction, Txid};
+use bitcoin::{
+    consensus::Encodable,
+    hashes::{sha256, Hash},
+    secp256k1::schnorr,
+    Block, Transaction, Txid,
+};
 use bitcoincore_rpc::RpcApi;
 use eyre::Context;
 

--- a/core/src/test/common/citrea/requests.rs
+++ b/core/src/test/common/citrea/requests.rs
@@ -1,14 +1,11 @@
-use crate::citrea::LIGHT_CLIENT_ADDRESS;
-use crate::errors::BridgeError;
-use crate::extended_rpc::ExtendedRpc;
-use crate::test::common::citrea::parameters::get_citrea_deposit_params;
-use crate::EVMAddress;
+use crate::{
+    citrea::LIGHT_CLIENT_ADDRESS, errors::BridgeError, extended_rpc::ExtendedRpc,
+    test::common::citrea::parameters::get_citrea_deposit_params, EVMAddress,
+};
 use alloy::sol_types::SolValue;
 use bitcoin::{Block, Transaction};
 use eyre::Context;
-use jsonrpsee::core::client::ClientT;
-use jsonrpsee::http_client::HttpClient;
-use jsonrpsee::rpc_params;
+use jsonrpsee::{core::client::ClientT, http_client::HttpClient, rpc_params};
 use serde_json::json;
 
 pub async fn block_number(client: &HttpClient) -> Result<u32, BridgeError> {

--- a/core/src/test/common/mod.rs
+++ b/core/src/test/common/mod.rs
@@ -1,46 +1,43 @@
 //! # Common Utilities for Integration Tests
-use std::path::Path;
-use std::process::Command;
-use std::sync::Mutex;
-use std::time::Duration;
+use std::{path::Path, process::Command, sync::Mutex, time::Duration};
 
-use crate::actor::Actor;
-use crate::bitvm_client::SECP;
-use crate::builder::address::create_taproot_address;
-use crate::builder::script::{CheckSig, Multisig, SpendableScript};
-use crate::builder::transaction::input::UtxoVout;
-use crate::builder::transaction::{create_replacement_deposit_txhandler, TxHandler};
-use crate::citrea::CitreaClientT;
-use crate::config::BridgeConfig;
-use crate::deposit::{
-    BaseDepositData, DepositInfo, DepositType, ReplacementDepositData, SecurityCouncil,
+use crate::{
+    actor::Actor,
+    bitvm_client::SECP,
+    builder::{
+        address::create_taproot_address,
+        script::{CheckSig, Multisig, SpendableScript},
+        transaction::{create_replacement_deposit_txhandler, input::UtxoVout, TxHandler},
+    },
+    citrea::CitreaClientT,
+    config::BridgeConfig,
+    deposit::{BaseDepositData, DepositInfo, DepositType, ReplacementDepositData, SecurityCouncil},
+    errors::BridgeError,
+    extended_rpc::ExtendedRpc,
+    musig2::{
+        aggregate_nonces, aggregate_partial_signatures, nonce_pair, partial_sign,
+        AggregateFromPublicKeys,
+    },
+    rpc::clementine::{
+        clementine_aggregator_client::ClementineAggregatorClient,
+        clementine_operator_client::ClementineOperatorClient,
+        clementine_verifier_client::ClementineVerifierClient, Deposit, Empty, NormalSignatureKind,
+        SendMoveTxRequest, TaggedSignature,
+    },
+    utils::FeePayingType,
+    EVMAddress,
 };
-use crate::errors::BridgeError;
-use crate::extended_rpc::ExtendedRpc;
-use crate::musig2::{
-    aggregate_nonces, aggregate_partial_signatures, nonce_pair, partial_sign,
-    AggregateFromPublicKeys,
+use bitcoin::{
+    hashes::Hash,
+    key::Keypair,
+    secp256k1::{rand, Message, PublicKey},
+    taproot, BlockHash, OutPoint, Transaction, Txid, Witness, XOnlyPublicKey,
 };
-use crate::rpc::clementine::clementine_aggregator_client::ClementineAggregatorClient;
-use crate::rpc::clementine::clementine_operator_client::ClementineOperatorClient;
-use crate::rpc::clementine::clementine_verifier_client::ClementineVerifierClient;
-use crate::rpc::clementine::{Deposit, Empty, SendMoveTxRequest};
-use crate::rpc::clementine::{NormalSignatureKind, TaggedSignature};
-use crate::utils::FeePayingType;
-use crate::EVMAddress;
-use bitcoin::hashes::Hash;
-use bitcoin::key::Keypair;
-use bitcoin::secp256k1::rand;
-use bitcoin::secp256k1::Message;
-use bitcoin::secp256k1::PublicKey;
-use bitcoin::XOnlyPublicKey;
-use bitcoin::{taproot, BlockHash, OutPoint, Transaction, Txid, Witness};
 use bitcoincore_rpc::RpcApi;
 use citrea::MockCitreaClient;
 use eyre::Context;
 pub use setup_utils::*;
-use tonic::transport::Channel;
-use tonic::Request;
+use tonic::{transport::Channel, Request};
 
 pub mod citrea;
 mod setup_utils;

--- a/core/src/test/common/setup_utils.rs
+++ b/core/src/test/common/setup_utils.rs
@@ -1,23 +1,29 @@
 //! # Testing Utilities
 
-use crate::builder::script::SpendPath;
-use crate::builder::transaction::TransactionType;
-use crate::citrea::CitreaClientT;
-use crate::rpc::clementine::clementine_aggregator_client::ClementineAggregatorClient;
-use crate::rpc::clementine::clementine_operator_client::ClementineOperatorClient;
-use crate::rpc::clementine::clementine_verifier_client::ClementineVerifierClient;
-use crate::rpc::clementine::NormalSignatureKind;
-use crate::rpc::get_clients;
-use crate::servers::{
-    create_aggregator_unix_server, create_operator_unix_server, create_verifier_unix_server,
-};
-use crate::utils::initialize_logger;
-use crate::utils::NamedEntity;
 use crate::{
-    actor::Actor, builder, config::BridgeConfig, database::Database, errors::BridgeError,
-    extended_rpc::ExtendedRpc, musig2::AggregateFromPublicKeys,
+    actor::Actor,
+    builder,
+    builder::{script::SpendPath, transaction::TransactionType},
+    citrea::CitreaClientT,
+    config::BridgeConfig,
+    database::Database,
+    errors::BridgeError,
+    extended_rpc::ExtendedRpc,
+    musig2::AggregateFromPublicKeys,
+    rpc::{
+        clementine::{
+            clementine_aggregator_client::ClementineAggregatorClient,
+            clementine_operator_client::ClementineOperatorClient,
+            clementine_verifier_client::ClementineVerifierClient, NormalSignatureKind,
+        },
+        get_clients,
+    },
+    servers::{
+        create_aggregator_unix_server, create_operator_unix_server, create_verifier_unix_server,
+    },
+    utils::{initialize_logger, NamedEntity},
+    EVMAddress, UTXO,
 };
-use crate::{EVMAddress, UTXO};
 use bitcoin::secp256k1::schnorr;
 use secrecy::ExposeSecret;
 use std::net::TcpListener;
@@ -604,13 +610,15 @@ impl NamedEntity for MockOwner {
 #[cfg(feature = "automation")]
 mod states {
     use super::*;
-    use crate::builder::block_cache;
-    use crate::builder::transaction::{ContractContext, TransactionType, TxHandler};
-    use crate::database::DatabaseTransaction;
-    use crate::states::context::DutyResult;
-    use crate::states::{Duty, Owner};
-    use std::collections::BTreeMap;
-    use std::sync::Arc;
+    use crate::{
+        builder::{
+            block_cache,
+            transaction::{ContractContext, TransactionType, TxHandler},
+        },
+        database::DatabaseTransaction,
+        states::{context::DutyResult, Duty, Owner},
+    };
+    use std::{collections::BTreeMap, sync::Arc};
     use tonic::async_trait;
 
     // Implement the Owner trait for MockOwner

--- a/core/src/test/common/tx_utils.rs
+++ b/core/src/test/common/tx_utils.rs
@@ -1,17 +1,20 @@
 use std::time::Duration;
 
-use crate::builder::transaction::TransactionType as TxType;
-use crate::config::BridgeConfig;
-use crate::database::Database;
-use crate::extended_rpc::ExtendedRpc;
-use crate::rpc::clementine::SignedTxsWithType;
-use crate::utils::{FeePayingType, RbfSigningInfo, TxMetadata};
-use bitcoin::consensus::{self};
-use bitcoin::{block, OutPoint, Transaction, Txid};
+use crate::{
+    builder::transaction::TransactionType as TxType,
+    config::BridgeConfig,
+    database::Database,
+    extended_rpc::ExtendedRpc,
+    rpc::clementine::SignedTxsWithType,
+    utils::{FeePayingType, RbfSigningInfo, TxMetadata},
+};
+use bitcoin::{
+    block,
+    consensus::{self},
+    OutPoint, Transaction, Txid,
+};
 use bitcoincore_rpc::RpcApi;
-use citrea_e2e::bitcoin::DEFAULT_FINALITY_DEPTH;
-use citrea_e2e::config::LightClientProverConfig;
-use citrea_e2e::node::Node;
+use citrea_e2e::{bitcoin::DEFAULT_FINALITY_DEPTH, config::LightClientProverConfig, node::Node};
 use eyre::{bail, Context, Result};
 
 use super::{mine_once_after_in_mempool, poll_until_condition};

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -1,49 +1,54 @@
 use super::common::citrea::get_bridge_params;
-use crate::actor::Actor;
-use crate::bitvm_client::{self, SECP};
-use crate::builder::address::create_taproot_address;
-use crate::builder::script::SpendPath;
-use crate::builder::transaction::input::{SpendableTxIn, UtxoVout};
-use crate::builder::transaction::output::UnspentTxOut;
-use crate::builder::transaction::{TransactionType, TxHandlerBuilder, DEFAULT_SEQUENCE};
-use crate::citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER};
-use crate::database::Database;
-use crate::deposit::KickoffData;
-use crate::operator::RoundIndex;
-use crate::rpc::clementine::{
-    Deposit, FeeType, FinalizedPayoutParams, KickoffId, NormalSignatureKind, RawSignedTx,
-    SendTxRequest, TransactionRequest, WithdrawParams,
-};
-use crate::test::common::citrea::{get_citrea_safe_withdraw_params, MockCitreaClient, SECRET_KEYS};
-use crate::test::common::tx_utils::get_tx_from_signed_txs_with_type;
-use crate::test::common::tx_utils::{
-    create_tx_sender, ensure_outpoint_spent,
-    ensure_outpoint_spent_while_waiting_for_light_client_sync, ensure_tx_onchain,
-    get_txid_where_utxo_is_spent, mine_once_after_outpoint_spent_in_mempool,
-};
-use crate::test::common::{
-    create_regtest_rpc, generate_withdrawal_transaction_and_signature, mine_once_after_in_mempool,
-    poll_get, poll_until_condition, run_single_deposit,
-};
-use crate::utils::{FeePayingType, TxMetadata};
-use crate::UTXO;
 use crate::{
-    extended_rpc::ExtendedRpc,
-    test::common::{
-        citrea::{self},
-        create_test_config_with_thread_name,
+    actor::Actor,
+    bitvm_client::{self, SECP},
+    builder::{
+        address::create_taproot_address,
+        script::SpendPath,
+        transaction::{
+            input::{SpendableTxIn, UtxoVout},
+            output::UnspentTxOut,
+            TransactionType, TxHandlerBuilder, DEFAULT_SEQUENCE,
+        },
     },
+    citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER},
+    database::Database,
+    deposit::KickoffData,
+    extended_rpc::ExtendedRpc,
+    operator::RoundIndex,
+    rpc::clementine::{
+        Deposit, FeeType, FinalizedPayoutParams, KickoffId, NormalSignatureKind, RawSignedTx,
+        SendTxRequest, TransactionRequest, WithdrawParams,
+    },
+    test::common::{
+        citrea::{
+            get_citrea_safe_withdraw_params, MockCitreaClient, SECRET_KEYS, {self},
+        },
+        create_regtest_rpc, create_test_config_with_thread_name,
+        generate_withdrawal_transaction_and_signature, mine_once_after_in_mempool, poll_get,
+        poll_until_condition, run_single_deposit,
+        tx_utils::{
+            create_tx_sender, ensure_outpoint_spent,
+            ensure_outpoint_spent_while_waiting_for_light_client_sync, ensure_tx_onchain,
+            get_tx_from_signed_txs_with_type, get_txid_where_utxo_is_spent,
+            mine_once_after_outpoint_spent_in_mempool,
+        },
+    },
+    utils::{FeePayingType, TxMetadata},
+    UTXO,
 };
 use alloy::primitives::U256;
 use async_trait::async_trait;
-use bitcoin::hashes::Hash;
-use bitcoin::{secp256k1::SecretKey, Address, Amount};
-use bitcoin::{OutPoint, Transaction, TxOut, Txid};
+use bitcoin::{
+    hashes::Hash, secp256k1::SecretKey, Address, Amount, OutPoint, Transaction, TxOut, Txid,
+};
 use bitcoincore_rpc::RpcApi;
-use citrea_e2e::bitcoin::DEFAULT_FINALITY_DEPTH;
-use citrea_e2e::config::{BatchProverConfig, LightClientProverConfig};
 use citrea_e2e::{
-    config::{BitcoinConfig, SequencerConfig, TestCaseConfig, TestCaseDockerConfig},
+    bitcoin::DEFAULT_FINALITY_DEPTH,
+    config::{
+        BatchProverConfig, BitcoinConfig, LightClientProverConfig, SequencerConfig, TestCaseConfig,
+        TestCaseDockerConfig,
+    },
     framework::TestFramework,
     test_case::{TestCase, TestCaseRunner},
     Result,

--- a/core/src/test/full_flow.rs
+++ b/core/src/test/full_flow.rs
@@ -1,29 +1,26 @@
 use super::common::{create_actors, create_test_config_with_thread_name, tx_utils::*};
-use crate::actor::Actor;
-use crate::bitvm_client::{self};
-use crate::builder::transaction::input::UtxoVout;
-use crate::builder::transaction::sign::get_kickoff_utxos_to_sign;
-use crate::builder::transaction::TransactionType as TxType;
-use crate::config::protocol::BLOCKS_PER_HOUR;
-use crate::config::BridgeConfig;
-use crate::database::Database;
-use crate::deposit::{BaseDepositData, DepositInfo, DepositType, KickoffData};
-use crate::extended_rpc::ExtendedRpc;
-use crate::operator::RoundIndex;
-use crate::rpc::clementine::clementine_operator_client::ClementineOperatorClient;
-use crate::rpc::clementine::clementine_verifier_client::ClementineVerifierClient;
-use crate::rpc::clementine::SendMoveTxRequest;
-use crate::rpc::clementine::{
-    Deposit, Empty, FinalizedPayoutParams, SignedTxsWithType, TransactionRequest,
+use crate::{
+    actor::Actor,
+    bitvm_client::{self},
+    builder::transaction::{
+        input::UtxoVout, sign::get_kickoff_utxos_to_sign, TransactionType as TxType,
+    },
+    config::{protocol::BLOCKS_PER_HOUR, BridgeConfig},
+    database::Database,
+    deposit::{BaseDepositData, DepositInfo, DepositType, KickoffData},
+    extended_rpc::ExtendedRpc,
+    operator::RoundIndex,
+    rpc::clementine::{
+        clementine_operator_client::ClementineOperatorClient,
+        clementine_verifier_client::ClementineVerifierClient, Deposit, Empty,
+        FinalizedPayoutParams, SendMoveTxRequest, SignedTxsWithType, TransactionRequest,
+    },
+    test::common::{citrea::MockCitreaClient, *},
+    tx_sender::TxSenderClient,
+    utils::RbfSigningInfo,
+    EVMAddress,
 };
-use crate::test::common::citrea::MockCitreaClient;
-use crate::test::common::*;
-use crate::tx_sender::TxSenderClient;
-use crate::utils::RbfSigningInfo;
-use crate::EVMAddress;
-use bitcoin::hashes::Hash;
-use bitcoin::secp256k1::PublicKey;
-use bitcoin::{OutPoint, Transaction, Txid, XOnlyPublicKey};
+use bitcoin::{hashes::Hash, secp256k1::PublicKey, OutPoint, Transaction, Txid, XOnlyPublicKey};
 use bitcoincore_rpc::RpcApi;
 use eyre::{Context, Result};
 use tonic::Request;

--- a/core/src/test/musig2.rs
+++ b/core/src/test/musig2.rs
@@ -1,25 +1,31 @@
-use crate::bitvm_client::SECP;
-use crate::builder::script::{CheckSig, OtherSpendable, SpendPath, SpendableScript};
-use crate::builder::transaction::input::SpendableTxIn;
-use crate::builder::transaction::output::UnspentTxOut;
-use crate::builder::transaction::{TransactionType, TxHandlerBuilder, DEFAULT_SEQUENCE};
-use crate::errors::BridgeError;
-use crate::musig2::{
-    aggregate_nonces, aggregate_partial_signatures, AggregateFromPublicKeys, Musig2Mode,
-};
-use crate::rpc::clementine::NormalSignatureKind;
-use crate::test::common::*;
 use crate::{
     bitvm_client,
-    builder::{self},
+    bitvm_client::SECP,
+    builder::{
+        script::{CheckSig, OtherSpendable, SpendPath, SpendableScript},
+        transaction::{
+            input::SpendableTxIn, output::UnspentTxOut, TransactionType, TxHandlerBuilder,
+            DEFAULT_SEQUENCE,
+        },
+        {self},
+    },
     config::BridgeConfig,
-    musig2::{nonce_pair, partial_sign, MuSigNoncePair},
+    errors::BridgeError,
+    musig2::{
+        aggregate_nonces, aggregate_partial_signatures, nonce_pair, partial_sign,
+        AggregateFromPublicKeys, MuSigNoncePair, Musig2Mode,
+    },
+    rpc::clementine::NormalSignatureKind,
+    test::common::*,
 };
 use ark_groth16::verifier;
-use bitcoin::key::Keypair;
-use bitcoin::secp256k1::{Message, PublicKey};
-use bitcoin::{hashes::Hash, script, Amount, TapSighashType};
-use bitcoin::{taproot, Sequence, TxOut, XOnlyPublicKey};
+use bitcoin::{
+    hashes::Hash,
+    key::Keypair,
+    script,
+    secp256k1::{Message, PublicKey},
+    taproot, Amount, Sequence, TapSighashType, TxOut, XOnlyPublicKey,
+};
 use bitcoincore_rpc::RpcApi;
 use secp256k1::musig::{AggregatedNonce, PartialSignature};
 use std::sync::Arc;

--- a/core/src/test/rpc_auth.rs
+++ b/core/src/test/rpc_auth.rs
@@ -1,12 +1,17 @@
-use crate::rpc::clementine::clementine_operator_client::ClementineOperatorClient;
-use crate::rpc::clementine::Empty;
-use crate::rpc::get_clients;
-use crate::servers::create_operator_grpc_server;
-use crate::test::common::citrea::MockCitreaClient;
-use crate::test::common::create_regtest_rpc;
-use crate::test::common::create_test_config_with_thread_name;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::path::PathBuf;
+use crate::{
+    rpc::{
+        clementine::{clementine_operator_client::ClementineOperatorClient, Empty},
+        get_clients,
+    },
+    servers::create_operator_grpc_server,
+    test::common::{
+        citrea::MockCitreaClient, create_regtest_rpc, create_test_config_with_thread_name,
+    },
+};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::PathBuf,
+};
 use tokio::net::TcpListener;
 
 // Helper function to find an available port

--- a/core/src/test/taproot.rs
+++ b/core/src/test/taproot.rs
@@ -1,12 +1,17 @@
-use crate::actor::Actor;
-use crate::bitvm_client::SECP;
-use crate::builder::script::{CheckSig, SpendPath, SpendableScript};
-use crate::builder::transaction::input::SpendableTxIn;
-use crate::builder::transaction::output::UnspentTxOut;
-use crate::builder::transaction::{TransactionType, TxHandlerBuilder, DEFAULT_SEQUENCE};
-use crate::builder::{self};
-use crate::rpc::clementine::NormalSignatureKind;
-use crate::test::common::*;
+use crate::{
+    actor::Actor,
+    bitvm_client::SECP,
+    builder::{
+        script::{CheckSig, SpendPath, SpendableScript},
+        transaction::{
+            input::SpendableTxIn, output::UnspentTxOut, TransactionType, TxHandlerBuilder,
+            DEFAULT_SEQUENCE,
+        },
+        {self},
+    },
+    rpc::clementine::NormalSignatureKind,
+    test::common::*,
+};
 use bitcoin::{Amount, TxOut};
 use bitcoincore_rpc::RpcApi;
 use std::sync::Arc;

--- a/core/src/test/withdraw.rs
+++ b/core/src/test/withdraw.rs
@@ -1,21 +1,21 @@
 use super::common::citrea::get_bridge_params;
-use crate::bitvm_client::SECP;
-use crate::citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER};
-use crate::test::common::citrea::SECRET_KEYS;
-use crate::test::common::generate_withdrawal_transaction_and_signature;
 use crate::{
+    bitvm_client::SECP,
+    citrea::{CitreaClient, CitreaClientT, SATS_TO_WEI_MULTIPLIER},
     extended_rpc::ExtendedRpc,
     test::common::{
-        citrea::{self},
-        create_test_config_with_thread_name,
+        citrea::{
+            SECRET_KEYS, {self},
+        },
+        create_test_config_with_thread_name, generate_withdrawal_transaction_and_signature,
     },
 };
-use alloy::primitives::FixedBytes;
-use alloy::primitives::U256;
-use alloy::providers::Provider;
+use alloy::{
+    primitives::{FixedBytes, U256},
+    providers::Provider,
+};
 use async_trait::async_trait;
-use bitcoin::hashes::Hash;
-use bitcoin::{secp256k1::SecretKey, Address, Amount};
+use bitcoin::{hashes::Hash, secp256k1::SecretKey, Address, Amount};
 use citrea_e2e::{
     config::{BitcoinConfig, SequencerConfig, TestCaseConfig, TestCaseDockerConfig},
     framework::TestFramework,

--- a/core/src/tx_sender/client.rs
+++ b/core/src/tx_sender/client.rs
@@ -1,18 +1,15 @@
-use super::Result;
-use super::{ActivatedWithOutpoint, ActivatedWithTxid};
-use crate::builder::transaction::input::UtxoVout;
-use crate::errors::ResultExt;
-use crate::operator::RoundIndex;
-use crate::rpc;
-use crate::rpc::clementine::XonlyPublicKey;
-use crate::utils::{FeePayingType, RbfSigningInfo, TxMetadata};
+use super::{ActivatedWithOutpoint, ActivatedWithTxid, Result};
 use crate::{
-    builder::transaction::TransactionType,
+    builder::transaction::{input::UtxoVout, TransactionType},
     config::BridgeConfig,
     database::{Database, DatabaseTransaction},
+    errors::ResultExt,
+    operator::RoundIndex,
+    rpc,
+    rpc::clementine::XonlyPublicKey,
+    utils::{FeePayingType, RbfSigningInfo, TxMetadata},
 };
-use bitcoin::hashes::Hash;
-use bitcoin::{OutPoint, Transaction, Txid};
+use bitcoin::{hashes::Hash, OutPoint, Transaction, Txid};
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]

--- a/core/src/tx_sender/cpfp.rs
+++ b/core/src/tx_sender/cpfp.rs
@@ -4,13 +4,9 @@ use std::env;
 use bitcoin::{
     transaction::Version, Address, Amount, FeeRate, OutPoint, Transaction, TxOut, Weight,
 };
-use bitcoincore_rpc::PackageSubmissionResult;
-use bitcoincore_rpc::{PackageTransactionResult, RpcApi};
+use bitcoincore_rpc::{PackageSubmissionResult, PackageTransactionResult, RpcApi};
 use eyre::Context;
 
-use crate::errors::{ErrorExt, ResultExt};
-use crate::extended_rpc::BitcoinRPCError;
-use crate::utils::FeePayingType;
 use crate::{
     builder::{
         self,
@@ -21,7 +17,10 @@ use crate::{
         },
     },
     constants::MIN_TAPROOT_AMOUNT,
+    errors::{ErrorExt, ResultExt},
+    extended_rpc::BitcoinRPCError,
     rpc::clementine::NormalSignatureKind,
+    utils::FeePayingType,
 };
 
 use super::{Result, SendTxError, TxMetadata, TxSender};

--- a/core/src/tx_sender/mod.rs
+++ b/core/src/tx_sender/mod.rs
@@ -1,21 +1,18 @@
-use bitcoin::taproot::TaprootSpendInfo;
-use bitcoin::TapNodeHash;
-use bitcoin::XOnlyPublicKey;
+use bitcoin::{taproot::TaprootSpendInfo, TapNodeHash, XOnlyPublicKey};
 use eyre::OptionExt;
 
 use bitcoin::{Amount, FeeRate, OutPoint, Transaction, TxOut, Txid, Weight};
 use bitcoincore_rpc::{json::EstimateMode, RpcApi};
 use serde::{Deserialize, Serialize};
 
-use crate::config::protocol::ProtocolParamset;
-use crate::errors::ResultExt;
-use crate::utils::FeePayingType;
 use crate::{
     actor::Actor,
     builder::{self, transaction::TransactionType},
+    config::protocol::ProtocolParamset,
     database::Database,
+    errors::ResultExt,
     extended_rpc::ExtendedRpc,
-    utils::TxMetadata,
+    utils::{FeePayingType, TxMetadata},
 };
 
 #[cfg(test)]
@@ -339,25 +336,31 @@ impl TxSender {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::actor::TweakCache;
-    use crate::bitcoin_syncer::BitcoinSyncer;
-    use crate::bitvm_client::SECP;
-    use crate::builder::script::{CheckSig, SpendPath, SpendableScript};
-    use crate::builder::transaction::input::SpendableTxIn;
-    use crate::builder::transaction::output::UnspentTxOut;
-    use crate::builder::transaction::{TransactionType, TxHandlerBuilder, DEFAULT_SEQUENCE};
-    use crate::constants::{MIN_TAPROOT_AMOUNT, NON_EPHEMERAL_ANCHOR_AMOUNT};
-    use crate::errors::BridgeError;
-    use crate::rpc::clementine::tagged_signature::SignatureId;
-    use crate::rpc::clementine::{NormalSignatureKind, NumberedSignatureKind};
-    use crate::task::{IntoTask, TaskExt};
-    use crate::{database::Database, test::common::*};
-    use bitcoin::secp256k1::rand;
-    use bitcoin::secp256k1::SecretKey;
-    use bitcoin::transaction::Version;
-    use std::result::Result;
-    use std::sync::Arc;
-    use std::time::Duration;
+    use crate::{
+        actor::TweakCache,
+        bitcoin_syncer::BitcoinSyncer,
+        bitvm_client::SECP,
+        builder::{
+            script::{CheckSig, SpendPath, SpendableScript},
+            transaction::{
+                input::SpendableTxIn, output::UnspentTxOut, TransactionType, TxHandlerBuilder,
+                DEFAULT_SEQUENCE,
+            },
+        },
+        constants::{MIN_TAPROOT_AMOUNT, NON_EPHEMERAL_ANCHOR_AMOUNT},
+        database::Database,
+        errors::BridgeError,
+        rpc::clementine::{
+            tagged_signature::SignatureId, NormalSignatureKind, NumberedSignatureKind,
+        },
+        task::{IntoTask, TaskExt},
+        test::common::*,
+    };
+    use bitcoin::{
+        secp256k1::{rand, SecretKey},
+        transaction::Version,
+    };
+    use std::{result::Result, sync::Arc, time::Duration};
     use tokio::sync::oneshot;
 
     impl TxSenderClient {

--- a/core/src/tx_sender/rbf.rs
+++ b/core/src/tx_sender/rbf.rs
@@ -1,7 +1,9 @@
-use bitcoin::script::Instruction;
-use bitcoin::sighash::{Prevouts, SighashCache};
-use bitcoin::taproot::{self};
-use bitcoin::{Psbt, TapSighashType, TxOut, Txid, Witness};
+use bitcoin::{
+    script::Instruction,
+    sighash::{Prevouts, SighashCache},
+    taproot::{self},
+    Psbt, TapSighashType, TxOut, Txid, Witness,
+};
 use bitcoincore_rpc::json::{
     BumpFeeOptions, BumpFeeResult, CreateRawTransactionInput, FinalizePsbtResult,
     WalletCreateFundedPsbtOutput, WalletCreateFundedPsbtOutputs, WalletCreateFundedPsbtResult,
@@ -822,29 +824,29 @@ impl TxSender {
 
 #[cfg(test)]
 mod tests {
-    use super::super::tests::*;
-    use super::*;
-    use crate::actor::Actor;
-    use crate::builder::script::SpendPath;
-    use crate::builder::transaction::input::SpendableTxIn;
-    use crate::builder::transaction::output::UnspentTxOut;
-    use crate::builder::transaction::{
-        op_return_txout, TransactionType, TxHandlerBuilder, DEFAULT_SEQUENCE,
+    use super::{super::tests::*, *};
+    use crate::{
+        actor::Actor,
+        builder::{
+            script::SpendPath,
+            transaction::{
+                input::SpendableTxIn, op_return_txout, output::UnspentTxOut, TransactionType,
+                TxHandlerBuilder, DEFAULT_SEQUENCE,
+            },
+        },
+        constants::MIN_TAPROOT_AMOUNT,
+        errors::BridgeError,
+        extended_rpc::ExtendedRpc,
+        rpc::clementine::{
+            tagged_signature::SignatureId, NormalSignatureKind, NumberedSignatureKind,
+        },
+        task::{IntoTask, TaskExt},
+        test::common::*,
+        utils::FeePayingType,
     };
-    use crate::constants::MIN_TAPROOT_AMOUNT;
-    use crate::errors::BridgeError;
-    use crate::extended_rpc::ExtendedRpc;
-    use crate::rpc::clementine::tagged_signature::SignatureId;
-    use crate::rpc::clementine::{NormalSignatureKind, NumberedSignatureKind};
-    use crate::task::{IntoTask, TaskExt};
-    use crate::test::common::*;
-    use crate::utils::FeePayingType;
-    use bitcoin::hashes::Hash;
-    use bitcoin::transaction::Version;
-    use bitcoin::TxOut;
+    use bitcoin::{hashes::Hash, transaction::Version, TxOut};
     use bitcoincore_rpc::json::GetRawTransactionResult;
-    use std::result::Result;
-    use std::time::Duration;
+    use std::{result::Result, time::Duration};
 
     async fn create_rbf_tx(
         rpc: &ExtendedRpc,

--- a/core/src/tx_sender/task.rs
+++ b/core/src/tx_sender/task.rs
@@ -5,12 +5,11 @@ use tonic::async_trait;
 
 use crate::errors::ResultExt;
 
-use crate::task::{IgnoreError, WithDelay};
 use crate::{
     bitcoin_syncer::BitcoinSyncerEvent,
     database::Database,
     errors::BridgeError,
-    task::{IntoTask, Task, TaskExt},
+    task::{IgnoreError, IntoTask, Task, TaskExt, WithDelay},
 };
 
 use super::TxSender;

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,17 +1,18 @@
-use crate::builder::transaction::TransactionType;
-use crate::errors::BridgeError;
-use crate::operator::RoundIndex;
-use crate::rpc::clementine::VergenResponse;
+use crate::{
+    builder::transaction::TransactionType, errors::BridgeError, operator::RoundIndex,
+    rpc::clementine::VergenResponse,
+};
 use bitcoin::{OutPoint, TapNodeHash, XOnlyPublicKey};
 use http::HeaderValue;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    fmt::Debug,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use tower::{Layer, Service};
 use tracing::level_filters::LevelFilter;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::{fmt, EnvFilter, Registry};
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Registry};
 
 /// Initializes `tracing` as the logger.
 ///

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+unstable_features = true
+imports_granularity = "Crate"


### PR DESCRIPTION
# Description

Showcase PR of using https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=#imports_granularity for formatting. Unfortunately, it is not yet stable (https://github.com/rust-lang/rustfmt/issues/4991).