### PR TITLE
Separate unit and integration tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[alias]
+test_unit = "test --features automation"
+test_integration = "test --workspace --all-features -p core test:: -- --test-threads 6"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -302,7 +302,7 @@ jobs:
           shared-key: ${{ runner.os }}-cargo-RELEASE-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
 
       - name: Run coverage
-        run: cargo llvm-cov $CARGOFLAGS_ALL_FEATURES --release --lcov --locked --no-cfg-coverage --output-path lcov.info -j 8
+        run: cargo llvm-cov $CARGOFLAGS_ALL_FEATURES --release --lcov --locked --output-path lcov.info -- --test-threads 6
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -108,8 +108,10 @@ jobs:
         with:
           shared-key: ${{ runner.os }}-cargo-DEBUG-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
 
-      - name: Run tests
-        run: cargo test $CARGOFLAGS_ALL_FEATURES
+      - name: Run unit tests
+        run: make test_unit
+      - name: Run integration tests
+        run: make test_integration
 
       - name: Upload test logs
         if: failure() || cancelled() # Only upload logs if the tests fail or are cancelled
@@ -161,8 +163,10 @@ jobs:
         with:
           shared-key: ${{ runner.os }}-cargo-RELEASE-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
 
-      - name: Run tests
-        run: cargo test --release $CARGOFLAGS_ALL_FEATURES
+      - name: Run unit tests
+        run: make test_unit
+      - name: Run integration tests
+        run: make test_integration
 
       - name: Upload test logs
         if: failure() || cancelled() # Only upload logs if the tests fail or are cancelled

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -109,9 +109,9 @@ jobs:
           shared-key: ${{ runner.os }}-cargo-DEBUG-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
 
       - name: Run unit tests
-        run: make test_unit
+        run: cargo test_unit
       - name: Run integration tests
-        run: make test_integration
+        run: cargo test_integration
 
       - name: Upload test logs
         if: failure() || cancelled() # Only upload logs if the tests fail or are cancelled
@@ -164,9 +164,9 @@ jobs:
           shared-key: ${{ runner.os }}-cargo-RELEASE-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
 
       - name: Run unit tests
-        run: make test_unit
+        run: cargo test_unit
       - name: Run integration tests
-        run: make test_integration
+        run: cargo test_integration
 
       - name: Upload test logs
         if: failure() || cancelled() # Only upload logs if the tests fail or are cancelled

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,4 @@ test_unit:
 	cargo test --features automation
 
 test_integration:
-	cargo test --package clementine-core --lib --all-features -- test::common --show-output
-	cargo test --package clementine-core --lib --all-features -- test::deposit_and_withdraw_e2e --show-output
-	cargo test --package clementine-core --lib --all-features -- test::full_flow --show-output
-	cargo test --package clementine-core --lib --all-features -- test::musig2 --show-output
-	cargo test --package clementine-core --lib --all-features -- test::rpc_auth --show-output
-	cargo test --package clementine-core --lib --all-features -- test::state_manager --show-output
-	cargo test --package clementine-core --lib --all-features -- test::taproot --show-output
-	cargo test --package clementine-core --lib --all-features -- test::withdraw --show-output
-	cargo test --package clementine-core --lib --all-features -- test::additional_disprove_scripts --show-output
-	cargo test --package clementine-core --lib --all-features -- test::bitvm_disprove_scripts --show-output
-	cargo test --package clementine-core --lib --all-features -- test::watchtower_challenge --show-output
-	cargo test --package clementine-core --lib --all-features -- test::bitvm_scripts --show-output
+	cargo test --workspace --all-features -p core test:: -- --test-threads 6

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-test_unit:
-	cargo test --features automation
-
-test_integration:
-	cargo test --workspace --all-features -p core test:: -- --test-threads 6

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+test_unit:
+	cargo test --all-features
+
+test_integration:
+	cargo test --package clementine-core --lib --all-features -- test::deposit_and_withdraw_e2e --show-output
+	cargo test --package clementine-core --lib --all-features -- test::full_flow --show-output
+	cargo test --package clementine-core --lib --all-features -- test::musig2 --show-output
+	cargo test --package clementine-core --lib --all-features -- test::rpc_auth --show-output
+	cargo test --package clementine-core --lib --all-features -- test::state_manager --show-output
+	cargo test --package clementine-core --lib --all-features -- test::taproot --show-output
+	cargo test --package clementine-core --lib --all-features -- test::withdraw --show-output
+	cargo test --package clementine-core --lib --all-features -- test::additional_disprove_scripts --show-output
+	cargo test --package clementine-core --lib --all-features -- test::bitvm_disprove_scripts --show-output
+	cargo test --package clementine-core --lib --all-features -- test::watchtower_challenge --show-output

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 test_unit:
-	cargo test --all-features
+	cargo test --features automation
 
 test_integration:
+	cargo test --package clementine-core --lib --all-features -- test::common --show-output
 	cargo test --package clementine-core --lib --all-features -- test::deposit_and_withdraw_e2e --show-output
 	cargo test --package clementine-core --lib --all-features -- test::full_flow --show-output
 	cargo test --package clementine-core --lib --all-features -- test::musig2 --show-output
@@ -12,3 +13,4 @@ test_integration:
 	cargo test --package clementine-core --lib --all-features -- test::additional_disprove_scripts --show-output
 	cargo test --package clementine-core --lib --all-features -- test::bitvm_disprove_scripts --show-output
 	cargo test --package clementine-core --lib --all-features -- test::watchtower_challenge --show-output
+	cargo test --package clementine-core --lib --all-features -- test::bitvm_scripts --show-output

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Before compiling Clementine:
 
 Before running Clementine:
 
-1. Install and configure a Bitcoin node (at least v28.0)
+1. Install and configure a Bitcoin node (at least v29.0)
 2. Install and configure PostgreSQL
 3. Set `RUST_MIN_STACK` to at least 33554432
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ To run all tests:
 cargo test --all-features
 ```
 
-Also, due to the test directory hieararchy, unit and integration tests can be
+Also, due to the test directory hierarchy, unit and integration tests can be
 run separately:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -270,6 +270,14 @@ To run all tests:
 cargo test --all-features
 ```
 
+Also, due to the test directory hieararchy, unit and integration tests can be
+run separately:
+
+```sh
+cargo test_unit
+cargo test_integration
+```
+
 #### Helper Scripts
 
 There are handful amount of scripts in [scripts](scripts) directory. Most of

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.85.0"
 
 [features]
 automation = []
+integration-tests = ["automation"]
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -103,6 +103,10 @@
 //!
 //! Please refer to the [`test`](test) module to check what utilities are
 //! available for testing and how to use them.
+//!
+//! Also, if a new integration test file is added, it should be guarded by the
+//! `#[cfg(feature = "integration-tests")]` attribute. This ensures that the
+//! integration and unit tests can be run separately.
 
 #![allow(clippy::too_many_arguments)]
 #![allow(warnings)]

--- a/core/src/test/common/citrea/client_mock.rs
+++ b/core/src/test/common/citrea/client_mock.rs
@@ -247,7 +247,7 @@ impl MockCitreaClient {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "integration-tests"))]
 mod tests {
     use crate::{citrea::CitreaClientT, test::common::create_test_config_with_thread_name};
     use bitcoin::hashes::Hash;

--- a/core/src/test/common/mod.rs
+++ b/core/src/test/common/mod.rs
@@ -696,6 +696,7 @@ async fn multiple_deposits_for_operator() {
         .unwrap();
 }
 
+#[cfg(feature = "integration-tests")]
 #[tokio::test]
 async fn test_regtest_create_and_connect() {
     let mut config = create_test_config_with_thread_name().await;

--- a/core/src/test/mod.rs
+++ b/core/src/test/mod.rs
@@ -1,22 +1,32 @@
 pub mod common;
 #[cfg(feature = "automation")]
+#[ignore]
 mod deposit_and_withdraw_e2e;
 #[cfg(feature = "automation")]
+#[ignore]
 mod full_flow;
+#[ignore]
 mod musig2;
+#[ignore]
 mod rpc_auth;
 #[cfg(feature = "automation")]
+#[ignore]
 mod state_manager;
+#[ignore]
 mod taproot;
+#[ignore]
 mod withdraw;
 
 #[cfg(feature = "automation")]
+#[ignore]
 mod additional_disprove_scripts;
 
 #[cfg(feature = "automation")]
+#[ignore]
 mod bitvm_disprove_scripts;
 
 #[cfg(feature = "automation")]
+#[ignore]
 mod watchtower_challenge;
 
 mod bitvm_script;

--- a/core/src/test/mod.rs
+++ b/core/src/test/mod.rs
@@ -1,3 +1,7 @@
+//! Note to developer: Guard the new integration test files with the
+//! `#[cfg(feature = "integration-tests")]` attribute (see #testing-clementine
+//! in [`super`]).
+
 pub mod common;
 #[cfg(all(feature = "automation", feature = "integration-tests"))]
 mod deposit_and_withdraw_e2e;

--- a/core/src/test/mod.rs
+++ b/core/src/test/mod.rs
@@ -1,34 +1,33 @@
 pub mod common;
-#[cfg(feature = "automation")]
-#[ignore]
+#[cfg(all(feature = "automation", feature = "integration-tests"))]
 mod deposit_and_withdraw_e2e;
-#[cfg(feature = "automation")]
-#[ignore]
+#[cfg(all(feature = "automation", feature = "integration-tests"))]
 mod full_flow;
-#[ignore]
+
+#[cfg(feature = "integration-tests")]
 mod musig2;
-#[ignore]
+
+#[cfg(feature = "integration-tests")]
 mod rpc_auth;
-#[cfg(feature = "automation")]
-#[ignore]
+#[cfg(all(feature = "automation", feature = "integration-tests"))]
 mod state_manager;
-#[ignore]
+
+#[cfg(feature = "integration-tests")]
 mod taproot;
-#[ignore]
+
+#[cfg(feature = "integration-tests")]
 mod withdraw;
 
-#[cfg(feature = "automation")]
-#[ignore]
+#[cfg(all(feature = "automation", feature = "integration-tests"))]
 mod additional_disprove_scripts;
 
-#[cfg(feature = "automation")]
-#[ignore]
+#[cfg(all(feature = "automation", feature = "integration-tests"))]
 mod bitvm_disprove_scripts;
 
-#[cfg(feature = "automation")]
-#[ignore]
+#[cfg(all(feature = "automation", feature = "integration-tests"))]
 mod watchtower_challenge;
 
+#[cfg(feature = "integration-tests")]
 mod bitvm_script;
 
 use ctor::ctor;


### PR DESCRIPTION
# Description

Aims to reduce flakiness.

- Separates integration test and unit test execution via `integration_tests` feature flag.
- Provides 2 `cargo` aliases for them
- Other small updates

New integration tests needs `#[cfg(feature = "integration-tests")]` attribute in module definition after this (as written in docs).