### PR TITLE
Test prereq ci cache

### DIFF
--- a/.github/actions/test-prerequisites/action.yml
+++ b/.github/actions/test-prerequisites/action.yml
@@ -12,22 +12,48 @@ runs:
   using: "composite"
 
   steps:
+    - name: Cache bitvm cache files
+      uses: actions/cache@v4
+      id: cache-bitvm
+      with:
+        path: |
+          core/bitvm_cache.bin
+          core/bitvm_cache_dev.bin
+        key: bitvm-cache-v3-dev
+
     - name: Download bitvm cache bin
+      if: steps.cache-bitvm.outputs.cache-hit != 'true'
       shell: bash
       run: wget https://static.testnet.citrea.xyz/common/bitvm_cache_v3.bin -O core/bitvm_cache.bin
+
     - name: Download bitvm cache dev bin
+      if: steps.cache-bitvm.outputs.cache-hit != 'true'
       shell: bash
       run: wget https://static.testnet.citrea.xyz/common/bitvm_cache_dev.bin -O core/bitvm_cache_dev.bin
 
+    - name: Cache Bitcoin binaries
+      uses: actions/cache@v4
+      id: cache-bitcoin
+      with:
+        path: |
+          bitcoin-29.0-x86_64-linux-gnu.tar.gz
+          bitcoin-29.0/
+        key: bitcoin-29.0-x86_64-linux-gnu
+
     - name: Download Bitcoin
+      if: steps.cache-bitcoin.outputs.cache-hit != 'true'
       shell: bash
       run: wget https://bitcoincore.org/bin/bitcoin-core-29.0/bitcoin-29.0-x86_64-linux-gnu.tar.gz
+
     - name: Unpack Bitcoin
+      if: steps.cache-bitcoin.outputs.cache-hit != 'true'
       shell: bash
       run: tar -xzvf bitcoin-29.0-x86_64-linux-gnu.tar.gz
+
     - name: Set executable permissions
       shell: bash
       run: chmod +x bitcoin-29.0/bin/*
+
     - name: Add bitcoin to path
       shell: bash
       run: echo "$PWD/bitcoin-29.0/bin" >> $GITHUB_PATH

--- a/core/src/bitcoin_syncer.rs
+++ b/core/src/bitcoin_syncer.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use tonic::async_trait;
 
 const POLL_DELAY: Duration = if cfg!(test) {
-    Duration::from_millis(100)
+    Duration::from_millis(250)
 } else {
     Duration::from_secs(30)
 };

--- a/core/src/states/task.rs
+++ b/core/src/states/task.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::{context::Owner, StateManager};
 
 const POLL_DELAY: Duration = if cfg!(test) {
-    Duration::from_millis(100)
+    Duration::from_millis(250)
 } else {
     Duration::from_secs(30)
 };

--- a/core/src/task/payout_checker.rs
+++ b/core/src/task/payout_checker.rs
@@ -6,7 +6,7 @@ use crate::{citrea::CitreaClientT, database::Database, errors::BridgeError, oper
 use super::Task;
 
 pub const PAYOUT_CHECKER_POLL_DELAY: Duration = if cfg!(test) {
-    Duration::from_millis(200)
+    Duration::from_millis(250)
 } else {
     Duration::from_secs(60)
 };

--- a/core/src/tx_sender/task.rs
+++ b/core/src/tx_sender/task.rs
@@ -16,7 +16,7 @@ use crate::{
 use super::TxSender;
 
 const POLL_DELAY: Duration = if cfg!(test) {
-    Duration::from_millis(100)
+    Duration::from_millis(250)
 } else {
     Duration::from_secs(30)
 };


### PR DESCRIPTION
Use CI cache for bitvm_cache and bitcoin 29.
With this the test prerequisite consistently takes about 1min for all tests.

I also increased poll delays for tasks, I believe this didn't affect the test runtime negatively but might decrease flakiness. Most likely it does nothing though.