### PR TITLE
Set up backtraces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,6 +2080,7 @@ dependencies = [
  "circuits-lib",
  "citrea-e2e",
  "clap",
+ "color-eyre",
  "ctor",
  "eyre",
  "futures",
@@ -2127,6 +2128,33 @@ name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -4923,6 +4951,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "owo-colors"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7713,6 +7747,16 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber 0.3.19",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 ] # Add "risc0-circuits/operator", "risc0-circuits/watchtower" later
 
 [workspace.dependencies]
+color-eyre = "0.6.5"
 ctor = "0.4.2"
 hex = "0.4.3"
 lazy_static = { version = "1.5.0", default-features = false }
@@ -122,6 +123,9 @@ vergen-git2 = { version = "1.0.0", features = [
 [patch.crates-io]
 bitcoincore-rpc = { version = "0.18.0", git = "https://github.com/chainwayxyz/rust-bitcoincore-rpc.git", rev = "5da45109a2de352472a6056ef90a517b66bc106f" }
 secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1", rev = "4d36fefdddb118425bb9bcf611bb6e4dff306cfc" }
+
+[profile.dev.package.backtrace]
+opt-level = 3
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ A server's log level can be specified with `--verbose` flag:
 ./target/release/clementine-core operator --config /path/to/config.toml --verbose 5 # Logs everything
 ```
 
+Setting `RUST_LIB_BACKTRACE` to `full` will enable full backtraces for errors
+
+```sh
+RUST_LIB_BACKTRACE=full ./target/release/clementine-core operator --config /path/to/config.toml
+```
+
 For more information, use `--help` flag:
 
 ```sh

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ tonic-build = "0.12"
 vergen-git2 = { workspace = true }
 
 [dependencies]
+color-eyre = { workspace = true }
 bitcoin = { workspace = true, features = ["rand", "bitcoinconsensus"] }
 bitcoincore-rpc = { workspace = true }
 hex = { workspace = true, features = ["serde"] }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -41,6 +41,11 @@ pub fn initialize_logger(level: Option<LevelFilter>) -> Result<(), BridgeError> 
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false);
 
+    if cfg!(test) {
+        // Enable full backtraces for tests
+        std::env::set_var("RUST_LIB_BACKTRACE", "full");
+    }
+
     // Initialize color-eyre for better error handling and backtraces
     let _ = color_eyre::install();
 


### PR DESCRIPTION
# Description

Sets up backtraces for all errors in tests and optionally in production. Sets up `color-eyre` for prettier error messages.

## Linked Issues

- Closes #
- Related to # (issue)

## Docs

Adds explanation of RUST_LIB_BACKTRACE in the production running section in README

