### PR TITLE
fix(metrics): add stopped tasks + more robust get_entity_statuses

### DIFF
--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -32,6 +32,8 @@ mod timeout {
     pub const DEPOSIT_FINALIZATION_TIMEOUT: Duration = Duration::from_secs(2400); // 40 minutes
 
     pub const RESTART_BACKGROUND_TASKS_TIMEOUT: Duration = Duration::from_secs(60);
+
+    pub const ENTITY_STATUS_POLL_TIMEOUT: Duration = Duration::from_secs(60);
 }
 
 lazy_static::lazy_static! {

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -68,6 +68,9 @@ pub struct EntityL1SyncStatusMetrics {
 
     #[metric(describe = "The number of error responses from the entity status endpoint")]
     pub entity_status_error_count: metrics::Counter,
+
+    #[metric(describe = "The number of stopped tasks for the entity")]
+    pub stopped_tasks_count: Gauge,
 }
 
 /// The L1 sync status metrics static for the currently running entity. (operator/verifier)

--- a/core/src/task/aggregator_metric_publisher.rs
+++ b/core/src/task/aggregator_metric_publisher.rs
@@ -136,6 +136,12 @@ impl Task for AggregatorMetricPublisher {
                     metrics
                         .state_manager_next_height
                         .set(status.state_manager_next_height as f64);
+                    metrics.stopped_tasks_count.set(
+                        status
+                            .stopped_tasks
+                            .map_or(0, |tasks| tasks.stopped_tasks.len())
+                            as f64,
+                    );
                 }
                 Some(crate::rpc::clementine::entity_status_with_id::StatusResult::Err(error)) => {
                     tracing::error!("Entity {} error: {}", entity_id, error.error);


### PR DESCRIPTION
# Description

Improve robustness of get_entity_statuses RPC so that the metrics publisher task does not crash. Publish stopped tasks


## Testing

None.

## Docs

Added some docs to get_entity_statuses
