### PR TITLE
Add LCP state root check

### DIFF
--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -1267,7 +1267,7 @@ where
         let payout_tx = &payout_block.txdata[payout_tx_index];
         tracing::debug!("Calculated payout tx in send_asserts: {:?}", payout_tx);
 
-        let (light_client_proof, lcp_receipt, l2_height) = self
+        let (light_client_proof, lcp_receipt, l2_height, _) = self
             .citrea_client
             .get_light_client_proof(payout_block_height as u64)
             .await

--- a/core/src/test/common/citrea/client_mock.rs
+++ b/core/src/test/common/citrea/client_mock.rs
@@ -178,7 +178,7 @@ impl CitreaClientT for MockCitreaClient {
     async fn get_light_client_proof(
         &self,
         l1_height: u64,
-    ) -> Result<Option<(LightClientProof, Receipt, u64)>, BridgeError> {
+    ) -> Result<Option<(LightClientProof, Receipt, u64, [u8; 32])>, BridgeError> {
         Ok(Some((
             LightClientProof {
                 lc_journal: vec![],
@@ -189,6 +189,7 @@ impl CitreaClientT for MockCitreaClient {
             ))
             .wrap_err("Couldn't create mock receipt")?,
             l1_height,
+            [0; 32],
         )))
     }
 
@@ -196,7 +197,7 @@ impl CitreaClientT for MockCitreaClient {
         &self,
         block_height: u64,
         _timeout: Duration,
-    ) -> Result<(u64, u64), BridgeError> {
+    ) -> Result<(u64, u64, [u8; 32]), BridgeError> {
         Ok((
             if block_height == 0 {
                 0
@@ -204,6 +205,7 @@ impl CitreaClientT for MockCitreaClient {
                 block_height - 1
             },
             block_height,
+            [0; 32],
         ))
     }
 
@@ -218,6 +220,14 @@ impl CitreaClientT for MockCitreaClient {
     async fn check_nofn_correctness(
         &self,
         _nofn_xonly_pk: bitcoin::XOnlyPublicKey,
+    ) -> Result<(), BridgeError> {
+        Ok(())
+    }
+
+    async fn check_state_root(
+        &self,
+        _l2_block_height: u64,
+        _state_root: [u8; 32],
     ) -> Result<(), BridgeError> {
         Ok(())
     }


### PR DESCRIPTION
# Description

Adds get_l2_block_by_number Citrea endpoint for checking state root against LCP's state root. Copy of #901.

## Linked Issues

- Related #897

## Testing

Current tests pass
