### PR TITLE
feat: granular timeouts in get_metrics

### DIFF
--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -223,11 +223,14 @@ where
 
         Ok(EntityStatus {
             automation: automation_enabled,
-            wallet_balance: format!("{} BTC", sync_status.wallet_balance.to_btc()),
+            wallet_balance: format!(
+                "{} BTC",
+                sync_status.wallet_balance.map_or(0.0, |a| a.to_btc())
+            ),
             tx_sender_synced_height: sync_status.tx_sender_synced_height.unwrap_or(0),
             finalized_synced_height: sync_status.finalized_synced_height.unwrap_or(0),
             hcp_last_proven_height: sync_status.hcp_last_proven_height.unwrap_or(0),
-            rpc_tip_height: sync_status.rpc_tip_height,
+            rpc_tip_height: sync_status.rpc_tip_height.unwrap_or(0),
             bitcoin_syncer_synced_height: sync_status.btc_syncer_synced_height.unwrap_or(0),
             stopped_tasks: Some(stopped_tasks),
             state_manager_next_height: sync_status.state_manager_next_height.unwrap_or(0),

--- a/core/src/task/entity_metric_publisher.rs
+++ b/core/src/task/entity_metric_publisher.rs
@@ -66,8 +66,10 @@ impl<T: NamedEntity> Task for EntityMetricPublisher<T> {
 
         metric
             .wallet_balance_btc
-            .set(l1_status.wallet_balance.to_btc());
-        metric.rpc_tip_height.set(l1_status.rpc_tip_height as f64);
+            .set(l1_status.wallet_balance.map_or(0.0, |a| a.to_btc()));
+        metric
+            .rpc_tip_height
+            .set(l1_status.rpc_tip_height.unwrap_or(0) as f64);
         metric
             .hcp_last_proven_height
             .set(l1_status.hcp_last_proven_height.unwrap_or(0) as f64);

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -17,6 +17,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
+use tokio::time::error::Elapsed;
 use tokio::time::timeout;
 use tonic::Status;
 use tower::{Layer, Service};
@@ -585,10 +586,34 @@ pub async fn timed_request<F, T>(
 where
     F: Future<Output = Result<T, BridgeError>>,
 {
+    timed_request_base(duration, description, future)
+        .await
+        .map_err(|_| Status::deadline_exceeded(format!("{} timed out", description)))?
+}
+
+/// Wraps a future with a timeout and adds a debug span with the description.
+///
+/// # Arguments
+///
+/// * `duration`: The maximum `Duration` to wait for the future to complete.
+/// * `description`: A string slice describing the operation, used in the timeout error message.
+/// * `future`: The `Future` to execute. The future should return a `Result<T, BridgeError>`.
+///
+/// # Returns
+///
+/// Returns `Ok(Ok(T))` if the future completes successfully within the time limit, returns `Ok(Err(e))`
+/// if the future returns an error, returns `Err(Elapsed)` if the request times out.
+pub async fn timed_request_base<F, T>(
+    duration: Duration,
+    description: &str,
+    future: F,
+) -> Result<Result<T, BridgeError>, Elapsed>
+where
+    F: Future<Output = Result<T, BridgeError>>,
+{
     timeout(duration, future)
         .instrument(debug_span!("timed_request", description = description))
         .await
-        .map_err(|_| Status::deadline_exceeded(format!("{} timed out", description)))?
 }
 
 /// Concurrently executes a collection of futures, applying a timeout to each one individually.

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -223,11 +223,14 @@ where
 
         Ok(EntityStatus {
             automation: automation_enabled,
-            wallet_balance: format!("{} BTC", l1_sync_status.wallet_balance.to_btc()),
+            wallet_balance: format!(
+                "{} BTC",
+                l1_sync_status.wallet_balance.map_or(0.0, |a| a.to_btc())
+            ),
             tx_sender_synced_height: l1_sync_status.tx_sender_synced_height.unwrap_or(0),
             finalized_synced_height: l1_sync_status.finalized_synced_height.unwrap_or(0),
             hcp_last_proven_height: l1_sync_status.hcp_last_proven_height.unwrap_or(0),
-            rpc_tip_height: l1_sync_status.rpc_tip_height,
+            rpc_tip_height: l1_sync_status.rpc_tip_height.unwrap_or(0),
             bitcoin_syncer_synced_height: l1_sync_status.btc_syncer_synced_height.unwrap_or(0),
             stopped_tasks: Some(stopped_tasks),
             state_manager_next_height: l1_sync_status.state_manager_next_height.unwrap_or(0),


### PR DESCRIPTION
- Updated `L1SyncStatus` struct to use `Option` types for `wallet_balance` and `rpc_tip_height` to handle potential absence of values.
- Replaced `timed_request` with `timed_request_base` for individual metrics retrieval with a reduced timeout of 45 seconds.
- Enhanced error handling in the operator and verifier to safely unwrap optional values for `wallet_balance` and `rpc_tip_height`.
- Updated metric publishing to accommodate changes in the L1 sync status structure.

# Description

Describe what this pull request does, here.

## Linked Issues

- Closes # (issue, if applicable)
- Related to # (issue)

## Testing

Describe how these changes were tested. If you've added new features, have you
added unit tests?

## Docs

Describe where this code is documented. If it changes a documented interface,
have the docs been updated?
