### PR TITLE
CMT 6 and 16

### DIFF
--- a/core/src/extended_rpc.rs
+++ b/core/src/extended_rpc.rs
@@ -279,7 +279,7 @@ impl ExtendedRpc {
         // if the collateral utxo we found latest in the round tx chain is spent, operators collateral is spent from Clementine
         // bridge protocol, thus it is unusable and operator cannot fulfill withdrawals anymore
         // if not spent, it should exist in chain, which is checked below
-        Ok(self.is_utxo_spent(&current_collateral_outpoint).await?)
+        Ok(!self.is_utxo_spent(&current_collateral_outpoint).await?)
     }
 
     /// Returns block hash of a transaction, if confirmed.


### PR DESCRIPTION
Fixes CMT 6 and 16

- Last utxo spent check in collateral_check doesn't consider tx's in mempool anymore
- In collateral_check, checking if the collateral utxo is in chain now considers only confirmed tx's in mainnet, but still accepts tx's in mempool for other networks for easier testing