### PR TITLE
CMT 3

### DIFF
--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -1031,6 +1031,13 @@ where
         output_script_pubkey: ScriptBuf,
         output_amount: Amount,
     ) -> Result<PartialSignature, BridgeError> {
+        // if the withdrawal utxo is spent, no reason to sign optimistic payout
+        if self.rpc.is_utxo_spent(&input_outpoint).await? {
+            return Err(
+                eyre::eyre!("Withdrawal utxo {:?} is already spent", input_outpoint).into(),
+            );
+        }
+
         // check if withdrawal is valid first
         let move_txid = self
             .db


### PR DESCRIPTION
Fixes CMT-3

Checks if withdrawal utxo is spent on optimistic payouts for verifier and aggregator

For new deposits, currently we didn't decide do add this check so that we can retry deposits in case of a data loss