### PR TITLE
CMT-17 Citrea HTTP client timeout

### DIFF
--- a/core/src/citrea.rs
+++ b/core/src/citrea.rs
@@ -328,12 +328,14 @@ impl CitreaClientT for CitreaClient {
         tracing::info!("Contract created");
 
         let client = HttpClientBuilder::default()
+            .request_timeout(Duration::from_secs(30))
             .build(citrea_rpc_url)
             .wrap_err("Failed to create Citrea RPC client")?;
 
         tracing::info!("Citrea RPC client created");
 
         let light_client_prover_client = HttpClientBuilder::default()
+            .request_timeout(Duration::from_secs(30))
             .build(light_client_prover_url)
             .wrap_err("Failed to create Citrea LCP RPC client")?;
 

--- a/core/src/citrea.rs
+++ b/core/src/citrea.rs
@@ -61,6 +61,7 @@ pub trait CitreaClientT: Send + Sync + Debug + Clone + 'static {
         light_client_prover_url: String,
         chain_id: u32,
         secret_key: Option<PrivateKeySigner>,
+        timeout: Option<Duration>,
     ) -> Result<Self, BridgeError>;
 
     /// Fetches an UTXO from Citrea for the given withdrawal index.
@@ -301,6 +302,7 @@ impl CitreaClientT for CitreaClient {
         light_client_prover_url: String,
         chain_id: u32,
         secret_key: Option<PrivateKeySigner>,
+        timeout: Option<Duration>,
     ) -> Result<Self, BridgeError> {
         let citrea_rpc_url = Url::parse(&citrea_rpc_url).wrap_err("Can't parse Citrea RPC URL")?;
         let light_client_prover_url =
@@ -328,14 +330,14 @@ impl CitreaClientT for CitreaClient {
         tracing::info!("Contract created");
 
         let client = HttpClientBuilder::default()
-            .request_timeout(Duration::from_secs(30))
+            .request_timeout(timeout.unwrap_or(Duration::from_secs(30)))
             .build(citrea_rpc_url)
             .wrap_err("Failed to create Citrea RPC client")?;
 
         tracing::info!("Citrea RPC client created");
 
         let light_client_prover_client = HttpClientBuilder::default()
-            .request_timeout(Duration::from_secs(30))
+            .request_timeout(timeout.unwrap_or(Duration::from_secs(30)))
             .build(light_client_prover_url)
             .wrap_err("Failed to create Citrea LCP RPC client")?;
 

--- a/core/src/config/env.rs
+++ b/core/src/config/env.rs
@@ -3,7 +3,7 @@
 use super::BridgeConfig;
 use crate::{deposit::SecurityCouncil, errors::BridgeError};
 use bitcoin::{address::NetworkUnchecked, secp256k1::SecretKey, Amount};
-use std::{path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr, time::Duration};
 
 pub(crate) fn read_string_from_env(env_var: &'static str) -> Result<String, BridgeError> {
     std::env::var(env_var).map_err(|e| BridgeError::EnvVarNotSet(e, env_var))
@@ -121,6 +121,11 @@ impl BridgeConfig {
 
         let security_council = SecurityCouncil::from_str(&security_council_string)?;
 
+        let citrea_timeout = std::env::var("CITREA_TIMEOUT")
+            .ok()
+            .and_then(|timeout| timeout.parse::<u64>().ok())
+            .map(Duration::from_secs);
+
         let config = BridgeConfig {
             // Protocol paramset's source is independently defined
             protocol_paramset: Default::default(),
@@ -142,6 +147,7 @@ impl BridgeConfig {
             citrea_rpc_url: read_string_from_env("CITREA_RPC_URL")?,
             citrea_light_client_prover_url: read_string_from_env("CITREA_LIGHT_CLIENT_PROVER_URL")?,
             citrea_chain_id: read_string_from_env_then_parse::<u32>("CITREA_CHAIN_ID")?,
+            citrea_timeout,
             bridge_contract_address: read_string_from_env("BRIDGE_CONTRACT_ADDRESS")?,
             header_chain_proof_path,
             verifier_endpoints,

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -20,6 +20,7 @@ use protocol::ProtocolParamset;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use std::time::Duration;
 use std::{fs::File, io::Read, path::PathBuf};
 
 pub mod env;
@@ -73,6 +74,8 @@ pub struct BridgeConfig {
     pub citrea_light_client_prover_url: String,
     /// Citrea's EVM Chain ID.
     pub citrea_chain_id: u32,
+    /// Timeout in seconds for Citrea RPC calls.
+    pub citrea_timeout: Option<Duration>,
     /// Bridge contract address.
     pub bridge_contract_address: String,
     // Initial header chain proof receipt's file path.
@@ -244,6 +247,7 @@ impl Default for BridgeConfig {
             citrea_light_client_prover_url: "".to_string(),
             citrea_chain_id: 5655,
             bridge_contract_address: "3100000000000000000000000000000000000002".to_string(),
+            citrea_timeout: None,
 
             header_chain_proof_path: None,
 

--- a/core/src/operator.rs
+++ b/core/src/operator.rs
@@ -304,6 +304,7 @@ where
             config.citrea_light_client_prover_url.clone(),
             config.citrea_chain_id,
             None,
+            config.citrea_timeout,
         )
         .await?;
 

--- a/core/src/test/additional_disprove_scripts.rs
+++ b/core/src/test/additional_disprove_scripts.rs
@@ -235,6 +235,7 @@ impl AdditionalDisproveTest {
             config.citrea_light_client_prover_url.clone(),
             config.citrea_chain_id,
             Some(SECRET_KEYS[0].to_string().parse().unwrap()),
+            config.citrea_timeout,
         )
         .await
         .unwrap();

--- a/core/src/test/bitvm_disprove_scripts.rs
+++ b/core/src/test/bitvm_disprove_scripts.rs
@@ -233,6 +233,7 @@ impl DisproveTest {
             config.citrea_light_client_prover_url.clone(),
             config.citrea_chain_id,
             Some(SECRET_KEYS[0].to_string().parse().unwrap()),
+            config.citrea_timeout,
         )
         .await
         .unwrap();

--- a/core/src/test/common/citrea/client_mock.rs
+++ b/core/src/test/common/citrea/client_mock.rs
@@ -88,6 +88,7 @@ impl CitreaClientT for MockCitreaClient {
         _light_client_prover_url: String,
         _chain_id: u32,
         _secret_key: Option<PrivateKeySigner>,
+        _timeout: Option<Duration>,
     ) -> Result<Self, BridgeError> {
         tracing::info!(
             "Using the mock Citrea client ({citrea_rpc_url}), beware that data returned from this client is not real"
@@ -260,6 +261,7 @@ mod tests {
             "".to_string(),
             config.citrea_chain_id,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -300,6 +302,7 @@ mod tests {
             config.citrea_rpc_url,
             "".to_string(),
             config.citrea_chain_id,
+            None,
             None,
         )
         .await

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -317,6 +317,7 @@ impl TestCase for CitreaDepositAndWithdrawE2E {
             config.citrea_light_client_prover_url.clone(),
             config.citrea_chain_id,
             Some(SECRET_KEYS[0].to_string().parse().unwrap()),
+            config.citrea_timeout,
         )
         .await
         .unwrap();
@@ -673,6 +674,7 @@ async fn mock_citrea_run_truthful() {
         "".to_string(),
         config.citrea_chain_id,
         None,
+        config.citrea_timeout,
     )
     .await
     .unwrap();
@@ -941,6 +943,7 @@ async fn mock_citrea_run_truthful_opt_payout() {
         "".to_string(),
         config.citrea_chain_id,
         None,
+        config.citrea_timeout,
     )
     .await
     .unwrap();
@@ -1126,6 +1129,7 @@ async fn mock_citrea_run_malicious() {
         "".to_string(),
         config.citrea_chain_id,
         None,
+        config.citrea_timeout,
     )
     .await
     .unwrap();
@@ -1332,6 +1336,7 @@ async fn mock_citrea_run_malicious_after_exit() {
         "".to_string(),
         config.citrea_chain_id,
         None,
+        config.citrea_timeout,
     )
     .await
     .unwrap();

--- a/core/src/test/withdraw.rs
+++ b/core/src/test/withdraw.rs
@@ -95,6 +95,7 @@ impl TestCase for CitreaWithdrawAndGetUTXO {
             config.citrea_light_client_prover_url.clone(),
             config.citrea_chain_id,
             Some(SECRET_KEYS[0].to_string().parse().unwrap()),
+            None,
         )
         .await
         .unwrap();

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -210,6 +210,7 @@ where
             config.citrea_light_client_prover_url.clone(),
             config.citrea_chain_id,
             None,
+            config.citrea_timeout,
         )
         .await?;
 


### PR DESCRIPTION
# Description

Adds optional timeout values for Citrea clients. By default, clients has a 60 second timeout. So, this PR might be unnecessary.