### PR TITLE
CMT-18-19-27 add grpc rate limiting and other limits

### DIFF
--- a/core/src/aggregator.rs
+++ b/core/src/aggregator.rs
@@ -158,7 +158,7 @@ impl Aggregator {
         // Create clients to connect to all verifiers
         let verifier_clients = rpc::get_clients(
             verifier_endpoints,
-            ClementineVerifierClient::new,
+            crate::rpc::verifier_client_builder(&config),
             &config,
             true,
         )
@@ -167,7 +167,7 @@ impl Aggregator {
         // Create clients to connect to all operators
         let operator_clients = rpc::get_clients(
             operator_endpoints,
-            ClementineOperatorClient::new,
+            crate::rpc::operator_client_builder(&config),
             &config,
             true,
         )

--- a/core/src/bin/cli.rs
+++ b/core/src/bin/cli.rs
@@ -10,10 +10,8 @@ use clementine_core::{
     deposit::SecurityCouncil,
     errors::BridgeError,
     rpc::clementine::{
-        self, clementine_aggregator_client::ClementineAggregatorClient,
-        clementine_operator_client::ClementineOperatorClient,
-        clementine_verifier_client::ClementineVerifierClient, deposit::DepositData, Actors,
-        BaseDeposit, Deposit, Empty, Outpoint, ReplacementDeposit, SendMoveTxRequest,
+        self, clementine_aggregator_client::ClementineAggregatorClient, deposit::DepositData,
+        Actors, BaseDeposit, Deposit, Empty, Outpoint, ReplacementDeposit, SendMoveTxRequest,
         VerifierPublicKeys, XOnlyPublicKeys,
     },
     EVMAddress,
@@ -430,11 +428,15 @@ async fn create_move_transaction(
 
 async fn handle_operator_call(url: String, command: OperatorCommands) {
     let config = create_minimal_config();
-    let mut operator =
-        clementine_core::rpc::get_clients(vec![url], ClementineOperatorClient::new, &config, true)
-            .await
-            .expect("Exists")[0]
-            .clone();
+    let mut operator = clementine_core::rpc::get_clients(
+        vec![url],
+        clementine_core::rpc::operator_client_builder(&config),
+        &config,
+        true,
+    )
+    .await
+    .expect("Exists")[0]
+        .clone();
 
     match command {
         OperatorCommands::GetDepositKeys {
@@ -529,11 +531,15 @@ async fn handle_operator_call(url: String, command: OperatorCommands) {
 async fn handle_verifier_call(url: String, command: VerifierCommands) {
     println!("Connecting to verifier at {}", url);
     let config = create_minimal_config();
-    let mut verifier =
-        clementine_core::rpc::get_clients(vec![url], ClementineVerifierClient::new, &config, true)
-            .await
-            .expect("Exists")[0]
-            .clone();
+    let mut verifier = clementine_core::rpc::get_clients(
+        vec![url],
+        clementine_core::rpc::verifier_client_builder(&config),
+        &config,
+        true,
+    )
+    .await
+    .expect("Exists")[0]
+        .clone();
 
     match command {
         VerifierCommands::GetParams => {

--- a/core/src/config/env.rs
+++ b/core/src/config/env.rs
@@ -29,28 +29,22 @@ impl GrpcLimits {
         let defaults = default_grpc_limits();
         Ok(GrpcLimits {
             max_message_size: read_string_from_env_then_parse::<usize>("GRPC_MAX_MESSAGE_SIZE")
-                .ok()
                 .unwrap_or(defaults.max_message_size),
             timeout_secs: read_string_from_env_then_parse::<u64>("GRPC_TIMEOUT_SECS")
-                .ok()
                 .unwrap_or(defaults.timeout_secs),
             tpc_keepalive_secs: read_string_from_env_then_parse::<u64>("GRPC_KEEPALIVE_SECS")
-                .ok()
                 .unwrap_or(defaults.tpc_keepalive_secs),
             req_concurrency_limit: read_string_from_env_then_parse::<usize>(
                 "GRPC_CONCURRENCY_LIMIT",
             )
-            .ok()
             .unwrap_or(defaults.req_concurrency_limit),
             ratelimit_req_count: read_string_from_env_then_parse::<usize>(
                 "GRPC_RATELIMIT_REQ_COUNT",
             )
-            .ok()
             .unwrap_or(defaults.ratelimit_req_count),
             ratelimit_req_interval_secs: read_string_from_env_then_parse::<u64>(
                 "GRPC_RATELIMIT_REQ_INTERVAL_SECS",
             )
-            .ok()
             .unwrap_or(defaults.ratelimit_req_interval_secs),
         })
     }
@@ -312,6 +306,27 @@ mod tests {
                 operator_collateral_funding_outpoint.to_string(),
             );
         }
+
+        std::env::set_var(
+            "GRPC_MAX_MESSAGE_SIZE",
+            default_config.grpc.max_message_size.to_string(),
+        );
+        std::env::set_var(
+            "GRPC_TIMEOUT_SECS",
+            default_config.grpc.timeout_secs.to_string(),
+        );
+        std::env::set_var(
+            "GRPC_KEEPALIVE_SECS",
+            default_config.grpc.tpc_keepalive_secs.to_string(),
+        );
+        std::env::set_var(
+            "GRPC_CONCURRENCY_LIMIT",
+            default_config.grpc.req_concurrency_limit.to_string(),
+        );
+        std::env::set_var(
+            "GRPC_RATELIMIT_REQ_COUNT",
+            default_config.grpc.ratelimit_req_count.to_string(),
+        );
 
         assert_eq!(super::BridgeConfig::from_env().unwrap(), default_config);
     }

--- a/core/src/config/env.rs
+++ b/core/src/config/env.rs
@@ -32,10 +32,10 @@ impl GrpcLimits {
                 .unwrap_or(defaults.max_message_size),
             timeout_secs: read_string_from_env_then_parse::<u64>("GRPC_TIMEOUT_SECS")
                 .unwrap_or(defaults.timeout_secs),
-            tcp_keepalive_secs: read_string_from_env_then_parse::<u64>("GRPC_KEEPALIVE_SECS")
+            tcp_keepalive_secs: read_string_from_env_then_parse::<u64>("GRPC_TCP_KEEPALIVE_SECS")
                 .unwrap_or(defaults.tcp_keepalive_secs),
             req_concurrency_limit: read_string_from_env_then_parse::<usize>(
-                "GRPC_CONCURRENCY_LIMIT",
+                "GRPC_REQ_CONCURRENCY_LIMIT",
             )
             .unwrap_or(defaults.req_concurrency_limit),
             ratelimit_req_count: read_string_from_env_then_parse::<usize>(
@@ -316,8 +316,8 @@ mod tests {
             default_config.grpc.timeout_secs.to_string(),
         );
         std::env::set_var(
-            "GRPC_KEEPALIVE_SECS",
-            default_config.grpc.tpc_keepalive_secs.to_string(),
+            "GRPC_TCP_KEEPALIVE_SECS",
+            default_config.grpc.tcp_keepalive_secs.to_string(),
         );
         std::env::set_var(
             "GRPC_CONCURRENCY_LIMIT",

--- a/core/src/config/env.rs
+++ b/core/src/config/env.rs
@@ -32,8 +32,8 @@ impl GrpcLimits {
                 .unwrap_or(defaults.max_message_size),
             timeout_secs: read_string_from_env_then_parse::<u64>("GRPC_TIMEOUT_SECS")
                 .unwrap_or(defaults.timeout_secs),
-            tpc_keepalive_secs: read_string_from_env_then_parse::<u64>("GRPC_KEEPALIVE_SECS")
-                .unwrap_or(defaults.tpc_keepalive_secs),
+            tcp_keepalive_secs: read_string_from_env_then_parse::<u64>("GRPC_KEEPALIVE_SECS")
+                .unwrap_or(defaults.tcp_keepalive_secs),
             req_concurrency_limit: read_string_from_env_then_parse::<usize>(
                 "GRPC_CONCURRENCY_LIMIT",
             )

--- a/core/src/config/env.rs
+++ b/core/src/config/env.rs
@@ -29,6 +29,12 @@ impl GrpcLimits {
             req_concurrency_limit: read_string_from_env_then_parse::<usize>(
                 "GRPC_CONCURRENCY_LIMIT",
             )?,
+            ratelimit_req_count: read_string_from_env_then_parse::<usize>(
+                "GRPC_RATELIMIT_REQ_COUNT",
+            )?,
+            ratelimit_req_interval_secs: read_string_from_env_then_parse::<u64>(
+                "GRPC_RATELIMIT_REQ_INTERVAL_SECS",
+            )?,
         })
     }
 }

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -140,7 +140,7 @@ pub struct BridgeConfig {
 pub struct GrpcLimits {
     pub max_message_size: usize,
     pub timeout_secs: u64,
-    pub tpc_keepalive_secs: u64,
+    pub tcp_keepalive_secs: u64,
     pub req_concurrency_limit: usize,
     pub ratelimit_req_count: usize,
     pub ratelimit_req_interval_secs: u64,
@@ -150,7 +150,7 @@ fn default_grpc_limits() -> GrpcLimits {
     GrpcLimits {
         max_message_size: 4 * 1024 * 1024,
         timeout_secs: 12 * 60 * 60, // 12 hours
-        tpc_keepalive_secs: 60,
+        tcp_keepalive_secs: 60,
         req_concurrency_limit: 300, // 100 deposits at the same time
         ratelimit_req_count: 1000,
         ratelimit_req_interval_secs: 60,

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -149,9 +149,9 @@ pub struct GrpcLimits {
 fn default_grpc_limits() -> GrpcLimits {
     GrpcLimits {
         max_message_size: 4 * 1024 * 1024,
-        timeout_secs: 30,
+        timeout_secs: 12 * 60 * 60, // 12 hours
         tpc_keepalive_secs: 60,
-        req_concurrency_limit: 100,
+        req_concurrency_limit: 300, // 100 deposits at the same time
         ratelimit_req_count: 1000,
         ratelimit_req_interval_secs: 60,
     }

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -130,6 +130,27 @@ pub struct BridgeConfig {
     #[cfg(test)]
     #[serde(skip)]
     pub test_params: test::TestParams,
+
+    /// gRPC client/server limits
+    #[serde(default = "default_grpc_limits")]
+    pub grpc: GrpcLimits,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct GrpcLimits {
+    pub max_message_size: usize,
+    pub timeout_secs: u64,
+    pub tpc_keepalive_secs: u64,
+    pub req_concurrency_limit: usize,
+}
+
+fn default_grpc_limits() -> GrpcLimits {
+    GrpcLimits {
+        max_message_size: 4 * 1024 * 1024,
+        timeout_secs: 30,
+        tpc_keepalive_secs: 60,
+        req_concurrency_limit: 100,
+    }
 }
 
 impl BridgeConfig {
@@ -210,7 +231,8 @@ impl PartialEq for BridgeConfig {
             && self.ca_cert_path == other.ca_cert_path
             && self.client_verification == other.client_verification
             && self.aggregator_cert_path == other.aggregator_cert_path
-            && self.test_params == other.test_params;
+            && self.test_params == other.test_params
+            && self.grpc == other.grpc;
 
         all_eq
     }
@@ -274,6 +296,9 @@ impl Default for BridgeConfig {
 
             #[cfg(test)]
             test_params: test::TestParams::default(),
+
+            // New hardening parameters, optional so they don't break existing configs.
+            grpc: default_grpc_limits(),
         }
     }
 }

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -142,6 +142,8 @@ pub struct GrpcLimits {
     pub timeout_secs: u64,
     pub tpc_keepalive_secs: u64,
     pub req_concurrency_limit: usize,
+    pub ratelimit_req_count: usize,
+    pub ratelimit_req_interval_secs: u64,
 }
 
 fn default_grpc_limits() -> GrpcLimits {
@@ -150,6 +152,8 @@ fn default_grpc_limits() -> GrpcLimits {
         timeout_secs: 30,
         tpc_keepalive_secs: 60,
         req_concurrency_limit: 100,
+        ratelimit_req_count: 1000,
+        ratelimit_req_interval_secs: 60,
     }
 }
 

--- a/core/src/rpc/mod.rs
+++ b/core/src/rpc/mod.rs
@@ -1,8 +1,15 @@
-use crate::errors::BridgeError;
+use crate::{
+    config::BridgeConfig,
+    errors::BridgeError,
+    rpc::clementine::{
+        clementine_operator_client::ClementineOperatorClient,
+        clementine_verifier_client::ClementineVerifierClient,
+    },
+};
 use clementine::*;
 use eyre::Context;
 use hyper_util::rt::TokioIo;
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 use tagged_signature::SignatureId;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity, Uri};
 
@@ -57,7 +64,7 @@ pub async fn get_clients<CLIENT, F>(
     use_client_cert: bool,
 ) -> Result<Vec<CLIENT>, BridgeError>
 where
-    F: FnOnce(Channel) -> CLIENT + Copy,
+    F: Fn(Channel) -> CLIENT,
 {
     // Ensure certificates exist in test mode
     #[cfg(test)]
@@ -115,6 +122,8 @@ where
                     ClientTlsConfig::new().ca_certificate(client_ca)
                 };
 
+                let connect = &connect;
+
                 async move {
                     let channel = if endpoint.starts_with("unix://") {
                         #[cfg(unix)]
@@ -154,6 +163,9 @@ where
                         })?;
 
                         Channel::builder(uri)
+                            .timeout(Duration::from_secs(config.grpc.timeout_secs))
+                            .concurrency_limit(config.grpc.req_concurrency_limit)
+                            .keep_alive_timeout(Duration::from_secs(config.grpc.tpc_keepalive_secs))
                             .tls_config(tls_config)
                             .wrap_err("Failed to configure TLS")?
                             .connect()
@@ -167,4 +179,26 @@ where
             .collect::<Vec<_>>(),
     )
     .await
+}
+
+pub fn operator_client_builder(
+    config: &BridgeConfig,
+) -> impl Fn(Channel) -> ClementineOperatorClient<Channel> {
+    let max_msg_size = config.grpc.max_message_size;
+    move |channel| {
+        ClementineOperatorClient::new(channel)
+            .max_decoding_message_size(max_msg_size)
+            .max_encoding_message_size(max_msg_size)
+    }
+}
+
+pub fn verifier_client_builder(
+    config: &BridgeConfig,
+) -> impl Fn(Channel) -> ClementineVerifierClient<Channel> {
+    let max_msg_size = config.grpc.max_message_size;
+    move |channel| {
+        ClementineVerifierClient::new(channel)
+            .max_decoding_message_size(max_msg_size)
+            .max_encoding_message_size(max_msg_size)
+    }
 }

--- a/core/src/rpc/mod.rs
+++ b/core/src/rpc/mod.rs
@@ -165,7 +165,7 @@ where
                         Channel::builder(uri)
                             .timeout(Duration::from_secs(config.grpc.timeout_secs))
                             .concurrency_limit(config.grpc.req_concurrency_limit)
-                            .keep_alive_timeout(Duration::from_secs(config.grpc.tpc_keepalive_secs))
+                            .keep_alive_timeout(Duration::from_secs(config.grpc.tcp_keepalive_secs))
                             .tls_config(tls_config)
                             .wrap_err("Failed to configure TLS")?
                             .connect()

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -187,8 +187,6 @@ where
         }
         #[cfg(unix)]
         ServerAddr::Unix(ref socket_path) => {
-            let layer = ServiceBuilder::new()
-
             let server_builder = tonic::transport::Server::builder()
                 .layer(AddMethodMiddlewareLayer)
                 .layer(BufferLayer::new(config.grpc.req_concurrency_limit as usize))

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -16,6 +16,7 @@ use errors::BridgeError;
 use eyre::Context;
 use rustls_pki_types::pem::PemObject;
 use std::thread;
+use std::time::Duration;
 use tokio::sync::oneshot;
 use tonic::server::NamedService;
 use tonic::service::interceptor::InterceptedService;
@@ -152,6 +153,10 @@ where
 
             let server_builder = tonic::transport::Server::builder()
                 .layer(AddMethodMiddlewareLayer)
+                .timeout(Duration::from_secs(config.grpc.timeout_secs))
+                .tcp_keepalive(Some(Duration::from_secs(config.grpc.tpc_keepalive_secs)))
+                .concurrency_limit_per_connection(config.grpc.req_concurrency_limit)
+                .http2_adaptive_window(Some(true))
                 .tls_config(tls_config)
                 .wrap_err("Failed to configure TLS")?
                 .add_service(service);
@@ -176,6 +181,8 @@ where
         ServerAddr::Unix(ref socket_path) => {
             let server_builder = tonic::transport::Server::builder()
                 .layer(AddMethodMiddlewareLayer)
+                .timeout(Duration::from_secs(43200)) // 12 hours
+                .concurrency_limit_per_connection(1000)
                 .add_service(service);
             tracing::info!(
                 "Starting {} gRPC server with Unix socket: {:?}",
@@ -234,7 +241,9 @@ pub async fn create_verifier_grpc_server<C: CitreaClientT>(
         .parse()
         .wrap_err("Failed to parse address")?;
     let verifier = VerifierServer::<C>::new(config.clone()).await?;
-    let svc = ClementineVerifierServer::new(verifier);
+    let svc = ClementineVerifierServer::new(verifier)
+        .max_encoding_message_size(config.grpc.max_message_size)
+        .max_decoding_message_size(config.grpc.max_message_size);
 
     let (server_addr, shutdown_tx) =
         create_grpc_server(addr.into(), svc, "Verifier", &config).await?;
@@ -261,7 +270,9 @@ pub async fn create_operator_grpc_server<C: CitreaClientT>(
     let operator = OperatorServer::<C>::new(config.clone()).await?;
 
     tracing::info!("Creating ClementineOperatorServer");
-    let svc = ClementineOperatorServer::new(operator);
+    let svc = ClementineOperatorServer::new(operator)
+        .max_encoding_message_size(config.grpc.max_message_size)
+        .max_decoding_message_size(config.grpc.max_message_size);
     let (server_addr, shutdown_tx) =
         create_grpc_server(addr.into(), svc, "Operator", &config).await?;
     tracing::info!("Operator gRPC server created");
@@ -279,7 +290,9 @@ pub async fn create_aggregator_grpc_server(
         .parse()
         .wrap_err("Failed to parse address")?;
     let aggregator = Aggregator::new(config.clone()).await?;
-    let svc = ClementineAggregatorServer::new(aggregator);
+    let svc = ClementineAggregatorServer::new(aggregator)
+        .max_encoding_message_size(config.grpc.max_message_size)
+        .max_decoding_message_size(config.grpc.max_message_size);
 
     if config.client_verification {
         tracing::warn!(
@@ -314,7 +327,9 @@ pub async fn create_verifier_unix_server<C: CitreaClientT>(
     .wrap_err("Failed to connect to Bitcoin RPC")?;
 
     let verifier = VerifierServer::<C>::new(config.clone()).await?;
-    let svc = ClementineVerifierServer::new(verifier);
+    let svc = ClementineVerifierServer::new(verifier)
+        .max_encoding_message_size(config.grpc.max_message_size)
+        .max_decoding_message_size(config.grpc.max_message_size);
 
     let (server_addr, shutdown_tx) =
         create_grpc_server(socket_path.into(), svc, "Verifier", &config).await?;
@@ -349,7 +364,9 @@ pub async fn create_operator_unix_server<C: CitreaClientT>(
     .wrap_err("Failed to connect to Bitcoin RPC")?;
 
     let operator = OperatorServer::<C>::new(config.clone()).await?;
-    let svc = ClementineOperatorServer::new(operator);
+    let svc = ClementineOperatorServer::new(operator)
+        .max_encoding_message_size(config.grpc.max_message_size)
+        .max_decoding_message_size(config.grpc.max_message_size);
 
     let (server_addr, shutdown_tx) =
         create_grpc_server(socket_path.into(), svc, "Operator", &config).await?;
@@ -376,7 +393,9 @@ pub async fn create_aggregator_unix_server(
     socket_path: std::path::PathBuf,
 ) -> Result<(std::path::PathBuf, oneshot::Sender<()>), BridgeError> {
     let aggregator = Aggregator::new(config.clone()).await?;
-    let svc = ClementineAggregatorServer::new(aggregator);
+    let svc = ClementineAggregatorServer::new(aggregator)
+        .max_encoding_message_size(config.grpc.max_message_size)
+        .max_decoding_message_size(config.grpc.max_message_size);
 
     let (server_addr, shutdown_tx) =
         create_grpc_server(socket_path.into(), svc, "Aggregator", &config).await?;

--- a/core/src/servers.rs
+++ b/core/src/servers.rs
@@ -162,7 +162,7 @@ where
                     Duration::from_secs(config.grpc.ratelimit_req_interval_secs),
                 ))
                 .timeout(Duration::from_secs(config.grpc.timeout_secs))
-                .tcp_keepalive(Some(Duration::from_secs(config.grpc.tpc_keepalive_secs)))
+                .tcp_keepalive(Some(Duration::from_secs(config.grpc.tcp_keepalive_secs)))
                 .concurrency_limit_per_connection(config.grpc.req_concurrency_limit)
                 .http2_adaptive_window(Some(true))
                 .tls_config(tls_config)
@@ -194,7 +194,7 @@ where
                     config.grpc.ratelimit_req_count as u64,
                     Duration::from_secs(config.grpc.ratelimit_req_interval_secs),
                 ))
-                .timeout(Duration::from_secs(43200)) // 12 hours
+                .timeout(Duration::from_secs(config.grpc.timeout_secs))
                 .concurrency_limit_per_connection(config.grpc.req_concurrency_limit)
                 .add_service(service);
             tracing::info!(

--- a/core/src/test/common/setup_utils.rs
+++ b/core/src/test/common/setup_utils.rs
@@ -438,7 +438,7 @@ pub async fn create_actors<C: CitreaClientT>(
             .iter()
             .map(|path| format!("unix://{}", path.display()))
             .collect::<Vec<_>>(),
-        ClementineVerifierClient::new,
+        crate::rpc::verifier_client_builder(&config),
         &verifier_configs[0],
         false,
     )
@@ -450,7 +450,7 @@ pub async fn create_actors<C: CitreaClientT>(
             .iter()
             .map(|path| format!("unix://{}", path.display()))
             .collect::<Vec<_>>(),
-        ClementineOperatorClient::new,
+        crate::rpc::operator_client_builder(&config),
         &operator_configs[0],
         false,
     )

--- a/core/src/test/data/bridge_config.toml
+++ b/core/src/test/data/bridge_config.toml
@@ -70,3 +70,11 @@ aggregator_cert_path = "certs/aggregator/aggregator.pem"
 client_verification = true
 
 # socket_path = "/"
+
+[grpc]
+max_message_size = 4194304
+timeout_secs = 43200
+tpc_keepalive_secs = 60
+req_concurrency_limit = 300
+ratelimit_req_count = 1000
+ratelimit_req_interval_secs = 60

--- a/core/src/test/data/bridge_config.toml
+++ b/core/src/test/data/bridge_config.toml
@@ -74,7 +74,7 @@ client_verification = true
 [grpc]
 max_message_size = 4194304
 timeout_secs = 43200
-tpc_keepalive_secs = 60
+tcp_keepalive_secs = 60
 req_concurrency_limit = 300
 ratelimit_req_count = 1000
 ratelimit_req_interval_secs = 60

--- a/core/src/test/rpc_auth.rs
+++ b/core/src/test/rpc_auth.rs
@@ -40,7 +40,7 @@ async fn test_mtls_connection() -> Result<(), eyre::Report> {
     let clients =
         crate::rpc::get_clients::<ClementineOperatorClient<tonic::transport::Channel>, _>(
             vec![endpoint],
-            ClementineOperatorClient::new,
+            crate::rpc::operator_client_builder(&config),
             &config,
             true,
         )
@@ -84,7 +84,7 @@ async fn test_auth_interceptor() -> Result<(), eyre::Report> {
 
     let mut clients = get_clients(
         vec![endpoint.clone()],
-        ClementineOperatorClient::new,
+        crate::rpc::operator_client_builder(&config),
         &agg_config,
         true,
     )
@@ -106,7 +106,7 @@ async fn test_auth_interceptor() -> Result<(), eyre::Report> {
 
     let mut clients = get_clients(
         vec![endpoint.clone()],
-        ClementineOperatorClient::new,
+        crate::rpc::operator_client_builder(&config),
         &bad_config,
         true,
     )
@@ -128,7 +128,7 @@ async fn test_auth_interceptor() -> Result<(), eyre::Report> {
 
     let mut clients = get_clients(
         vec![endpoint.clone()],
-        ClementineOperatorClient::new,
+        crate::rpc::operator_client_builder(&config),
         &internal_client_config,
         true,
     )

--- a/scripts/docker/docker_config.toml
+++ b/scripts/docker/docker_config.toml
@@ -80,3 +80,11 @@ security_council = "1:50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace
 winternitz_secret_key = "2222222222222222222222222222222222222222222222222222222222222222"
 
 socket_path = "/"
+
+[grpc]
+max_message_size = 4194304
+timeout_secs = 43200
+tpc_keepalive_secs = 60
+req_concurrency_limit = 300
+ratelimit_req_count = 1000
+ratelimit_req_interval_secs = 60

--- a/scripts/docker/docker_config.toml
+++ b/scripts/docker/docker_config.toml
@@ -84,7 +84,7 @@ socket_path = "/"
 [grpc]
 max_message_size = 4194304
 timeout_secs = 43200
-tpc_keepalive_secs = 60
+tcp_keepalive_secs = 60
 req_concurrency_limit = 300
 ratelimit_req_count = 1000
 ratelimit_req_interval_secs = 60


### PR DESCRIPTION
# Description

- Integrated RateLimitLayer for improved rate limiting based on configuration settings.
- Updated server builder to apply new layers for both TCP and Unix socket configurations.

