### PR TITLE
CMT-34 Remove unused withdrawal_utxos Citrea call.

### DIFF
--- a/core/src/citrea.rs
+++ b/core/src/citrea.rs
@@ -63,17 +63,6 @@ pub trait CitreaClientT: Send + Sync + Debug + Clone + 'static {
         secret_key: Option<PrivateKeySigner>,
     ) -> Result<Self, BridgeError>;
 
-    /// Fetches an UTXO from Citrea for the given withdrawal index.
-    ///
-    /// # Parameters
-    ///
-    /// - `withdrawal_index`: Index of the withdrawal.
-    ///
-    /// # Returns
-    ///
-    /// - [`OutPoint`]: UTXO for the given withdrawal.
-    async fn withdrawal_utxos(&self, withdrawal_index: u64) -> Result<OutPoint, BridgeError>;
-
     /// Returns deposit move txids, starting from the last deposit index.
     ///
     /// # Parameters
@@ -345,23 +334,6 @@ impl CitreaClientT for CitreaClient {
             wallet_address,
             contract,
         })
-    }
-
-    async fn withdrawal_utxos(&self, withdrawal_index: u64) -> Result<OutPoint, BridgeError> {
-        let withdrawal_utxo = self
-            .contract
-            .withdrawalUTXOs(U256::from(withdrawal_index))
-            .call()
-            .await
-            .wrap_err("Failed to get withdrawal UTXO")?;
-
-        let txid = withdrawal_utxo.txId.0;
-        let txid = Txid::from_slice(txid.as_slice())?;
-
-        let vout = withdrawal_utxo.outputId.0;
-        let vout = u32::from_be_bytes(vout);
-
-        Ok(OutPoint { txid, vout })
     }
 
     async fn collect_deposit_move_txids(

--- a/core/src/test/common/citrea/client_mock.rs
+++ b/core/src/test/common/citrea/client_mock.rs
@@ -115,23 +115,6 @@ impl CitreaClientT for MockCitreaClient {
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::DEBUG))]
-    async fn withdrawal_utxos(&self, withdrawal_index: u64) -> Result<OutPoint, BridgeError> {
-        Ok(*self
-            .get_storage()
-            .await
-            .withdrawals
-            .iter()
-            .find_map(|Withdrawal { idx, utxo, .. }| {
-                if *idx == withdrawal_index as u32 {
-                    Some(utxo)
-                } else {
-                    None
-                }
-            })
-            .unwrap())
-    }
-
-    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::DEBUG))]
     async fn collect_deposit_move_txids(
         &self,
         last_deposit_idx: Option<u32>,
@@ -335,12 +318,6 @@ mod tests {
         assert_eq!(utxos.len(), 1);
         assert_eq!(
             utxos[0].1,
-            bitcoin::OutPoint::new(bitcoin::Txid::from_slice(&[2; 32]).unwrap(), 1)
-        );
-
-        let utxo_from_index = client.withdrawal_utxos(1).await.unwrap();
-        assert_eq!(
-            utxo_from_index,
             bitcoin::OutPoint::new(bitcoin::Txid::from_slice(&[2; 32]).unwrap(), 1)
         );
     }


### PR DESCRIPTION
# Description

Removes unused `withdrawal_utxos` Citrea call.