### PR TITLE
Fix CMT-08

### DIFF
--- a/core/src/bitvm_client.rs
+++ b/core/src/bitvm_client.rs
@@ -3,6 +3,7 @@ use crate::builder::address::taproot_builder_with_scripts;
 use crate::builder::script::{SpendableScript, WinternitzCommit};
 
 use crate::config::protocol::ProtocolParamset;
+use crate::constants::MAX_SCRIPT_REPLACEMENT_OPERATIONS;
 use crate::errors::BridgeError;
 use bitcoin::{self};
 use bitcoin::{ScriptBuf, XOnlyPublicKey};
@@ -572,22 +573,44 @@ impl ClementineBitVMPublicKeys {
             .collect::<Vec<_>>()
     }
 
-    pub fn get_g16_verifier_disprove_scripts(&self) -> Vec<ScriptBuf> {
+    pub fn get_g16_verifier_disprove_scripts(&self) -> Result<Vec<ScriptBuf>, BridgeError> {
         if cfg!(debug_assertions) {
-            vec![ScriptBuf::from_bytes(vec![0x51])] // OP_TRUE
+            Ok(vec![ScriptBuf::from_bytes(vec![0x51])]) // OP_TRUE
         } else {
-            replace_disprove_scripts(self)
+            Ok(replace_disprove_scripts(self)?)
         }
     }
 }
 
-pub fn replace_disprove_scripts(pks: &ClementineBitVMPublicKeys) -> Vec<ScriptBuf> {
+pub fn replace_disprove_scripts(
+    pks: &ClementineBitVMPublicKeys,
+) -> Result<Vec<ScriptBuf>, BridgeError> {
     let start = Instant::now();
     tracing::info!("Starting script replacement");
 
     let cache = &*BITVM_CACHE;
-    let mut result: Vec<Vec<u8>> = cache.disprove_scripts.clone();
     let replacement_places = &cache.replacement_places;
+
+    // Calculate estimated operations to prevent DoS attacks
+    let estimated_operations = calculate_replacement_operations(replacement_places);
+    tracing::info!(
+        "Estimated operations for script replacement: {}",
+        estimated_operations
+    );
+    if estimated_operations > MAX_SCRIPT_REPLACEMENT_OPERATIONS {
+        tracing::warn!(
+            "Rejecting script replacement: estimated {} operations exceeds limit of {}",
+            estimated_operations,
+            MAX_SCRIPT_REPLACEMENT_OPERATIONS
+        );
+        return Err(BridgeError::BitvmReplacementResourceExhaustion(
+            estimated_operations,
+        ));
+    }
+
+    tracing::info!("Estimated operations: {}", estimated_operations);
+
+    let mut result: Vec<Vec<u8>> = cache.disprove_scripts.clone();
 
     for (digit, places) in replacement_places.payout_tx_blockhash_pk.iter().enumerate() {
         for (script_idx, pos) in places.iter() {
@@ -643,9 +666,54 @@ pub fn replace_disprove_scripts(pks: &ClementineBitVMPublicKeys) -> Vec<ScriptBu
     let result: Vec<ScriptBuf> = result.into_iter().map(ScriptBuf::from_bytes).collect();
 
     let elapsed = start.elapsed();
-    tracing::info!("Script replacement completed in {:?}", elapsed);
+    tracing::info!(
+        "Script replacement completed in {:?} with {} operations",
+        elapsed,
+        estimated_operations
+    );
 
-    result
+    Ok(result)
+}
+
+/// Helper function to calculate the total number of replacement operations
+fn calculate_replacement_operations(replacement_places: &ClementineBitVMReplacementData) -> usize {
+    let mut total_operations = 0;
+
+    // Count payout_tx_blockhash_pk operations
+    for places in &replacement_places.payout_tx_blockhash_pk {
+        total_operations += places.len();
+    }
+
+    // Count latest_blockhash_pk operations
+    for places in &replacement_places.latest_blockhash_pk {
+        total_operations += places.len();
+    }
+
+    // Count challenge_sending_watchtowers_pk operations
+    for places in &replacement_places.challenge_sending_watchtowers_pk {
+        total_operations += places.len();
+    }
+
+    // Count bitvm_pks operations (this is typically the largest contributor)
+    for digit_places in &replacement_places.bitvm_pks.0 {
+        for places in digit_places {
+            total_operations += places.len();
+        }
+    }
+
+    for digit_places in &replacement_places.bitvm_pks.1 {
+        for places in digit_places {
+            total_operations += places.len();
+        }
+    }
+
+    for digit_places in &replacement_places.bitvm_pks.2 {
+        for places in digit_places {
+            total_operations += places.len();
+        }
+    }
+
+    total_operations
 }
 
 #[cfg(test)]

--- a/core/src/builder/transaction/creator.rs
+++ b/core/src/builder/transaction/creator.rs
@@ -702,7 +702,7 @@ pub async fn create_txhandlers(
         let actor = context.signer.clone().ok_or(TxError::InsufficientContext)?;
         let bitvm_pks =
             actor.generate_bitvm_pks_for_deposit(deposit_data.get_deposit_outpoint(), paramset)?;
-        let disprove_scripts = bitvm_pks.get_g16_verifier_disprove_scripts();
+        let disprove_scripts = bitvm_pks.get_g16_verifier_disprove_scripts()?;
         DisprovePath::Scripts(disprove_scripts)
     } else {
         DisprovePath::HiddenNode(&disprove_root_hash)

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -12,6 +12,25 @@ pub const TEN_MINUTES_IN_SECS: u32 = 600;
 
 pub const DEFAULT_CHANNEL_SIZE: usize = 1280;
 
+/// The maximum number of Winternitz digits per key.
+/// This is used to limit the size of the Winternitz public keys in the protocol
+/// to prevent excessive memory usage and ensure efficient processing.
+/// This value is achieved when signing a 32-byte message with a Winternitz key,
+/// resulting in a maximum of 64 + 4 digits per key, where the last 4 digits are used for
+/// the sum-check operation.
+pub const MAX_WINTERNITZ_DIGITS_PER_KEY: usize = 68;
+
+/// The maximum number of script replacement operations allowed in a single BitVM operation.
+/// This is a safeguard to prevent excessive resource usage and ensure that the BitVM protocol
+/// remains efficient and manageable.
+/// The limit is set to 100,000 operations, which is a reasonable upper bound for
+/// script replacement operations in the context of BitVM, which is normally a constant
+/// equal to 47544.
+pub const MAX_SCRIPT_REPLACEMENT_OPERATIONS: usize = 100_000;
+
+/// The maximum number of bytes per Winternitz key.
+pub const MAX_BYTES_PER_WINTERNITZ_KEY: usize = MAX_WINTERNITZ_DIGITS_PER_KEY * 20;
+
 pub use timeout::*;
 
 mod timeout {

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -133,6 +133,8 @@ pub enum BridgeError {
     OperatorWinternitzPublicKeysMismatch(XOnlyPublicKey),
     #[error("BitVM setup data mismatch. Data already stored in DB doesn't match the new data for operator {0} and deposit {1:?}")]
     BitvmSetupDataMismatch(XOnlyPublicKey, OutPoint),
+    #[error("BitVM replacement data will exhaust memory. The maximum number of operations is {0}")]
+    BitvmReplacementResourceExhaustion(usize),
     #[error("Operator challenge ack hashes mismatch. Data already stored in DB doesn't match the new data for operator {0} and deposit {1:?}")]
     OperatorChallengeAckHashesMismatch(XOnlyPublicKey, OutPoint),
     #[error("Invalid BitVM public keys")]

--- a/core/src/rpc/parser/mod.rs
+++ b/core/src/rpc/parser/mod.rs
@@ -4,6 +4,7 @@ use super::clementine::{
 };
 use super::error;
 use crate::builder::transaction::sign::TransactionRequestData;
+use crate::constants::{MAX_BYTES_PER_WINTERNITZ_KEY, MAX_WINTERNITZ_DIGITS_PER_KEY};
 use crate::deposit::{
     Actors, BaseDepositData, DepositData, DepositInfo, DepositType, ReplacementDepositData,
     SecurityCouncil,
@@ -30,6 +31,8 @@ pub enum ParserError {
     RPCRequiredParam(&'static str),
     #[error("RPC function parameter {0} is malformed")]
     RPCParamMalformed(String),
+    #[error("RPC function parameter {0} is oversized: {1}")]
+    RPCParamOversized(String, usize),
 }
 
 impl From<ParserError> for tonic::Status {
@@ -41,6 +44,10 @@ impl From<ParserError> for tonic::Status {
             ParserError::RPCParamMalformed(field) => {
                 Status::invalid_argument(format!("RPC function parameter {} is malformed.", field))
             }
+            ParserError::RPCParamOversized(field, size) => Status::invalid_argument(format!(
+                "RPC function parameter {} is oversized: {}",
+                field, size
+            )),
         }
     }
 }
@@ -168,6 +175,23 @@ impl TryFrom<WinternitzPubkey> for winternitz::PublicKey {
 
     fn try_from(value: WinternitzPubkey) -> Result<Self, Self::Error> {
         let inner = value.digit_pubkey;
+
+        // Add reasonable size limit per key
+        if inner.len() > MAX_WINTERNITZ_DIGITS_PER_KEY {
+            return Err(BridgeError::Parser(ParserError::RPCParamOversized(
+                "digit_pubkey".to_string(),
+                inner.len(),
+            )));
+        }
+
+        // Add total memory limit check
+        let total_bytes = inner.len() * 20;
+        if total_bytes > MAX_BYTES_PER_WINTERNITZ_KEY {
+            return Err(BridgeError::Parser(ParserError::RPCParamOversized(
+                "digit_pubkey".to_string(),
+                inner.len(),
+            )));
+        }
 
         inner
             .into_iter()

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -1200,7 +1200,7 @@ where
 
         // TODO: Use correct verification key and along with a dummy proof.
         let start = std::time::Instant::now();
-        let scripts: Vec<ScriptBuf> = bitvm_pks.get_g16_verifier_disprove_scripts();
+        let scripts: Vec<ScriptBuf> = bitvm_pks.get_g16_verifier_disprove_scripts()?;
 
         let taproot_builder = taproot_builder_with_scripts(&scripts);
         let root_hash = taproot_builder
@@ -2037,7 +2037,7 @@ where
             deposit_data.get_deposit_outpoint(),
             self.config.protocol_paramset,
         )?;
-        let disprove_scripts = bitvm_pks.get_g16_verifier_disprove_scripts();
+        let disprove_scripts = bitvm_pks.get_g16_verifier_disprove_scripts()?;
 
         let deposit_outpoint = deposit_data.get_deposit_outpoint();
         let paramset = self.config.protocol_paramset();


### PR DESCRIPTION
Fixes CMT-08:

- Adds necessary size checks for both RPC calls and replace_disprove_scripts to prevent resource exhaustion
