### PR TITLE
Fix CMT-20 and CMT-21

### DIFF
--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -161,8 +161,13 @@ impl AggregateFromPublicKeys for XOnlyPublicKey {
 }
 
 // Aggregates the public nonces into a single aggregated nonce.
-pub fn aggregate_nonces(pub_nonces: &[&PublicNonce]) -> AggregatedNonce {
-    AggregatedNonce::new(SECP256K1, pub_nonces)
+pub fn aggregate_nonces(pub_nonces: &[&PublicNonce]) -> Result<AggregatedNonce, BridgeError> {
+    if pub_nonces.is_empty() {
+        return Err(BridgeError::from(eyre::eyre!(
+            "MuSig2 Error: cannot aggregate nonces (no public nonces provided)"
+        )));
+    }
+    Ok(AggregatedNonce::new(SECP256K1, pub_nonces))
 }
 
 // Aggregates the partial signatures into a single aggregated signature.
@@ -304,7 +309,8 @@ mod tests {
                 .map(|(_, musig_pub_nonce)| musig_pub_nonce)
                 .collect::<Vec<_>>()
                 .as_slice(),
-        );
+        )
+        .unwrap();
 
         let partial_sigs = key_pairs
             .into_iter()
@@ -352,7 +358,8 @@ mod tests {
         let (sec_nonce_2, pub_nonce_2) =
             super::nonce_pair(&kp_2, &mut secp256k1::rand::thread_rng()).unwrap();
 
-        let agg_nonce = super::aggregate_nonces(&[&pub_nonce_0, &pub_nonce_1, &pub_nonce_2]);
+        let agg_nonce =
+            super::aggregate_nonces(&[&pub_nonce_0, &pub_nonce_1, &pub_nonce_2]).unwrap();
 
         let partial_sig_0 =
             super::partial_sign(pks.clone(), None, sec_nonce_0, agg_nonce, kp_0, message).unwrap();
@@ -402,7 +409,8 @@ mod tests {
                 .map(|(_, musig_pub_nonce)| musig_pub_nonce)
                 .collect::<Vec<_>>()
                 .as_slice(),
-        );
+        )
+        .unwrap();
 
         let partial_sigs = key_pairs
             .into_iter()
@@ -456,7 +464,8 @@ mod tests {
         let (sec_nonce_2, pub_nonce_2) =
             super::nonce_pair(&kp_2, &mut secp256k1::rand::thread_rng()).unwrap();
 
-        let agg_nonce = super::aggregate_nonces(&[&pub_nonce_0, &pub_nonce_1, &pub_nonce_2]);
+        let agg_nonce =
+            super::aggregate_nonces(&[&pub_nonce_0, &pub_nonce_1, &pub_nonce_2]).unwrap();
 
         let partial_sig_0 = super::partial_sign(
             pks.clone(),
@@ -515,7 +524,8 @@ mod tests {
                 .map(|(_, musig_pub_nonce)| musig_pub_nonce)
                 .collect::<Vec<_>>()
                 .as_slice(),
-        );
+        )
+        .unwrap();
 
         let dummy_script = script::Builder::new().push_int(1).into_script();
         let scripts: Vec<Arc<dyn SpendableScript>> =
@@ -621,7 +631,8 @@ mod tests {
                 .map(|x| &x.1)
                 .collect::<Vec<_>>()
                 .as_slice(),
-        );
+        )
+        .unwrap();
         let musig_agg_xonly_pubkey_wrapped =
             XOnlyPublicKey::from_musig2_pks(public_keys.clone(), None).unwrap();
 
@@ -760,7 +771,7 @@ mod tests {
             nonce_pair(&kp1, &mut secp256k1::rand::thread_rng()).unwrap();
         let (sec_nonce2, pub_nonce2) =
             nonce_pair(&kp2, &mut secp256k1::rand::thread_rng()).unwrap();
-        let agg_nonce = aggregate_nonces(&[&pub_nonce1, &pub_nonce2]);
+        let agg_nonce = aggregate_nonces(&[&pub_nonce1, &pub_nonce2]).unwrap();
 
         let partial_sig1 = partial_sign(
             public_keys.clone(),

--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -85,6 +85,11 @@ fn create_key_agg_cache(
     mut public_keys: Vec<PublicKey>,
     mode: Option<Musig2Mode>,
 ) -> Result<KeyAggCache, BridgeError> {
+    if public_keys.is_empty() {
+        return Err(BridgeError::from(eyre::eyre!(
+            "MuSig2 Error: cannot create key aggregation cache (no public keys provided)"
+        )));
+    }
     public_keys.sort();
     let secp_pubkeys: Vec<secp256k1::PublicKey> =
         public_keys.iter().map(|pk| to_secp_pk(*pk)).collect();

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -137,7 +137,7 @@ async fn nonce_aggregator(
         );
 
         // TODO: consider spawn_blocking here
-        let agg_nonce = aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice());
+        let agg_nonce = aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice())?;
 
         agg_nonce_sender
             .send(AggNonceQueueItem { agg_nonce, sighash })
@@ -174,7 +174,7 @@ async fn nonce_aggregator(
     tracing::trace!("Received nonces for movetx in nonce_aggregator");
 
     // TODO: consider spawn_blocking here
-    let move_tx_agg_nonce = aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice());
+    let move_tx_agg_nonce = aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice())?;
 
     let pub_nonces = try_join_all(nonce_streams.iter_mut().map(|s| async {
         s.next()
@@ -192,7 +192,7 @@ async fn nonce_aggregator(
     .wrap_err("Failed to aggregate nonces for the emergency stop tx")?;
 
     let emergency_stop_agg_nonce =
-        aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice());
+        aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice())?;
 
     Ok((move_tx_agg_nonce, emergency_stop_agg_nonce))
 }
@@ -903,7 +903,7 @@ impl ClementineAggregator for Aggregator {
                 .await
                 .wrap_err("Failed to aggregate nonces for optimistic payout")
                 .map_to_status()?;
-            let agg_nonce = aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice());
+            let agg_nonce = aggregate_nonces(pub_nonces.iter().collect::<Vec<_>>().as_slice())?;
             // send the agg nonce to the verifiers to sign the optimistic payout tx
             let verifier_clients = self.get_verifier_clients();
             let payout_sigs = verifier_clients

--- a/core/src/test/musig2.rs
+++ b/core/src/test/musig2.rs
@@ -63,7 +63,7 @@ fn get_nonces(
             .map(|(_, musig_pub_nonces)| musig_pub_nonces)
             .collect::<Vec<_>>()
             .as_slice(),
-    );
+    )?;
 
     Ok((nonce_pairs, agg_nonce))
 }


### PR DESCRIPTION
# Description
Fixes CMT-20 with [8b02122](https://github.com/chainwayxyz/clementine/commit/8b0212281aec24261f0940fe82e4eb2a22b32fd3):

- Adds an empty vector check.

Fixes CMT-21 with [a6e1adb](https://github.com/chainwayxyz/clementine/commit/a6e1adb4eda850182a2a72d0c069dbc2f062964b):

- Adds an empty slice check.
