### PR TITLE
Batch gRPC messages over the wire

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,7 +17,7 @@ env:
   RUST_LOG: warn,risc0_zkvm=error,risc0_circuit_rv32im=error
   RISC0_DEV_MODE: 1
   RUST_MIN_STACK: 33554432
-
+  GRPC_BATCH_SIZE: 128
   CARGOFLAGS: --workspace --all-targets
   CARGOFLAGS_ALL_FEATURES: --workspace --all-targets --all-features
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -17,6 +17,7 @@ env:
   RUST_LOG: warn,risc0_zkvm=error,risc0_circuit_rv32im=error
   RISC0_DEV_MODE: 1
   RUST_MIN_STACK: 33554432
+  GRPC_BATCH_SIZE: 128
 
 jobs:
   formatting:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ env:
   RUST_LOG: warn,risc0_zkvm=error,risc0_circuit_rv32im=error
   RISC0_DEV_MODE: 1
   RUST_MIN_STACK: 33554432
-
+  GRPC_BATCH_SIZE: 128
   CARGOFLAGS: --workspace --all-targets
   CARGOFLAGS_ALL_FEATURES: --workspace --all-targets --all-features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,7 +4419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -7899,8 +7899,6 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "tonic"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7899,6 +7899,8 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "tonic"
 version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 
 # async + gRPC
 # revert
-tonic = { path = "../tonic/tonic", features = ["tls"] }
-# tonic = { version = "0.12.3", features = ["tls"] }
+# tonic = { path = "../tonic/tonic", features = ["tls"] }
+tonic = { version = "0.12.3", features = ["tls"] }
 prost = "0.13.3"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-stream = { version = "0.1.16", features = ["sync"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 
 # async + gRPC
 # revert
-# tonic = { path = "../tonic/tonic", features = ["tls"] }
-tonic = { version = "0.12.3", features = ["tls"] }
+tonic = { path = "../tonic/tonic", features = ["tls"] }
+# tonic = { version = "0.12.3", features = ["tls"] }
 prost = "0.13.3"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-stream = { version = "0.1.16", features = ["sync"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,6 @@ secp256k1 = { version = "0.31.0", features = [
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 
 # async + gRPC
-# revert
-# tonic = { path = "../tonic/tonic", features = ["tls"] }
 tonic = { version = "0.12.3", features = ["tls"] }
 prost = "0.13.3"
 tokio = { version = "1.40.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,9 @@ secp256k1 = { version = "0.31.0", features = [
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 
 # async + gRPC
-tonic = { version = "0.12.3", features = ["tls"] }
+# revert
+tonic = { path = "../tonic/tonic", features = ["tls"] }
+# tonic = { version = "0.12.3", features = ["tls"] }
 prost = "0.13.3"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-stream = { version = "0.1.16", features = ["sync"] }

--- a/core/build.rs
+++ b/core/build.rs
@@ -52,6 +52,7 @@ fn compile_protobuf() {
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
+        .codec_path("crate::utils::BatchingCodec")
         .out_dir("./src/rpc")
         .compile_protos(
             &proto_files,

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -51,11 +51,9 @@ use futures::{
     FutureExt, Stream, StreamExt, TryFutureExt,
 };
 use secp256k1::musig::{AggregatedNonce, PartialSignature, PublicNonce};
-use std::collections::VecDeque;
 use std::future::Future;
 use tokio::join;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
-use tokio::sync::Mutex;
 use tonic::{async_trait, Request, Response, Status, Streaming};
 
 #[derive(Debug, Clone)]

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -44,7 +44,6 @@ use bitcoin::secp256k1::schnorr::Signature;
 use bitcoin::secp256k1::{Message, PublicKey};
 use bitcoin::{TapSighash, TxOut, Txid, XOnlyPublicKey};
 use eyre::{Context, OptionExt};
-use futures::SinkExt;
 use futures::{
     future::try_join_all,
     stream::{BoxStream, TryStreamExt},

--- a/core/src/rpc/clementine.rs
+++ b/core/src/rpc/clementine.rs
@@ -1005,7 +1005,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/GetXOnlyPublicKey",
             );
@@ -1040,7 +1040,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/GetParams",
             );
@@ -1065,7 +1065,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/GetDepositKeys",
             );
@@ -1089,7 +1089,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/GetCurrentStatus",
             );
@@ -1125,7 +1125,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/DepositSign",
             );
@@ -1147,7 +1147,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/RestartBackgroundTasks",
             );
@@ -1176,7 +1176,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/Withdraw",
             );
@@ -1213,7 +1213,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/InternalCreateSignedTxs",
             );
@@ -1251,7 +1251,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/InternalCreateAssertCommitmentTxs",
             );
@@ -1277,7 +1277,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/InternalFinalizedPayout",
             );
@@ -1303,7 +1303,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/InternalEndRound",
             );
@@ -1326,7 +1326,7 @@ pub mod clementine_operator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineOperator/Vergen",
             );
@@ -1443,7 +1443,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/GetParams",
             );
@@ -1467,7 +1467,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/SetOperator",
             );
@@ -1492,7 +1492,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/SetOperatorKeys",
             );
@@ -1525,7 +1525,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/NonceGen",
             );
@@ -1555,7 +1555,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/DepositSign",
             );
@@ -1577,7 +1577,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/OptimisticPayoutSign",
             );
@@ -1611,7 +1611,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/DepositFinalize",
             );
@@ -1635,7 +1635,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/DebugTx",
             );
@@ -1657,7 +1657,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/RestartBackgroundTasks",
             );
@@ -1684,7 +1684,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/InternalHandleKickoff",
             );
@@ -1711,7 +1711,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/GetCurrentStatus",
             );
@@ -1748,7 +1748,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/InternalCreateSignedTxs",
             );
@@ -1779,7 +1779,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/InternalCreateWatchtowerChallenge",
             );
@@ -1805,7 +1805,7 @@ pub mod clementine_verifier_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineVerifier/Vergen",
             );
@@ -1919,7 +1919,7 @@ pub mod clementine_aggregator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineAggregator/GetNofnAggregatedXonlyPk",
             );
@@ -1956,7 +1956,7 @@ pub mod clementine_aggregator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineAggregator/Setup",
             );
@@ -1985,7 +1985,7 @@ pub mod clementine_aggregator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineAggregator/NewDeposit",
             );
@@ -2013,7 +2013,7 @@ pub mod clementine_aggregator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineAggregator/Withdraw",
             );
@@ -2035,7 +2035,7 @@ pub mod clementine_aggregator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineAggregator/OptimisticPayout",
             );
@@ -2062,7 +2062,7 @@ pub mod clementine_aggregator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineAggregator/InternalSendTx",
             );
@@ -2085,7 +2085,7 @@ pub mod clementine_aggregator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineAggregator/SendMoveToVaultTx",
             );
@@ -2113,7 +2113,7 @@ pub mod clementine_aggregator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineAggregator/GetEntityStatuses",
             );
@@ -2145,7 +2145,7 @@ pub mod clementine_aggregator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineAggregator/InternalCreateEmergencyStopTx",
             );
@@ -2171,7 +2171,7 @@ pub mod clementine_aggregator_client {
                         format!("Service was not ready: {}", e.into()),
                     )
                 })?;
-            let codec = tonic::codec::ProstCodec::default();
+            let codec = crate::utils::BatchingCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/clementine.ClementineAggregator/Vergen",
             );
@@ -2433,7 +2433,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetXOnlyPublicKeySvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -2479,7 +2479,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetParamsSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -2525,7 +2525,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetDepositKeysSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -2572,7 +2572,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetCurrentStatusSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -2619,7 +2619,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = DepositSignSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -2666,7 +2666,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = RestartBackgroundTasksSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -2711,7 +2711,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = WithdrawSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -2760,7 +2760,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = InternalCreateSignedTxsSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -2811,7 +2811,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = InternalCreateAssertCommitmentTxsSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -2860,7 +2860,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = InternalFinalizedPayoutSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -2907,7 +2907,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = InternalEndRoundSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -2950,7 +2950,7 @@ pub mod clementine_operator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = VergenSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3245,7 +3245,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetParamsSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3293,7 +3293,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = SetOperatorSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3342,7 +3342,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = SetOperatorKeysSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3388,7 +3388,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = NonceGenSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3437,7 +3437,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = DepositSignSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3486,7 +3486,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = OptimisticPayoutSignSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3535,7 +3535,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = DepositFinalizeSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3580,7 +3580,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = DebugTxSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3627,7 +3627,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = RestartBackgroundTasksSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3674,7 +3674,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = InternalHandleKickoffSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3721,7 +3721,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetCurrentStatusSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3770,7 +3770,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = InternalCreateSignedTxsSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3821,7 +3821,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = InternalCreateWatchtowerChallengeSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -3864,7 +3864,7 @@ pub mod clementine_verifier_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = VergenSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -4118,7 +4118,7 @@ pub mod clementine_aggregator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetNofnAggregatedXonlyPkSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -4162,7 +4162,7 @@ pub mod clementine_aggregator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = SetupSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -4207,7 +4207,7 @@ pub mod clementine_aggregator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = NewDepositSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -4252,7 +4252,7 @@ pub mod clementine_aggregator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = WithdrawSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -4301,7 +4301,7 @@ pub mod clementine_aggregator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = OptimisticPayoutSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -4350,7 +4350,7 @@ pub mod clementine_aggregator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = InternalSendTxSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -4399,7 +4399,7 @@ pub mod clementine_aggregator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = SendMoveToVaultTxSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -4448,7 +4448,7 @@ pub mod clementine_aggregator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetEntityStatusesSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -4499,7 +4499,7 @@ pub mod clementine_aggregator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = InternalCreateEmergencyStopTxSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,
@@ -4543,7 +4543,7 @@ pub mod clementine_aggregator_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = VergenSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
+                        let codec = crate::utils::BatchingCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
                                 accept_compression_encodings,

--- a/core/src/rpc/operator.rs
+++ b/core/src/rpc/operator.rs
@@ -12,7 +12,7 @@ use crate::constants::DEFAULT_CHANNEL_SIZE;
 use crate::deposit::DepositData;
 use crate::operator::OperatorServer;
 use crate::rpc::parser;
-use crate::utils::get_vergen_response;
+use crate::utils::{batched_stream_from_rx, get_vergen_response, BatchedStream};
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, OutPoint};
 use bitvm::chunk::api::{NUM_HASH, NUM_PUBS, NUM_U256};
@@ -26,7 +26,7 @@ impl<C> ClementineOperator for OperatorServer<C>
 where
     C: CitreaClientT,
 {
-    type DepositSignStream = ReceiverStream<Result<SchnorrSig, Status>>;
+    type DepositSignStream = BatchedStream<Result<SchnorrSig, Status>>;
     type GetParamsStream = ReceiverStream<Result<OperatorParams, Status>>;
 
     async fn vergen(&self, _request: Request<Empty>) -> Result<Response<VergenResponse>, Status> {
@@ -131,7 +131,7 @@ where
             }
         });
 
-        Ok(Response::new(ReceiverStream::new(rx)))
+        Ok(Response::new(batched_stream_from_rx(rx)))
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -22,7 +22,7 @@ use crate::{
 use bitcoin::Witness;
 use clementine::verifier_deposit_finalize_params::Params;
 use secp256k1::musig::AggregatedNonce;
-use tokio::sync::mpsc::{self, error::SendError};
+use tokio::sync::mpsc::{self};
 use tonic::{async_trait, Request, Response, Status, Streaming};
 
 #[async_trait]

--- a/core/src/rpc/verifier.rs
+++ b/core/src/rpc/verifier.rs
@@ -38,7 +38,7 @@ type BatchedStream<T> = FlatMap<
 
 fn batched_stream_from_rx<T>(rx: mpsc::Receiver<T>) -> BatchedStream<T> {
     ReceiverStream::new(rx)
-        .chunks_timeout(64, Duration::from_secs(1))
+        .chunks_timeout(64, Duration::from_millis(1))
         .flat_map(stream::iter)
 }
 

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -764,7 +764,7 @@ fn iter_with_log<T>(iter: Vec<T>) -> stream::Iter<std::vec::IntoIter<T>> {
 // }
 
 pub fn batched_stream_from_rx<T>(rx: mpsc::Receiver<T>) -> BatchedStream<T> {
-    rx.into()
+    ReceiverStream::new(rx)
         .chunks_timeout(128, Duration::from_millis(2))
         .flat_map(iter_with_log)
 }


### PR DESCRIPTION
# Description

This PR uses Tonic's native batching capabilities by wrapping our receiver streams with batching transformations and increasing the max yield threshold to 4MB (which is the HTTP frame size that triggers a send in Tonic). Batching can be observed by filtering the log `RUST_LOG=clementine_core::utils=debug` and/or by adding log statements to `tonic::codec` where a Frame is flushed to see #messages or #bytes (cf. [this fork](https://github.com/mmtftr/tonic/tree/efe/logs) for an example).

Current batch size is set to 128. Tonic will split the batch further if it exceeds 4MB.

A batch is flushed if there is no new message for 2 milliseconds. This is done to avoid getting stuck when waiting for first parameters or an half-empty batch when the receiver stream hasn't closed but is stuck for some other reason.

Part of the nonce distribution/partial sig collection stack has been refactored to enable parallel processing and batching.

## Docs

None, this is an experimental change at the moment.
