### PR TITLE
Change metrics db query

### DIFF
--- a/core/src/database/bitcoin_syncer.rs
+++ b/core/src/database/bitcoin_syncer.rs
@@ -323,47 +323,32 @@ impl Database {
         Ok(())
     }
 
-    /// Gets the block id belonging to the event from the database, given the event id
-    /// event id is the serial key of the bitcoin_syncer_events table
-    pub async fn get_block_id_from_event_id(
-        &self,
-        tx: DatabaseTransaction<'_, '_>,
-        event_id: i32,
-    ) -> Result<Option<u32>, BridgeError> {
-        let event =
-            sqlx::query_as::<_, (i32,)>("SELECT block_id FROM bitcoin_syncer_events WHERE id = $1")
-                .bind(event_id)
-                .fetch_optional(tx.deref_mut())
-                .await?;
-
-        match event {
-            Some((block_id,)) => Ok(Some(
-                u32::try_from(block_id).wrap_err(BridgeError::IntConversionError)?,
-            )),
-            None => Ok(None),
-        }
-    }
-
-    /// Returns the last processed Bitcoin Syncer event's block height.
-    /// If the last processed event is missing, returns `None`.
+    /// Returns the last processed Bitcoin Syncer event's block height for given consumer.
+    /// If the last processed event is missing, i.e. there are no processed events for the consumer, returns `None`.
     pub async fn get_last_processed_event_block_height(
         &self,
-        tx: DatabaseTransaction<'_, '_>,
+        tx: Option<DatabaseTransaction<'_, '_>>,
         consumer_handle: &str,
     ) -> Result<Option<u32>, BridgeError> {
-        let event_id = self
-            .get_last_processed_event_id(tx, consumer_handle)
-            .await?;
-        let block_id = self.get_block_id_from_event_id(tx, event_id).await?;
-        let block_id = match block_id {
-            Some(block_id) => block_id,
-            None => return Ok(None),
-        };
-        let block_info = self.get_block_info_from_id(Some(tx), block_id).await?;
-        match block_info {
-            Some((_, height)) => Ok(Some(height)),
-            None => Ok(None),
-        }
+        let query = sqlx::query_scalar::<_, i32>(
+            r#"SELECT bs.height
+             FROM bitcoin_syncer_event_handlers bseh
+             INNER JOIN bitcoin_syncer_events bse ON bseh.last_processed_event_id = bse.id
+             INNER JOIN bitcoin_syncer bs ON bse.block_id = bs.id
+             WHERE bseh.consumer_handle = $1"#,
+        )
+        .bind(consumer_handle);
+
+        let result: Option<i32> =
+            execute_query_with_tx!(self.connection, tx, query, fetch_optional)?;
+
+        result
+            .map(|h| {
+                u32::try_from(h)
+                    .wrap_err(BridgeError::IntConversionError)
+                    .map_err(BridgeError::from)
+            })
+            .transpose()
     }
 
     /// Gets the last processed event id for a given consumer

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -119,12 +119,8 @@ pub async fn get_btc_syncer_consumer_last_processed_block_height(
     db: &Database,
     consumer_handle: &str,
 ) -> Result<Option<u32>, BridgeError> {
-    let mut dbtx = db.begin_transaction().await?;
-    let height = db
-        .get_last_processed_event_block_height(&mut dbtx, consumer_handle)
-        .await?;
-    dbtx.commit().await?;
-    Ok(height)
+    db.get_last_processed_event_block_height(None, consumer_handle)
+        .await
 }
 
 /// Get the last processed block height of the Bitcoin Syncer or None if no


### PR DESCRIPTION
Changes metrics db query for getting last event height of btc syncer consumer.

I think the previous query might be the cause of timeouts, because it included INSERT INTO (in fn get_last_processed_event_id), which might cause the query to attempt to get locks on the bitcoin_syncer_event_handlers row. And txsender, finalizedblocktask etc also attempt to get locks on their own row on that table time everytime they poll. 
Also new query is only one query instead of multiple queries like before.