### PR TITLE
Create pgmq queue to make sure it exists before sending a message

### DIFF
--- a/core/src/states/event.rs
+++ b/core/src/states/event.rs
@@ -49,6 +49,8 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
     ) -> Result<(), eyre::Report> {
         let queue_name = StateManager::<T>::queue_name();
         let queue = PGMQueueExt::new_with_pool(db.get_pool()).await;
+        // create the queue if it doesn't exist, doesn't return error if it already exists
+        queue.create(&queue_name).await?;
         let message = SystemEvent::NewOperator { operator_data };
         queue
             .send_with_cxn(&queue_name, &message, &mut *(*tx))
@@ -68,6 +70,9 @@ impl<T: Owner + std::fmt::Debug + 'static> StateManager<T> {
     ) -> Result<(), eyre::Report> {
         let queue_name = StateManager::<T>::queue_name();
         let queue = PGMQueueExt::new_with_pool(db.get_pool()).await;
+        // create the queue if it doesn't exist, doesn't return error if it already exists
+        queue.create(&queue_name).await?;
+
         let message = SystemEvent::NewKickoff {
             kickoff_data,
             kickoff_height,

--- a/core/src/states/task.rs
+++ b/core/src/states/task.rs
@@ -71,6 +71,11 @@ impl<T: Owner + std::fmt::Debug + 'static> BlockFetcherTask<T> {
     ) -> Result<FinalizedBlockFetcherTask<QueueBlockHandler>, BridgeError> {
         let queue = PGMQueueExt::new_with_pool(db.get_pool()).await;
         let queue_name = StateManager::<T>::queue_name();
+        // create the queue if it doesn't exist, doesn't return error if it already exists
+        queue
+            .create(&queue_name)
+            .await
+            .wrap_err_with(|| format!("Error creating pqmq queue with name {}", queue_name))?;
 
         tracing::info!(
             "Creating block fetcher task for owner type {} starting from height {}",


### PR DESCRIPTION
My previous pr can cause errors if the queue is not created yet. To avoid future problems I added queue.create to all places where pgmq queue is used.