### PR TITLE
Security mod for withdrawals

### DIFF
--- a/core/src/bin/cli.rs
+++ b/core/src/bin/cli.rs
@@ -526,7 +526,7 @@ async fn handle_operator_call(url: String, command: OperatorCommands) {
                 output_amount,
             };
             operator
-                .withdraw(Request::new(params))
+                .internal_withdraw(Request::new(params))
                 .await
                 .expect("Failed to make a request to operator");
         }

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -71,6 +71,8 @@ mod timeout {
     pub const ENTITY_STATUS_POLL_TIMEOUT: Duration = Duration::from_secs(120);
 
     pub const PUBLIC_KEY_COLLECTION_TIMEOUT: Duration = Duration::from_secs(30);
+
+    pub const WITHDRAWAL_TIMEOUT: Duration = Duration::from_secs(120); // 2 minutes
 }
 
 pub const NON_STANDARD_V3: Version = Version(3);

--- a/core/src/rpc/clementine.proto
+++ b/core/src/rpc/clementine.proto
@@ -359,7 +359,14 @@ service ClementineOperator {
   // Prepares a withdrawal if it's profitable and the withdrawal is correct and registered in Citrea bridge contract/
   // If withdrawal is accepted, the payout tx will be added to the TxSender and success is returned, otherwise an error is returned.
   // If automation is disabled, the withdrawal will not be accepted and an error will be returned.
-  rpc Withdraw(WithdrawParams)
+  // Note: This is intended for operator's own use, so it doesn't include a signature from aggregator.
+  rpc InternalWithdraw(WithdrawParams)
+    returns (RawSignedTx) {}
+
+  // Prepares a withdrawal if it's profitable and the withdrawal is correct and registered in Citrea bridge contract/
+  // If withdrawal is accepted, the payout tx will be added to the TxSender and success is returned, otherwise an error is returned.
+  // If automation is disabled, the withdrawal will not be accepted and an error will be returned.
+  rpc Withdraw(WithdrawParamsWithSig)
     returns (RawSignedTx) {}
 
   // For a given deposit outpoint, determines the next step in the kickoff process the operator is in,
@@ -439,6 +446,16 @@ message OptimisticWithdrawParams {
   // An ECDSA signature (of citrea/aggregator) over the withdrawal params
   // to authenticate the withdrawal params. This will be signed manually by citrea 
   // after manual verification of the optimistic payout.
+  optional string verification_signature = 2;
+}
+
+message WithdrawParamsWithSig {
+  WithdrawParams withdrawal = 1;
+  // An ECDSA signature (of citrea/aggregator) over the withdrawal params
+  // to authenticate the withdrawal params. This will be signed manually by citrea 
+  // after manual verification of the optimistic payout.
+  // This message contains same data as the one in Optimistic Payout signature, but with a different message name,
+  // so that the same signature can't be used for both optimistic payout and normal withdrawal.
   optional string verification_signature = 2;
 }
 

--- a/core/src/rpc/clementine.proto
+++ b/core/src/rpc/clementine.proto
@@ -12,10 +12,6 @@ message Outpoint {
   uint32 vout = 2;
 }
 
-message XonlyPublicKey {
-  bytes xonly_pk = 1;
-}
-
 message NofnResponse {
   bytes nofn_xonly_pk = 1;
   uint32 num_verifiers = 2;
@@ -459,6 +455,14 @@ message WithdrawParamsWithSig {
   optional string verification_signature = 2;
 }
 
+// Input of the aggregator's withdraw function.
+// It contains the withdrawal params along with the verification signature that signs the withdrawal params.
+// It also contains the operator's xonly public keys that the withdrawal request should be sent to.
+message AggregatorWithdrawalInput {
+  WithdrawParamsWithSig withdrawal = 1;
+  repeated XOnlyPublicKeyRpc operator_xonly_pks = 2;
+}
+
 message OptimisticPayoutParams {
   OptimisticWithdrawParams opt_withdrawal = 1;
   NonceGenFirstResponse nonce_gen = 2;
@@ -510,7 +514,7 @@ message TxMetadata {
   // Optional outpoint of the deposit transaction
   Outpoint deposit_outpoint = 1;
   // Deposit identification
-  XonlyPublicKey operator_xonly_pk = 2;
+  XOnlyPublicKeyRpc operator_xonly_pk = 2;
   uint32 round_idx = 4;
   uint32 kickoff_idx = 5;
   // Transaction ID
@@ -692,7 +696,9 @@ service ClementineAggregator {
 
   // Call's withdraw on all operators
   // Used by the clementine-backend service to initiate a withdrawal
-  rpc Withdraw(WithdrawParams)
+  // If the operator's xonly public keys list is empty, the withdrawal will be sent to all operators.
+  // If not, only the operators in the list will be sent the withdrawal request.
+  rpc Withdraw(AggregatorWithdrawalInput)
     returns (AggregatorWithdrawResponse) {}
 
   // Perform an optimistic payout to reimburse a peg-out from Citrea

--- a/core/src/rpc/ecdsa_verification_sig.rs
+++ b/core/src/rpc/ecdsa_verification_sig.rs
@@ -1,3 +1,13 @@
+//! # ECDSA Verification Signature
+//!
+//! This module contains the ECDSA verification signature for the Clementine protocol.
+//! It is for additional verification that the request for optimistic payout and withdrawal is coming from the aggregator, which
+//! is the owner of the address in operator/verifiers config.
+//!
+//! The address who signed the signature is retrieved by calculating the EIP-712 hash of the withdrawal params.
+//! The address is then compared to the address in the config.
+//!
+
 use alloy::primitives::PrimitiveSignature;
 use alloy::sol_types::Eip712Domain;
 use bitcoin::hashes::Hash;

--- a/core/src/rpc/ecdsa_verification_sig.rs
+++ b/core/src/rpc/ecdsa_verification_sig.rs
@@ -1,0 +1,133 @@
+use alloy::primitives::PrimitiveSignature;
+use alloy::sol_types::Eip712Domain;
+use bitcoin::hashes::Hash;
+use bitcoin::secp256k1::schnorr::Signature;
+use bitcoin::OutPoint;
+use bitcoin::{Amount, ScriptBuf};
+use eyre::{Context, Result};
+
+use crate::errors::BridgeError;
+
+alloy_sol_types::sol! {
+    #[derive(Debug)]
+    struct ClementineOptimisticPayoutMessage {
+            uint32 withdrawal_id;
+            bytes input_signature;
+            bytes32 input_outpoint_txid;
+            uint32 input_outpoint_vout;
+            bytes output_script_pubkey;
+            uint64 output_amount;
+    }
+
+    #[derive(Debug)]
+    struct ClementineWithdrawalMessage  {
+            uint32 withdrawal_id;
+            bytes input_signature;
+            bytes32 input_outpoint_txid;
+            uint32 input_outpoint_vout;
+            bytes output_script_pubkey;
+            uint64 output_amount;
+    }
+}
+
+pub static OPT_PAYOUT_DOMAIN: Eip712Domain = alloy_sol_types::eip712_domain! {
+    name: "ClementineOptimisticPayoutMessage",
+    version: "1",
+};
+
+pub static WITHDRAWAL_DOMAIN: Eip712Domain = alloy_sol_types::eip712_domain! {
+    name: "ClementineWithdrawalMessage",
+    version: "1",
+};
+
+pub trait WithdrawalMessage {
+    const DOMAIN: &Eip712Domain;
+
+    fn new(
+        deposit_id: u32,
+        input_signature: Signature,
+        input_outpoint: OutPoint,
+        output_script_pubkey: ScriptBuf,
+        output_amount: Amount,
+    ) -> Self;
+}
+
+impl WithdrawalMessage for ClementineOptimisticPayoutMessage {
+    const DOMAIN: &Eip712Domain = &OPT_PAYOUT_DOMAIN;
+
+    fn new(
+        deposit_id: u32,
+        input_signature: Signature,
+        input_outpoint: OutPoint,
+        output_script_pubkey: ScriptBuf,
+        output_amount: Amount,
+    ) -> Self {
+        ClementineOptimisticPayoutMessage {
+            withdrawal_id: deposit_id,
+            input_signature: input_signature.serialize().to_vec().into(),
+            input_outpoint_txid: input_outpoint.txid.to_byte_array().into(),
+            input_outpoint_vout: input_outpoint.vout,
+            output_script_pubkey: output_script_pubkey.as_bytes().to_vec().into(),
+            output_amount: output_amount.to_sat(),
+        }
+    }
+}
+
+impl WithdrawalMessage for ClementineWithdrawalMessage {
+    const DOMAIN: &Eip712Domain = &WITHDRAWAL_DOMAIN;
+
+    fn new(
+        deposit_id: u32,
+        input_signature: Signature,
+        input_outpoint: OutPoint,
+        output_script_pubkey: ScriptBuf,
+        output_amount: Amount,
+    ) -> Self {
+        ClementineWithdrawalMessage {
+            withdrawal_id: deposit_id,
+            input_signature: input_signature.serialize().to_vec().into(),
+            input_outpoint_txid: input_outpoint.txid.to_byte_array().into(),
+            input_outpoint_vout: input_outpoint.vout,
+            output_script_pubkey: output_script_pubkey.as_bytes().to_vec().into(),
+            output_amount: output_amount.to_sat(),
+        }
+    }
+}
+
+/// Recover the address from the signature
+/// EIP712 hash is calculated from optimistic payout params
+/// Signature is the signature of the eip712 hash
+///
+/// Parameters:
+/// - deposit_id: The id of the deposit
+/// - input_signature: The signature of the withdrawal input
+/// - input_outpoint: The outpoint of the withdrawal input
+/// - output_script_pubkey: The script pubkey of the withdrawal output
+/// - output_amount: The amount of the withdrawal output
+/// - signature: The signature of the eip712 hash of the withdrawal params
+///
+/// Returns:
+/// - The address recovered from the signature
+pub fn recover_address_from_ecdsa_signature<M: WithdrawalMessage + alloy_sol_types::SolStruct>(
+    deposit_id: u32,
+    input_signature: Signature,
+    input_outpoint: OutPoint,
+    output_script_pubkey: ScriptBuf,
+    output_amount: Amount,
+    signature: PrimitiveSignature,
+) -> Result<alloy::primitives::Address, BridgeError> {
+    let params = M::new(
+        deposit_id,
+        input_signature,
+        input_outpoint,
+        output_script_pubkey,
+        output_amount,
+    );
+
+    let eip712_hash = params.eip712_signing_hash(M::DOMAIN);
+
+    let address = signature
+        .recover_address_from_prehash(&eip712_hash)
+        .wrap_err("Invalid signature")?;
+    Ok(address)
+}

--- a/core/src/rpc/mod.rs
+++ b/core/src/rpc/mod.rs
@@ -21,6 +21,7 @@ use crate::test::common::ensure_test_certificates;
 pub mod clementine;
 
 pub mod aggregator;
+pub mod ecdsa_verification_sig;
 mod error;
 pub mod interceptors;
 pub mod operator;

--- a/core/src/rpc/operator.rs
+++ b/core/src/rpc/operator.rs
@@ -11,14 +11,21 @@ use crate::builder::transaction::ContractContext;
 use crate::citrea::CitreaClientT;
 use crate::constants::DEFAULT_CHANNEL_SIZE;
 use crate::deposit::DepositData;
+use crate::errors::BridgeError;
+use crate::errors::ResultExt;
 use crate::operator::OperatorServer;
-use crate::rpc::clementine::RawSignedTx;
+use crate::rpc::clementine::{RawSignedTx, WithdrawParamsWithSig};
+use crate::rpc::ecdsa_verification_sig::{
+    recover_address_from_ecdsa_signature, ClementineWithdrawalMessage,
+};
 use crate::rpc::parser;
 use crate::utils::get_vergen_response;
+use alloy::primitives::PrimitiveSignature;
 use bitcoin::hashes::Hash;
 use bitcoin::{BlockHash, OutPoint};
 use bitvm::chunk::api::{NUM_HASH, NUM_PUBS, NUM_U256};
 use futures::TryFutureExt;
+use std::str::FromStr;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{async_trait, Request, Response, Status};
@@ -137,12 +144,70 @@ where
     }
 
     #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
-    async fn withdraw(
+    async fn internal_withdraw(
         &self,
         request: Request<WithdrawParams>,
     ) -> Result<Response<RawSignedTx>, Status> {
         let (withdrawal_id, input_signature, input_outpoint, output_script_pubkey, output_amount) =
             parser::operator::parse_withdrawal_sig_params(request.into_inner())?;
+
+        let payout_tx = self
+            .operator
+            .withdraw(
+                withdrawal_id,
+                input_signature,
+                input_outpoint,
+                output_script_pubkey,
+                output_amount,
+            )
+            .await?;
+
+        Ok(Response::new(RawSignedTx::from(&payout_tx)))
+    }
+
+    #[tracing::instrument(skip(self), err(level = tracing::Level::ERROR), ret(level = tracing::Level::TRACE))]
+    async fn withdraw(
+        &self,
+        request: Request<WithdrawParamsWithSig>,
+    ) -> Result<Response<RawSignedTx>, Status> {
+        let params = request.into_inner();
+        let withdraw_params = params.withdrawal.ok_or(Status::invalid_argument(
+            "Withdrawal params not found for withdrawal",
+        ))?;
+        let (withdrawal_id, input_signature, input_outpoint, output_script_pubkey, output_amount) =
+            parser::operator::parse_withdrawal_sig_params(withdraw_params)?;
+
+        // if verification address is set in config, check if verification signature is valid
+        if let Some(address_in_config) = self.operator.config.opt_payout_verification_address {
+            let verification_signature = params
+                .verification_signature
+                .map(|sig| {
+                    PrimitiveSignature::from_str(&sig).map_err(|e| {
+                        Status::invalid_argument(format!("Invalid verification signature: {}", e))
+                    })
+                })
+                .transpose()?;
+            // check if verification signature is provided by aggregator
+            if let Some(verification_signature) = verification_signature {
+                let address_from_sig =
+                    recover_address_from_ecdsa_signature::<ClementineWithdrawalMessage>(
+                        withdrawal_id,
+                        input_signature,
+                        input_outpoint,
+                        output_script_pubkey.clone(),
+                        output_amount,
+                        verification_signature,
+                    )?;
+
+                // check if verification signature is signed by the address in config
+                if address_from_sig != address_in_config {
+                    return Err(BridgeError::InvalidOptPayoutVerificationSignature).map_to_status();
+                }
+            } else {
+                // if verification signature is not provided, but verification address is set in config, return error
+                return Err(BridgeError::OptPayoutVerificationSignatureMissing).map_to_status();
+            }
+        }
 
         let payout_tx = self
             .operator

--- a/core/src/rpc/parser/operator.rs
+++ b/core/src/rpc/parser/operator.rs
@@ -71,6 +71,14 @@ impl TryFrom<DepositSignSession> for DepositParams {
     }
 }
 
+impl From<XOnlyPublicKey> for XOnlyPublicKeyRpc {
+    fn from(xonly_public_key: XOnlyPublicKey) -> Self {
+        XOnlyPublicKeyRpc {
+            xonly_public_key: xonly_public_key.serialize().to_vec(),
+        }
+    }
+}
+
 impl TryFrom<XOnlyPublicKeyRpc> for XOnlyPublicKey {
     type Error = BridgeError;
 

--- a/core/src/test/common/clementine_utils.rs
+++ b/core/src/test/common/clementine_utils.rs
@@ -7,11 +7,16 @@ use crate::citrea::CitreaClient;
 use crate::database::Database;
 use crate::deposit::KickoffData;
 use crate::rpc::clementine::clementine_operator_client::ClementineOperatorClient;
-use crate::rpc::clementine::{OptimisticWithdrawParams, TransactionRequest, WithdrawParams};
+use crate::rpc::clementine::{
+    OptimisticWithdrawParams, TransactionRequest, WithdrawParams, WithdrawParamsWithSig,
+};
+use crate::rpc::ecdsa_verification_sig::{
+    ClementineOptimisticPayoutMessage, ClementineWithdrawalMessage,
+};
 use crate::test::common::citrea::CitreaE2EData;
 use crate::test::common::mine_once_after_in_mempool;
 use crate::test::common::tx_utils::get_txid_where_utxo_is_spent_while_waiting_for_state_mngr_sync;
-use crate::test::sign::sign_optimistic_payout_verification_signature;
+use crate::test::sign::sign_withdrawal_verification_signature;
 use crate::utils::FeePayingType;
 use bitcoin::{OutPoint, Transaction, TxOut, Txid, XOnlyPublicKey};
 use citrea_e2e::bitcoin::DEFAULT_FINALITY_DEPTH;
@@ -37,14 +42,24 @@ pub async fn payout_and_start_kickoff(
     e2e: &CitreaE2EData<'_>,
     actors: &TestActors<CitreaClient>,
 ) -> OutPoint {
+    let withdrawal_params = WithdrawParams {
+        withdrawal_id,
+        input_signature: sig.serialize().to_vec(),
+        input_outpoint: Some((*withdrawal_utxo).into()),
+        output_script_pubkey: payout_txout.script_pubkey.to_bytes(),
+        output_amount: payout_txout.value.to_sat(),
+    };
+    let verification_signature = sign_withdrawal_verification_signature::<
+        ClementineWithdrawalMessage,
+    >(&e2e.config, withdrawal_params.clone());
+
+    let verification_signature_str = verification_signature.to_string();
+
     loop {
         let withdrawal_response = operator
-            .withdraw(WithdrawParams {
-                withdrawal_id,
-                input_signature: sig.serialize().to_vec(),
-                input_outpoint: Some((*withdrawal_utxo).into()),
-                output_script_pubkey: payout_txout.script_pubkey.to_bytes(),
-                output_amount: payout_txout.value.to_sat(),
+            .withdraw(WithdrawParamsWithSig {
+                withdrawal: Some(withdrawal_params.clone()),
+                verification_signature: Some(verification_signature_str.clone()),
             })
             .await;
 
@@ -134,8 +149,9 @@ pub async fn reimburse_with_optimistic_payout(
         output_amount: payout_txout.value.to_sat(),
     };
 
-    let verification_signature =
-        sign_optimistic_payout_verification_signature(&e2e.config, withdrawal_params.clone());
+    let verification_signature = sign_withdrawal_verification_signature::<
+        ClementineOptimisticPayoutMessage,
+    >(&e2e.config, withdrawal_params.clone());
 
     let verification_signature_str = verification_signature.to_string();
 

--- a/core/src/test/deposit_and_withdraw_e2e.rs
+++ b/core/src/test/deposit_and_withdraw_e2e.rs
@@ -17,7 +17,10 @@ use crate::rpc::clementine::clementine_aggregator_client::ClementineAggregatorCl
 use crate::rpc::clementine::{
     Deposit, Empty, FeeType, FinalizedPayoutParams, KickoffId, NormalSignatureKind,
     OptimisticWithdrawParams, RawSignedTx, SendMoveTxRequest, SendTxRequest, TransactionRequest,
-    WithdrawParams,
+    WithdrawParams, WithdrawParamsWithSig,
+};
+use crate::rpc::ecdsa_verification_sig::{
+    ClementineOptimisticPayoutMessage, ClementineWithdrawalMessage,
 };
 use crate::test::common::citrea::{
     get_new_withdrawal_utxo_and_register_to_citrea, register_replacement_deposit_to_citrea,
@@ -40,7 +43,7 @@ use crate::test::common::{
 use crate::test::common::{
     create_test_config_with_thread_name, run_multiple_deposits, run_single_replacement_deposit,
 };
-use crate::test::sign::sign_optimistic_payout_verification_signature;
+use crate::test::sign::sign_withdrawal_verification_signature;
 use crate::utils::initialize_logger;
 use crate::{EVMAddress, UTXO};
 use async_trait::async_trait;
@@ -618,14 +621,24 @@ async fn mock_citrea_run_truthful() {
     tracing::info!("Withdrawal tx sent");
     let mut operator0 = actors.get_operator_client_by_index(0);
 
+    let withdrawal_params = WithdrawParams {
+        withdrawal_id: 0,
+        input_signature: sig.serialize().to_vec(),
+        input_outpoint: Some(withdrawal_utxo.into()),
+        output_script_pubkey: payout_txout.script_pubkey.to_bytes(),
+        output_amount: payout_txout.value.to_sat(),
+    };
+    let verification_signature = sign_withdrawal_verification_signature::<
+        ClementineWithdrawalMessage,
+    >(&config, withdrawal_params.clone());
+
+    let verification_signature_str = verification_signature.to_string();
+
     loop {
         let withdrawal_response = operator0
-            .withdraw(WithdrawParams {
-                withdrawal_id: 0,
-                input_signature: sig.serialize().to_vec(),
-                input_outpoint: Some(withdrawal_utxo.into()),
-                output_script_pubkey: payout_txout.script_pubkey.to_bytes(),
-                output_amount: payout_txout.value.to_sat(),
+            .withdraw(WithdrawParamsWithSig {
+                withdrawal: Some(withdrawal_params.clone()),
+                verification_signature: Some(verification_signature_str.clone()),
             })
             .await;
 
@@ -1073,8 +1086,9 @@ async fn mock_citrea_run_truthful_opt_payout() {
         output_amount: payout_txout.value.to_sat(),
     };
 
-    let verification_signature =
-        sign_optimistic_payout_verification_signature(&config, withdrawal_params.clone());
+    let verification_signature = sign_withdrawal_verification_signature::<
+        ClementineOptimisticPayoutMessage,
+    >(&config, withdrawal_params.clone());
 
     let verification_signature_str = verification_signature.to_string();
 
@@ -1812,12 +1826,22 @@ async fn concurrent_deposits_and_withdrawals() {
             let mut withdrawal_requests = Vec::new();
 
             for (i, operator) in operator0s.iter_mut().enumerate() {
-                withdrawal_requests.push(operator.withdraw(WithdrawParams {
+                let withdraw_params = WithdrawParams {
                     withdrawal_id: i as u32,
                     input_signature: sigs[i].serialize().to_vec(),
                     input_outpoint: Some(withdrawal_utxos[i].into()),
                     output_script_pubkey: payout_txouts[i].script_pubkey.to_bytes(),
                     output_amount: payout_txouts[i].value.to_sat(),
+                };
+                let verification_signature = sign_withdrawal_verification_signature::<
+                    ClementineWithdrawalMessage,
+                >(&config, withdraw_params.clone());
+
+                let verification_signature_str = verification_signature.to_string();
+
+                withdrawal_requests.push(operator.withdraw(WithdrawParamsWithSig {
+                    withdrawal: Some(withdraw_params.clone()),
+                    verification_signature: Some(verification_signature_str.clone()),
                 }));
             }
 
@@ -1936,10 +1960,9 @@ async fn concurrent_deposits_and_optimistic_payouts() {
                     output_amount: payout_txouts[i].value.to_sat(),
                 };
 
-                let verification_signature = sign_optimistic_payout_verification_signature(
-                    &config,
-                    withdrawal_params.clone(),
-                );
+                let verification_signature = sign_withdrawal_verification_signature::<
+                    ClementineOptimisticPayoutMessage,
+                >(&config, withdrawal_params.clone());
 
                 let verification_signature_str = verification_signature.to_string();
 

--- a/core/src/test/sign.rs
+++ b/core/src/test/sign.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::BridgeConfig,
     rpc::clementine::WithdrawParams,
-    verifier::{ClementineOptimisticPayoutMessage, DOMAIN},
+    verifier::{ClementineOptimisticPayoutMessage, OPT_PAYOUT_DOMAIN},
 };
 use alloy::primitives::PrimitiveSignature;
 use alloy_sol_types::SolStruct;
@@ -33,7 +33,7 @@ pub fn sign_optimistic_payout_verification_signature(
         output_amount: output_amount.to_sat(),
     };
 
-    let eip712_hash = params.eip712_signing_hash(&DOMAIN);
+    let eip712_hash = params.eip712_signing_hash(&OPT_PAYOUT_DOMAIN);
 
     let signature = signing_key
         .sign_prehash_recoverable(eip712_hash.as_slice())

--- a/core/src/test/sign.rs
+++ b/core/src/test/sign.rs
@@ -1,15 +1,13 @@
 use crate::{
     config::BridgeConfig,
-    rpc::clementine::WithdrawParams,
-    verifier::{ClementineOptimisticPayoutMessage, OPT_PAYOUT_DOMAIN},
+    rpc::{clementine::WithdrawParams, ecdsa_verification_sig::WithdrawalMessage},
 };
 use alloy::primitives::PrimitiveSignature;
 use alloy_sol_types::SolStruct;
-use bitcoin::hashes::Hash;
 
 /// Signs the optimistic payout verification signature for a given withdrawal params
 /// using the private key in the test_params in the config.
-pub fn sign_optimistic_payout_verification_signature(
+pub fn sign_optimistic_payout_verification_signature<M: WithdrawalMessage + SolStruct>(
     config: &BridgeConfig,
     withdrawal_params: WithdrawParams,
 ) -> PrimitiveSignature {
@@ -21,19 +19,15 @@ pub fn sign_optimistic_payout_verification_signature(
     let (withdrawal_id, input_signature, input_outpoint, output_script_pubkey, output_amount) =
         crate::rpc::parser::operator::parse_withdrawal_sig_params(withdrawal_params).unwrap();
 
-    let input_sig_bytes = input_signature.serialize().to_vec();
-    let outpoint_txid_bytes = input_outpoint.txid.to_byte_array();
-    let script_pubkey_bytes = output_script_pubkey.as_bytes().to_vec();
-    let params = ClementineOptimisticPayoutMessage {
+    let params = M::new(
         withdrawal_id,
-        input_signature: input_sig_bytes.into(),
-        input_outpoint_txid: outpoint_txid_bytes.into(),
-        input_outpoint_vout: input_outpoint.vout,
-        output_script_pubkey: script_pubkey_bytes.into(),
-        output_amount: output_amount.to_sat(),
-    };
+        input_signature,
+        input_outpoint,
+        output_script_pubkey,
+        output_amount,
+    );
 
-    let eip712_hash = params.eip712_signing_hash(&OPT_PAYOUT_DOMAIN);
+    let eip712_hash = params.eip712_signing_hash(M::DOMAIN);
 
     let signature = signing_key
         .sign_prehash_recoverable(eip712_hash.as_slice())

--- a/core/src/test/sign.rs
+++ b/core/src/test/sign.rs
@@ -7,7 +7,7 @@ use alloy_sol_types::SolStruct;
 
 /// Signs the optimistic payout verification signature for a given withdrawal params
 /// using the private key in the test_params in the config.
-pub fn sign_optimistic_payout_verification_signature<M: WithdrawalMessage + SolStruct>(
+pub fn sign_withdrawal_verification_signature<M: WithdrawalMessage + SolStruct>(
     config: &BridgeConfig,
     withdrawal_params: WithdrawParams,
 ) -> PrimitiveSignature {

--- a/core/src/tx_sender/client.rs
+++ b/core/src/tx_sender/client.rs
@@ -4,7 +4,6 @@ use crate::builder::transaction::input::UtxoVout;
 use crate::errors::ResultExt;
 use crate::operator::RoundIndex;
 use crate::rpc;
-use crate::rpc::clementine::XonlyPublicKey;
 use crate::utils::{FeePayingType, RbfSigningInfo, TxMetadata};
 use crate::{
     builder::transaction::TransactionType,
@@ -417,9 +416,7 @@ impl TxSenderClient {
             raw_tx: bitcoin::consensus::serialize(&tx),
             metadata: tx_metadata.map(|metadata| rpc::clementine::TxMetadata {
                 deposit_outpoint: metadata.deposit_outpoint.map(Into::into),
-                operator_xonly_pk: metadata.operator_xonly_pk.map(|pk| XonlyPublicKey {
-                    xonly_pk: pk.serialize().to_vec(),
-                }),
+                operator_xonly_pk: metadata.operator_xonly_pk.map(Into::into),
 
                 round_idx: metadata
                     .round_idx

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -33,6 +33,9 @@ use crate::header_chain_prover::HeaderChainProver;
 use crate::metrics::L1SyncStatusProvider;
 use crate::operator::RoundIndex;
 use crate::rpc::clementine::{EntityStatus, NormalSignatureKind, OperatorKeys, TaggedSignature};
+use crate::rpc::ecdsa_verification_sig::{
+    recover_address_from_ecdsa_signature, ClementineOptimisticPayoutMessage,
+};
 #[cfg(feature = "automation")]
 use crate::states::StateManager;
 use crate::task::entity_metric_publisher::{
@@ -46,8 +49,6 @@ use crate::utils::NamedEntity;
 use crate::utils::TxMetadata;
 use crate::{musig2, UTXO};
 use alloy::primitives::PrimitiveSignature;
-use alloy::sol_types::Eip712Domain;
-use alloy_sol_types::SolStruct;
 use bitcoin::hashes::Hash;
 use bitcoin::key::rand::Rng;
 use bitcoin::key::Secp256k1;
@@ -80,23 +81,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
-
-alloy_sol_types::sol! {
-    #[derive(Debug)]
-    struct ClementineOptimisticPayoutMessage {
-        uint32 withdrawal_id;
-        bytes input_signature;
-        bytes32 input_outpoint_txid;
-        uint32 input_outpoint_vout;
-        bytes output_script_pubkey;
-        uint64 output_amount;
-    }
-}
-
-pub static DOMAIN: Eip712Domain = alloy_sol_types::eip712_domain! {
-    name: "ClementineOptimisticPayoutMessage",
-    version: "1",
-};
 
 #[derive(Debug)]
 pub struct NonceSession {
@@ -1290,48 +1274,6 @@ where
         Ok((move_tx_partial_sig, emergency_stop_partial_sig))
     }
 
-    /// Recover the address from the signature
-    /// EIP712 hash is calculated from optimistic payout params
-    /// Signature is the signature of the eip712 hash
-    ///
-    /// Parameters:
-    /// - deposit_id: The id of the deposit
-    /// - input_signature: The signature of the withdrawal input
-    /// - input_outpoint: The outpoint of the withdrawal input
-    /// - output_script_pubkey: The script pubkey of the withdrawal output
-    /// - output_amount: The amount of the withdrawal output
-    /// - signature: The signature of the eip712 hash of the withdrawal params
-    ///
-    /// Returns:
-    /// - The address recovered from the signature
-    pub fn recover_address_from_ecdsa_signature(
-        deposit_id: u32,
-        input_signature: Signature,
-        input_outpoint: OutPoint,
-        output_script_pubkey: ScriptBuf,
-        output_amount: Amount,
-        signature: PrimitiveSignature,
-    ) -> Result<alloy::primitives::Address, BridgeError> {
-        let input_sig_bytes = input_signature.serialize().to_vec();
-        let outpoint_txid_bytes = input_outpoint.txid.to_byte_array();
-        let script_pubkey_bytes = output_script_pubkey.as_bytes().to_vec();
-        let params = ClementineOptimisticPayoutMessage {
-            withdrawal_id: deposit_id,
-            input_signature: input_sig_bytes.into(),
-            input_outpoint_txid: outpoint_txid_bytes.into(),
-            input_outpoint_vout: input_outpoint.vout,
-            output_script_pubkey: script_pubkey_bytes.into(),
-            output_amount: output_amount.to_sat(),
-        };
-
-        let eip712_hash = params.eip712_signing_hash(&DOMAIN);
-
-        let address = signature
-            .recover_address_from_prehash(&eip712_hash)
-            .wrap_err("Invalid signature")?;
-        Ok(address)
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub async fn sign_optimistic_payout(
         &self,
@@ -1354,14 +1296,15 @@ where
         if let Some(address_in_config) = self.config.opt_payout_verification_address {
             // check if verification signature is provided by aggregator
             if let Some(verification_signature) = verification_signature {
-                let address_from_sig = Self::recover_address_from_ecdsa_signature(
-                    deposit_id,
-                    input_signature,
-                    input_outpoint,
-                    output_script_pubkey.clone(),
-                    output_amount,
-                    verification_signature,
-                )?;
+                let address_from_sig =
+                    recover_address_from_ecdsa_signature::<ClementineOptimisticPayoutMessage>(
+                        deposit_id,
+                        input_signature,
+                        input_outpoint,
+                        output_script_pubkey.clone(),
+                        output_amount,
+                        verification_signature,
+                    )?;
 
                 // check if verification signature is signed by the address in config
                 if address_from_sig != address_in_config {

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -3128,7 +3128,7 @@ mod tests {
                 .unwrap();
         let output_amount = Amount::from_sat(1000000000000000000);
         let deposit_id = 1;
-        let address = Verifier::<MockCitreaClient>::recover_address_from_ecdsa_signature(
+        let address = recover_address_from_ecdsa_signature::<ClementineOptimisticPayoutMessage>(
             deposit_id,
             input_signature,
             input_outpoint,


### PR DESCRIPTION
- Same as opt payouts, add an sig verification check for withdraw() rpcs of operators.
- Add option to specify which operators to send withdraw() to for aggregator.withdraw()