### PR TITLE
fix: xonly tweak with keyspendscript

### DIFF
--- a/core/src/musig2.rs
+++ b/core/src/musig2.rs
@@ -121,7 +121,7 @@ fn create_key_agg_cache(
                     .finalize();
 
                 musig_key_agg_cache
-                    .pubkey_ec_tweak_add(
+                    .pubkey_xonly_tweak_add(
                         SECP256K1,
                         &Scalar::from_be_bytes(xonly_tweak.into())
                             .wrap_err("Failed to create scalar from xonly tweak bytes")?,


### PR DESCRIPTION
Fixes tweak type for Musig2Mode::KeySpendWithScript. We didn't use this before so didn't catch this so this doesn't actually change anything in current code