### PR TITLE
fix: possible race condition on txsender observability

### DIFF
--- a/core/src/database/tx_sender.rs
+++ b/core/src/database/tx_sender.rs
@@ -147,8 +147,7 @@ impl Database {
                 "{}
             SELECT txs.id, txs.txid
             FROM tx_sender_try_to_send_txs AS txs
-            WHERE txs.txid IN (SELECT txid FROM relevant_txs)
-            AND txs.seen_block_id IS NULL",
+            WHERE txs.txid IN (SELECT txid FROM relevant_txs)",
                 common_ctes
             ))
             .bind(block_id)
@@ -164,8 +163,7 @@ impl Database {
                 "{}
             SELECT txs.id
             FROM tx_sender_try_to_send_txs AS txs
-            WHERE txs.id IN (SELECT id FROM confirmed_rbf_ids)
-            AND txs.seen_block_id IS NULL",
+            WHERE txs.id IN (SELECT id FROM confirmed_rbf_ids)",
                 common_ctes
             ))
             .bind(block_id)


### PR DESCRIPTION
Cantina 82
https://cantina.xyz/code/ce181972-2b40-4047-8ee9-89ec43527686/findings/82

If seen block ids are set before tokio::spawn in confirm_transactions run, they won't be set as confirmed in tx_debug state