### PR TITLE
fix: lands_onchain_flakiness

### DIFF
--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -1794,7 +1794,7 @@ mod tests {
         rpc.mine_blocks(1).await.unwrap();
         sleep(Duration::from_secs(3)).await;
 
-        let tx = poll_get(
+        poll_get(
             async || {
                 rpc.mine_blocks(1).await.unwrap();
 
@@ -1806,7 +1806,21 @@ mod tests {
                     })
                     .ok();
 
-                Ok(tx_result)
+                // check if tx is confirmed
+                match tx_result {
+                    Some(tx_result) => {
+                        if let Some(confirmations) = tx_result.confirmations {
+                            if confirmations > 0 {
+                                Ok(Some(tx_result))
+                            } else {
+                                Ok(None)
+                            }
+                        } else {
+                            Ok(None)
+                        }
+                    }
+                    None => Ok(None),
+                }
             },
             None,
             None,
@@ -1814,8 +1828,6 @@ mod tests {
         .await
         .wrap_err_with(|| eyre::eyre!("MoveTx did not land onchain"))
         .unwrap();
-
-        assert!(tx.confirmations.unwrap() > 0);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1890,7 +1902,7 @@ mod tests {
         rpc.mine_blocks(1).await.unwrap();
         sleep(Duration::from_secs(3)).await;
 
-        let tx = poll_get(
+        poll_get(
             async || {
                 rpc.mine_blocks(1).await.unwrap();
 
@@ -1902,7 +1914,21 @@ mod tests {
                     })
                     .ok();
 
-                Ok(tx_result)
+                // check if tx is confirmed
+                match tx_result {
+                    Some(tx_result) => {
+                        if let Some(confirmations) = tx_result.confirmations {
+                            if confirmations > 0 {
+                                Ok(Some(tx_result))
+                            } else {
+                                Ok(None)
+                            }
+                        } else {
+                            Ok(None)
+                        }
+                    }
+                    None => Ok(None),
+                }
             },
             None,
             None,
@@ -1910,8 +1936,6 @@ mod tests {
         .await
         .wrap_err_with(|| eyre::eyre!("MoveTx did not land onchain"))
         .unwrap();
-
-        assert!(tx.confirmations.unwrap() > 0);
     }
 
     #[tokio::test]

--- a/core/src/rpc/aggregator.rs
+++ b/core/src/rpc/aggregator.rs
@@ -1794,33 +1794,13 @@ mod tests {
         rpc.mine_blocks(1).await.unwrap();
         sleep(Duration::from_secs(3)).await;
 
-        poll_get(
+        poll_until_condition(
             async || {
                 rpc.mine_blocks(1).await.unwrap();
-
-                let tx_result = rpc.get_raw_transaction_info(&movetx_one_txid, None).await;
-
-                let tx_result = tx_result
-                    .inspect_err(|e| {
-                        tracing::error!("Error getting transaction: {:?}", e);
-                    })
-                    .ok();
-
-                // check if tx is confirmed
-                match tx_result {
-                    Some(tx_result) => {
-                        if let Some(confirmations) = tx_result.confirmations {
-                            if confirmations > 0 {
-                                Ok(Some(tx_result))
-                            } else {
-                                Ok(None)
-                            }
-                        } else {
-                            Ok(None)
-                        }
-                    }
-                    None => Ok(None),
-                }
+                Ok(rpc
+                    .is_tx_on_chain(&movetx_one_txid)
+                    .await
+                    .unwrap_or_default())
             },
             None,
             None,
@@ -1902,33 +1882,10 @@ mod tests {
         rpc.mine_blocks(1).await.unwrap();
         sleep(Duration::from_secs(3)).await;
 
-        poll_get(
+        poll_until_condition(
             async || {
                 rpc.mine_blocks(1).await.unwrap();
-
-                let tx_result = rpc.get_raw_transaction_info(&movetx_txid, None).await;
-
-                let tx_result = tx_result
-                    .inspect_err(|e| {
-                        tracing::error!("Error getting transaction: {:?}", e);
-                    })
-                    .ok();
-
-                // check if tx is confirmed
-                match tx_result {
-                    Some(tx_result) => {
-                        if let Some(confirmations) = tx_result.confirmations {
-                            if confirmations > 0 {
-                                Ok(Some(tx_result))
-                            } else {
-                                Ok(None)
-                            }
-                        } else {
-                            Ok(None)
-                        }
-                    }
-                    None => Ok(None),
-                }
+                Ok(rpc.is_tx_on_chain(&movetx_txid).await.unwrap_or_default())
             },
             None,
             None,
@@ -2097,21 +2054,13 @@ mod tests {
         let emergency_stop_txid = emergency_stop_tx.compute_txid();
         rpc.mine_blocks(1).await.unwrap();
 
-        let _emergencty_tx = poll_get(
+        poll_until_condition(
             async || {
                 rpc.mine_blocks(1).await.unwrap();
-
-                let tx_result = rpc
-                    .get_raw_transaction_info(&emergency_stop_txid, None)
-                    .await;
-
-                let tx_result = tx_result
-                    .inspect_err(|e| {
-                        tracing::error!("Error getting transaction: {:?}", e);
-                    })
-                    .ok();
-
-                Ok(tx_result)
+                Ok(rpc
+                    .is_tx_on_chain(&emergency_stop_txid)
+                    .await
+                    .unwrap_or_default())
             },
             None,
             None,


### PR DESCRIPTION
Not related to cantina

lands_onchain test failed if movetx was on mempool but not mined into chain, because get_raw_transaction_info returns info of txs in mempool too