### PR TITLE
fix: calculate correct number of unproven blocks

### DIFF
--- a/core/src/header_chain_prover.rs
+++ b/core/src/header_chain_prover.rs
@@ -630,7 +630,7 @@ impl HeaderChainProver {
             non_proven_block.2,
             self.batch_size
         );
-        if tip_height - non_proven_block.2 >= self.batch_size {
+        if tip_height - non_proven_block.2 + 1 >= self.batch_size {
             return Ok(true);
         }
         tracing::debug!(


### PR DESCRIPTION
- Fixes off by one error in is_batch_ready. This wasn't actually a problem as we still prove by batch_size number of blocks (using 
fn get_next_n_non_proven_block), but the proving was always delayed by 1 block. Ex: blocks 1 - 100 is proven in 101th block 