### PR TITLE
order reorgs so that reorged block event arrives from tip downwards

### DIFF
--- a/core/src/database/bitcoin_syncer.rs
+++ b/core/src/database/bitcoin_syncer.rs
@@ -196,7 +196,7 @@ impl Database {
     /// # Returns
     ///
     /// - [`Vec<u32>`]: List of block ids that were marked as non-canonical in
-    ///   ascending order.
+    ///   descending order.
     pub async fn update_non_canonical_block_hashes(
         &self,
         tx: Option<DatabaseTransaction<'_, '_>>,
@@ -208,7 +208,7 @@ impl Database {
                 SET is_canonical = false
                 WHERE height > $1
                 RETURNING id
-            ) SELECT id FROM deleted",
+            ) SELECT id FROM deleted ORDER BY id DESC",
         )
         .bind(i32::try_from(height).wrap_err(BridgeError::IntConversionError)?);
 


### PR DESCRIPTION
- Order reorged blocks id by desc in db fn so that BitcoinSyncerEvent::ReorgedBlock are sent with height desc, so that no errors happen if any updates in the reorged event depends on others