### PR TITLE
Add automation tagging for DockerHub in release and update automation dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,3 +152,10 @@ jobs:
           file: ./scripts/docker/Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/clementine:${{ github.ref_name }}
+      - name: Build and push
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          file: ./scripts/docker/Dockerfile.automation
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/clementine-automation:${{ github.ref_name }}

--- a/scripts/docker/Dockerfile.automation
+++ b/scripts/docker/Dockerfile.automation
@@ -1,8 +1,8 @@
 # Compile Clementine
-FROM rust:1.88.0
-COPY . .
+FROM rust:1.88.0 as builder
 WORKDIR /clementine
-RUN cargo +1.88.0 build --release --bin clementine-core --features=automation
+COPY . .
+RUN cargo build --release --bin clementine-core --features=automation
 
 FROM debian:bookworm-slim
 RUN \
@@ -13,7 +13,7 @@ RUN \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=0 /target/release/clementine-core /clementine-core
+COPY --from=builder /clementine/target/release/clementine-core /clementine-core
 
 # Set up Clementine
 ENTRYPOINT [ "/clementine-core" ]


### PR DESCRIPTION
# Description

Small update to dockerfile.automation to make it consistent with the non-automation.

Now also tagging the automation pushes to Docker with ref_name
