### PR TITLE
docs: improve wording in README and usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ check Clementine whitepaper at [citrea.xyz/clementine_whitepaper.pdf](https://ci
 
 The repository includes:
 
-- A library for bridge operator, verifiers, aggregator and watchtower
+- A library for bridge operators, verifiers, aggregators, and watchtowers
 - Circuits that will be optimistically verified with BitVM
 
 ## Documentation
 
-High level documentations are in [docs/](docs). These documentations explains
+High-level documentation is in [docs/](docs). This documentation explains
 the design, architecture and usage of Clementine.
 
-To start using Clementine, jump [docs/usage.md](docs/usage.md) documentation.
+To start using Clementine, see the [docs/usage.md](docs/usage.md) documentation.
 
 Code documentation is also present and can be viewed at
 [chainwayxyz.github.io/clementine/clementine_core](https://chainwayxyz.github.io/clementine/clementine_core/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
 # Clementine Documentation
 
-Welcome to the Clementine documentation. This is not a code documentation,
-rather a higher view of the Clementine. To view code documentation, please visit
+Welcome to the Clementine documentation. This is not code documentation,
+but rather a higher-level view of Clementine. To view code documentation, please visit
 [chainwayxyz.github.io/clementine/clementine_core](https://chainwayxyz.github.io/clementine/clementine_core/).
 
-- [The Design of Clementine](design.md): Design and technicals of Clementine
+- [The Design of Clementine](design.md): Design and technical details of Clementine
 - [Usage](usage.md): How to use Clementine
 
 ## Circuits

--- a/docs/bridge-circuit.md
+++ b/docs/bridge-circuit.md
@@ -50,7 +50,7 @@ If a Challenger finds an error with the output of the Operator's off-chain execu
 
 ## High-Level Overview
 > [!WARNING]
-> Before reading this document, please read the [header chain circuit](header-chain-circuit.md) and [work only circuit](work-only-circuit.md) documentations.
+> Before reading this document, please read the [header chain circuit](header-chain-circuit.md) and [work only circuit](work-only-circuit.md) documentation.
 
 The bridge circuit in Clementine serves as a critical component that enables secure and (optimistically) verifiable cross-chain interactions between Bitcoin and the Citrea L2 rollup. Its primary function is to allow Operators, when challenged, to prove the correctness of their operations and the validity of state transitions.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,16 +1,16 @@
 # The Design Of Clementine
 
 Our bridge leverages BitVM for a trust minimized BTC <> Citrea bridge. The
-[whitepaper](https://citrea.xyz/clementine_whitepaper.pdf) explains technicals.
-Also, [https://bitvm.org/bitvm_bridge.pdf](https://bitvm.org/bitvm_bridge.pdf)
-and [http://bitvm.org/bitvm2](http://bitvm.org/bitvm2) can be checked to learn
-more about BitVM.
+[whitepaper](https://citrea.xyz/clementine_whitepaper.pdf) explains the technical details.
+See [https://bitvm.org/bitvm_bridge.pdf](https://bitvm.org/bitvm_bridge.pdf)
+and [http://bitvm.org/bitvm2](http://bitvm.org/bitvm2) to learn more about
+BitVM.
 
 ![Clementine Tx Graph](images/clementine_diagram.png)
 
 ## Depositing
 
-Aggregator is responsible for helping verifiers to finalize deposits, using
+The aggregator is responsible for helping verifiers finalize deposits by using
 [musig2](https://github.com/bitcoin-core/secp256k1/blob/master/doc/musig.md#signing).
 It has 3 steps:
 
@@ -20,15 +20,15 @@ It has 3 steps:
 
 ![Move TX creation](images/move_tx_creation.png)
 
-1. In the first step, aggregator will collect nonces from all the verifiers,
-   soon to be aggregated and send back to the verifiers. Aggregation is done by
-   musig2.
-2. At the second step, partial signatures will be requested from verifiers for
-   the provided aggregated nonce. They will be aggregated using musig2, just
-   like nonces. Final Schnorr signature will be sent to verifiers.
-3. Aggregated signatures are used by verifiers to finalize deposit. Then,
-   verifiers will return move tx partial signatures, which will later be
-   aggregated. Finally, aggregator will create a move tx.
+1. In the first step, the aggregator collects nonces from all verifiers,
+   aggregates them, and sends them back to the verifiers. Aggregation is done
+   by musig2.
+2. In the second step, partial signatures are requested from verifiers for the
+   provided aggregated nonce. They are aggregated using musig2, just like
+   nonces. The final Schnorr signature is sent to verifiers.
+3. Aggregated signatures are used by verifiers to finalize the deposit. Then,
+   verifiers return move tx partial signatures, which are later aggregated.
+   Finally, the aggregator creates a move tx.
 
 ## FAQ
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,13 +1,12 @@
 # Usage
 
-Clementine provides a single binary, that can act as 3 different actors
-services:
+Clementine provides a single binary that can act as 3 different actor services:
 
-- Verifier (We sometimes call this as signer)
+- Verifier (sometimes called a signer)
 - Operator
 - Aggregator
 
-These services communicate via gRPC and use a Postgresql database. They can be
+These services communicate via gRPC and use a PostgreSQL database. They can be
 configured to share the same database.
 
 An entity can choose to run these services on a single host to be a part of the
@@ -15,7 +14,7 @@ peg-in and peg-out process. All the services that are run by a single entity
 should ideally share the same database. Typical entities are:
 
 - Operator entity
-- Runs both an operator and a verifier service
+  - Runs both an operator and a verifier service
 - Verifier entity
   - Runs a verifier service
 - Aggregator entity
@@ -78,8 +77,8 @@ Before running Clementine:
    ./scripts/generate_certs.sh
    ```
 
-5. Set `RISC0_DEV_MODE` environment variable if tests are going to be run or
-   deployment that requires it:
+5. Set the `RISC0_DEV_MODE` environment variable if tests are going to be run
+   or if the deployment requires it:
 
    ```sh
    export RISC0_DEV_MODE=1
@@ -164,7 +163,7 @@ configuration file. An example configuration file is located at
 be taken as reference. Please copy that configuration file to another location
 and modify fields to your local configuration.
 
-Additionally, Clementine requires protocol parameters, that are either specified
+Additionally, Clementine requires protocol parameters that are specified either
 by a file or from the environment. You can specify a separate protocol
 parameters file using the `--protocol-params` option. This file contains
 protocol-specific settings that affect transactions in the contract.
@@ -299,10 +298,10 @@ docker build -f scripts/docker/Dockerfile.automation -t clementine:latest .
 ```
 
 Also, there are multiple Docker compose files located at [scripts/docker/](../scripts/docker/)
-which can be used to start Bitcoin, PostgreSQL, Citrea and Clementine. Config
+which can be used to start Bitcoin, PostgreSQL, Citrea, and Clementine. Config
 files for these compose files can be found at [scripts/docker/configs/](../scripts/docker/configs/).
-They are configured for a typical deployment and needs modification before deployment.
-**Please note that**, apart from regtest, new wallet that is created won't have
+They are configured for a typical deployment and need modification before deployment.
+**Please note that**, apart from regtest, a newly created wallet won't have
 any funds and users are responsible for configuring their own address.
 
 ```sh
@@ -328,7 +327,7 @@ cargo test_integration
 
 ## Helper Scripts
 
-There are handful amount of scripts in [scripts/](../scripts/) directory. Most of
+There are a handful of scripts in the [scripts/](../scripts/) directory. Most of
 them are for testing but still can be used for setting up the environment. They
 can change quite frequently. So, please check for useful ones.
 


### PR DESCRIPTION
# Description

This PR improves wording and grammar in the README and documentation pages without changing any technical behavior.

Changes include:
- Clarifying the main README documentation section
- Improving wording in the docs index and design overview
- Fixing list indentation in the usage guide
- Standardizing PostgreSQL capitalization
- Cleaning up a few awkward phrases in the usage and bridge circuit docs



## Linked Issues

- Closes # (issue, if applicable)
- Related to # (issue)

## Testing

- Ran `git diff --check`

## Docs

This is a documentation-only change. No documented interfaces or code behavior were changed.
